### PR TITLE
ci: generate Cloudflare env types before typecheck/build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,9 @@ jobs:
     - name: Install dependencies
       run: bun install --frozen-lockfile
 
+    - name: Generate Cloudflare env types
+      run: bun run cf-typegen
+
     - name: Audit direct dependencies for known vulnerabilities
       run: bash scripts/audit-direct.sh
 


### PR DESCRIPTION
## Summary
- Add a \`bun run cf-typegen\` step to the CI workflow.
- \`worker-configuration.d.ts\` is gitignored, so without this step \`tsgo\` cannot resolve \`CloudflareEnv\` bindings (\`DB\`, \`AVATARS_BUCKET\`) and the \`typecheck\` / \`build\` steps fail on every PR (including main).

## Test plan
- [ ] CI \`build\` job goes green on this PR.