### PR TITLE
fix: switch Dependabot to the bun package-ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,10 @@
 version: 2
 updates:
-  - package-ecosystem: npm
+  # `bun` (not `npm`) so Dependabot regenerates bun.lock alongside package.json —
+  # with `npm` every PR fails CI's `bun install --frozen-lockfile` (see PRs #30–#34).
+  # Note: the bun ecosystem supports version updates only, not security updates;
+  # direct-dep vulnerabilities are still gated by scripts/audit-direct.sh (ADR-0002).
+  - package-ecosystem: bun
     directory: /
     schedule:
       interval: weekly


### PR DESCRIPTION
## Why

All 5 recent Dependabot PRs (#30–#34) failed CI: with `package-ecosystem: npm`, Dependabot edits only `package.json` and never `bun.lock`, so `bun install --frozen-lockfile` always fails. Each PR had to be completed by hand (merge main + `bun install` + push).

## What

- `.github/dependabot.yml`: `package-ecosystem: npm` → `bun` for the root entry ([GA since 2025-02](https://github.blog/changelog/2025-02-13-dependabot-version-updates-now-support-the-bun-package-manager-ga/), requires the text `bun.lock` — satisfied). Dependabot will now regenerate `bun.lock` alongside `package.json`.

## Caveat

The bun ecosystem supports **version updates only** (no security-update PRs). Direct-dependency vulnerabilities remain gated by `scripts/audit-direct.sh` in CI (ADR-0002), so coverage doesn't regress in practice. After merge, check the repo's Dependabot tab once to confirm the config validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6x161GzUodTZG6BHu7fs1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Dependabot to the `bun` package-ecosystem so it updates `bun.lock` alongside `package.json`, fixing CI failures from `bun install --frozen-lockfile` on Dependabot PRs. Note: `bun` supports version updates only; CI still gates direct-dependency vulns via `scripts/audit-direct.sh`.

<sup>Written for commit 8877f30d316431865ab497775f48d30c419e6800. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imaimai17468/imaimai-front-templete/pull/36?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

