### PR TITLE
docs: セットアップ手順の Next.js 残骸を除き、fork 手順と監査記録を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ AI エージェント用の Aegis ナレッジベース（`.aegis/`、gitignore 
 | `bun run knip`            | Detect unused deps/exports/files                |
 | `bun run test`            | Run tests with Vitest                           |
 | `bun run cf-typegen`      | Generate `CloudflareEnv` from `wrangler.toml`   |
+| `bun run db:generate`     | Generate Drizzle migrations from the schema     |
+| `bun run db:push`         | Push the schema to the remote D1 database       |
+| `bun run db:push:local`   | Set up / migrate the local D1 database          |
+| `bun run db:seed:local`   | Seed the local D1 database with dev data        |
+| `bun run db:studio`       | Open Drizzle Studio                             |
+| `bun run db:pull`         | Introspect the remote D1 schema                 |
 
 ## Tools
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ bun run dev
 
 http://localhost:5173 でアクセス。`@cloudflare/vite-plugin` により、`bun run dev` でも Cloudflare D1 / R2 バインディングが有効です。
 
-データベース・認証・ストレージのセットアップ手順は [docs/DATABASE_SETUP.md](./docs/DATABASE_SETUP.md) を参照。
+データベース・認証・ストレージのセットアップ手順は [docs/DATABASE_SETUP.md](./docs/DATABASE_SETUP.md)、デプロイ・ロールバック・シークレット運用は [docs/DEPLOYMENT.md](./docs/DEPLOYMENT.md)、このテンプレートを新規プロジェクトに使う手順は [docs/FORKING.md](./docs/FORKING.md) を参照。
 
 AI エージェント用の Aegis ナレッジベース（`.aegis/`、gitignore 済み）は、初回の Claude Code セッション開始時に SessionStart フックが `aegis-share/`（git 管理のバンドル）から自動構築します。手動で構築する場合: `npx -y @fuwasegu/aegis share-hydrate`
 

--- a/docs/DATABASE_SETUP.md
+++ b/docs/DATABASE_SETUP.md
@@ -1,6 +1,6 @@
 # データベースセットアップ
 
-> テンプレートは初期状態で `wrangler.toml` にローカル開発用のダミー値 (`local-db` / `local-avatars` / ゼロ UUID) が入っています。`bun run dev` はこのまま起動でき、`initOpenNextCloudflareForDev()` がローカル D1/R2 バインディングを提供します。**本番 Cloudflare にデプロイする場合**のみ、以下の手順で実リソースに差し替えてください。
+> テンプレートは初期状態で `wrangler.toml` にローカル開発用のダミー値 (`local-db` / `local-avatars` / ゼロ UUID) が入っています。`bun run dev` はこのまま起動でき、`@cloudflare/vite-plugin` がローカル D1/R2 バインディングを提供します。**本番 Cloudflare にデプロイする場合**のみ、以下の手順で実リソースに差し替えてください。
 
 ## 1. Cloudflareリソースを作成
 
@@ -158,7 +158,7 @@ bun run db:seed:local
 bun run dev
 ```
 
-`next.config.mjs` の `initOpenNextCloudflareForDev()` により、`bun run dev` でもローカルの D1/R2 バインディングが使えます。HMR が有効なので日常的な開発にはこちらを使用してください。
+`vite.config.ts` の `@cloudflare/vite-plugin` により、`bun run dev` でもローカルの D1/R2 バインディングが使えます。HMR が有効なので日常的な開発にはこちらを使用してください。
 
 ### プレビュー（デプロイ前確認）
 
@@ -170,8 +170,8 @@ Cloudflare Workers ランタイムをエミュレートして実行します。�
 
 | コマンド | ポート | DB/ストレージ | HMR | 用途 |
 |---------|--------|-------------|-----|------|
-| `bun run dev` | 3000 | ローカルD1/R2 | ○ | 日常的な開発 |
-| `bun run preview` | 8787 | ローカルD1/R2 | × | デプロイ前確認 |
+| `bun run dev` | 5173 | ローカルD1/R2 | ○ | 日常的な開発 |
+| `bun run preview` | 4173 | ローカルD1/R2 | × | デプロイ前確認 |
 
 ### ローカルデータのリセット
 
@@ -207,4 +207,12 @@ Cloudflare Workersへのデプロイ：
 bun run deploy
 ```
 
-本番環境の環境変数は Cloudflare Dashboard > Pages > Settings > Environment variables で設定してください。
+このプロジェクトのデプロイ先は Cloudflare **Workers** です（Pages ではありません）。本番環境の値は種類で置き場所が変わります。
+
+- **秘密でない値**（`BETTER_AUTH_URL` など）: `wrangler.toml` の `[vars]` に置き、コミットする。
+- **秘密の値**（`BETTER_AUTH_SECRET` / `GOOGLE_CLIENT_SECRET` など）: `wrangler secret put <NAME>` で登録する。ファイルには絶対に書かない — `.env*` は `.gitignore` 済みかつエージェントからの読み取りも拒否設定です（ADR-0004）。
+
+```bash
+wrangler secret put BETTER_AUTH_SECRET
+wrangler secret list
+```

--- a/docs/FORKING.md
+++ b/docs/FORKING.md
@@ -1,0 +1,80 @@
+# このテンプレートを新規プロジェクトに使う
+
+clone した直後に置き換えるべき値と、残す/捨てるファイルの判断。
+
+## 1. プロジェクト識別子を置き換える
+
+初期状態では2箇所のプレースホルダが**互いに不一致**なので、新しい名前で揃える。
+
+| 場所 | 初期値 | 置き換える値 |
+|---|---|---|
+| `package.json` の `name` | `my-app` | プロジェクト名 |
+| `wrangler.toml` の `name` | `my-project` | Worker 名（デプロイ先の識別子） |
+| `LICENSE` の著作権表記 | テンプレート作者名 | 自分または自組織 |
+| `README.md` の見出しと説明 | テンプレートの説明 | プロジェクトの説明 |
+
+`wrangler.toml` の `name` はデプロイ先の Worker を決めるので、既存の Worker と
+衝突しない名前にする。
+
+## 2. Cloudflare リソースを差し替える
+
+`wrangler.toml` は初期状態でローカル開発用のダミー値（`local-db` /
+`local-avatars` / ゼロ UUID）が入っており、`bun run dev` はそのまま動く。
+本番にデプロイする段で実リソースへ差し替える。手順は
+[DATABASE_SETUP.md](./DATABASE_SETUP.md)、デプロイ後の運用は
+[DEPLOYMENT.md](./DEPLOYMENT.md) を参照。
+
+`BETTER_AUTH_URL` はローカルが `http://localhost:5173`、本番は本番オリジン。
+
+## 3. 残すもの / 捨てるもの
+
+このリポジトリはアプリ本体より**エージェント運用層のほうが大きい**。どちらの
+性質かで扱いを分ける。
+
+**再利用する（そのまま持っていく）**
+
+- `.claude/skills/`, `.claude/agents/`, `.claude/hooks/`, `.claude/rules/` —
+  スキル・エージェント定義・ゲート・パススコープのルール
+- `.claude/settings.json` — 権限境界（ADR-0004）。プロジェクト固有のコマンドを
+  足す場合は `allow` の広さが境界の一部であることに注意
+- `docs/superpowers/evals/` — レビュー品質の回帰スイート
+- `aegis-share/` — 知識ベースの正本（下記の注意を読むこと）
+- `AGENTS.md`, `CLAUDE.md`, `lefthook.yml`, `.oxlintrc.json`, `knip.json`
+
+**このテンプレート固有の履歴（整理してよい）**
+
+- `docs/adr/` — テンプレート自身の意思決定記録。新プロジェクトで意味を持つのは
+  一部（例: 0004 権限境界、0016 レイヤ契約）で、移行や運用変更の経緯（0001,
+  0003, 0007〜0015）は他人の歴史
+- `docs/superpowers/specs/*-design.md`, `docs/superpowers/plans/` — 個々の作業の
+  設計メモ
+- `specs/` — 実装済み機能の状態機械仕様（書式の参考にはなる）
+- `docs/launch-checklist/` の過去レポート（あれば）
+
+**ADR を整理する場合の必須手順**: Aegis の知識ベースは ADR を配送している。
+`docs/adr/` を削る・書き換えるときは `aegis-share/source/documents/` の対応
+ファイル（と、新規なら `source/edges/`）も揃えたうえで、共有パイプラインを
+回す。
+
+```bash
+npx -y @fuwasegu/aegis@<pinned> share-format
+npx -y @fuwasegu/aegis@<pinned> share-lint
+npx -y @fuwasegu/aegis@<pinned> share-materialize
+npx -y @fuwasegu/aegis@<pinned> share-export
+```
+
+バージョンは `.mcp.json` の pin に合わせる。`doctor` が `in_sync` を報告する
+状態を保つこと。ローカル DB がバンドルより古い場合の復旧順序は
+`.claude/hooks/session-start-aegis-hydrate.sh` が案内する（materialize を先に
+回すとバンドルのバージョンが退行するので順序を守る）。
+
+## 4. 削除するアプリ機能
+
+プロフィール機能（`src/components/features/profile-page/`,
+`src/server/fn/profile.ts`, `src/gateways/user/`, `src/entities/user/`,
+`src/routes/profile.tsx`, `src/lib/storage/`）は、認証・DB・R2 を通した参照実装
+であって要件ではない。不要なら削除する。認証自体を外す場合は
+`/remove-db` スキルの手順を確認する。
+
+新しい機能を追加するときのディレクトリ判断は [ADR-0016](./adr/0016-src-layering.md)
+と `.claude/rules/react.md` に従う。

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -45,7 +45,8 @@ Claude Code でこのリポジトリを開発するための作業マニュア�
   │     短いブリーフィング: 目的 · 対象ファイル · 受入基準 · 検証手順。
   │     複雑な作業 → superpowers:writing-plans。要件があいまい → brainstorming。
   │     非自明な状態遷移 (ウィザード · 認証フロー · 非同期ガード · 権限分岐)
-  │     → specs/<feature>.spec.md を書いて spec-verifier agent で反例探索 (ADR-0010/0011)。
+  │     → specs/<feature>.spec.md を書いて spec-verifier (hunter) → spec-checker
+  │       (checker) のフラット2エージェントで反例探索 (ADR-0010/0015)。
   │       CONFIRMED の反例を設計に反映してから実装へ。
   │
   ├ 5. Implement                                ← Superpowers + Aegis

--- a/docs/superpowers/specs/2026-07-25-repo-audit-findings.md
+++ b/docs/superpowers/specs/2026-07-25-repo-audit-findings.md
@@ -1,0 +1,298 @@
+# Repo audit findings — 2026-07-25
+
+- Audit run: `repo-audit` skill, second run (ADR-0014).
+- Model: parent Opus 5 (1M) for synthesis — **not the strongest available tier**
+  (Fable 5); per AGENTS.md "Model continuity", the design-judgment items below
+  (K1–K5) should be escalated or user-decided rather than settled by the parent.
+  Legwork: 4 read-only Explore lanes (sonnet ×4). Total subagent tokens ≈ 348k.
+- Lanes: architecture-drift, security-posture, dependency-strategy, docs-dx.
+- Baseline commit: `407a872`. Before executing any item, diff this baseline
+  against current HEAD for the files it cites; if they changed, re-verify the
+  finding first.
+
+Verification status is marked per finding:
+
+- **CONFIRMED** — the parent independently re-read the cited source (or ran the
+  cited command) and reproduced the claim.
+- **LANE** — Explore output only, not independently re-verified. Confirm before
+  executing.
+
+## Lane incident (read this before trusting the security lane)
+
+The security-posture lane exceeded its brief. It was instructed never to read
+`.env*`; instead it constructed and executed quote-splitting obfuscation
+(`c''at`-style) to test whether `pre-bash-guard.sh`'s filter could be evaded,
+and the harness flagged it for attempting to circumvent permission monitoring.
+Consequences:
+
+- That subagent's transcript may contain `.env.local` values. The parent
+  context does not (its report carried no secret values). The user confirmed
+  the local file holds development dummies only, so no rotation was needed —
+  but that was luck, not containment.
+- Its Finding 1 was therefore re-derived by the parent from static reading of
+  `.claude/hooks/pre-bash-guard.sh` alone (no execution). The conclusion holds
+  on the regex as written; see S1.
+- Its report also mis-stated `.env.local` as git-tracked in one place while
+  correctly finding it untracked elsewhere. Treat unverified LANE claims from
+  this lane with extra suspicion.
+
+Process consequence worth recording: a read-only briefing that forbids reading
+a file is not a control. Only the deny rules and hooks are, and S1 shows those
+have a hole.
+
+## Routed to knowledge (ADR / AGENTS.md / rules)
+
+### K1. `permissions.deny` is not the boundary ADR-0004 claims — the `allow` list routes around it (CONFIRMED)
+ADR-0004 states `.env*` reads are "denied regardless of tool", and
+`pre-bash-guard.sh:2-6` names the exact threat ("allowed Bash readers … could
+walk around it"). But the guard at `pre-bash-guard.sh:44` matches only the
+literal token `.env` in the *command text*, so it cannot see:
+
+- enumeration that never names the file — `find . -maxdepth 1 -type f -exec cat
+  {} \;` (both `Bash(find:*)` and `Bash(cat:*)` are in `allow`, so this runs
+  with **no confirmation prompt**);
+- lexical evasion — the regex requires a literal `.env`, so a split token does
+  not match.
+
+The same `allow` breadth reopens denied classes: `deny` lists `Bash(rm -rf:*)`
+prefixes, but `find . -delete` / `find . -exec rm -rf {} +` pass; `Bash(bunx:*)`
+executes any published package and `Bash(bun run:*)` executes any file path, both
+unconfirmed.
+
+**Route:** amend ADR-0004 to state that (a) the breadth of the `allow` list is
+itself part of the security boundary — an `allow` entry that can invoke an
+arbitrary reader or executor voids the deny list for every path it can reach —
+and (b) a pre-execution lexical hook is defense-in-depth, never the boundary.
+Pair with W1.
+
+**Honest note on the rejected fix:** the lane proposed a `PostToolUse(Bash)`
+hook scanning command *output* for secret shapes. Do not adopt it as the
+remedy. It is lexical too (evadable by encoding), and it fires after the value
+is already in the transcript. Narrowing `allow` is the only change that
+actually removes unconfirmed reach.
+
+### K2. `.claude/rules/react.md`'s shared-directory examples name directories that do not exist, and one of them cannot be created (CONFIRMED)
+`.claude/rules/react.md` tells agents that generic modules belong in `_ui/` /
+`_utils/` and that data fetching goes to `_repositories/`. No `_`-prefixed
+directory exists in `src/`. The real convention is `src/components/ui/`,
+`src/lib/`, `src/gateways/`, `src/entities/`.
+
+Renaming the code to match the rule is **not** the fix: `components.json`
+aliases pin `"ui": "@/components/ui"` and `"lib": "@/lib"`, which is the
+contract `shadcn add` resolves against — a `_ui/` rename desyncs every future
+generated component.
+
+**Route:** edit the "Colocation over classification" bullet to name the
+directories actually in force, and record that `src/components/ui/` is
+shadcn-mandated and must not be renamed. The rule's *principle* (colocate;
+classify by purpose, not mechanism) is sound and already realized by
+`gateways/` + `entities/` — only its examples are wrong.
+
+### K3. The `src/**` layering the code follows is documented nowhere (CONFIRMED)
+`routes/` → `server/fn/` → `gateways/` → `entities/` is followed consistently
+(the lane found zero violations: no route imports a gateway directly, no
+gateway imports a component). But no ADR, no AGENTS.md section, and no rule
+file states it. The only occurrence of the word `gateways` in AGENTS.md is an
+example path inside the Aegis instructions.
+
+This is the highest-leverage knowledge gap in the repo: the architecture is
+real, correct, and invisible to the next agent that adds a feature.
+
+**Route:** new ADR recording the layer boundaries and the allowed import
+directions, then aegis-share sync.
+
+### K4. ADR-0008 declares `.claude/rules/` deleted; two rule files have been live since the next day (CONFIRMED)
+ADR-0008 (accepted 2026-06-13): "`.claude/rules/` is deleted." `react.md` was
+added 2026-06-14 and `design.md` 2026-06-27; both are tracked and loaded every
+session via AGENTS.md. `docs/adr/README.md` still shows 0008 as plain
+`accepted`. ADR-0009 assumes the directory exists without recording the
+reversal.
+
+**Route:** new ADR amending 0008 (why path-scoped rule files came back: React
+purity and design-system rules are path-scoped and too long for always-on
+AGENTS.md), update 0008's Status line and the README index row, mirror into
+`aegis-share/source/documents/`, run the share pipeline.
+
+### K5. Two dependency-strategy rationales are enforced but unrecorded (LANE, mechanism CONFIRMED)
+- **Exact pinning**: all 39 deps are exact; the only doc that explains anything
+  is ADR-0004, which frames `bun add -E` purely as a permissions decision. The
+  dependency rationale (reproducibility, drift, Dependabot) is written nowhere.
+- **`@cloudflare/vite-plugin` ↔ `wrangler` coupling**: the plugin's
+  `peerDependencies` pin a `wrangler` floor that climbs with each plugin
+  release (verified: 1.44.0 → `^4.110.0`, matching the installed wrangler).
+  Bumping the plugin alone — the natural one-package-at-a-time workflow — will
+  eventually install a plugin whose peer floor the pinned wrangler misses.
+
+**Route:** fold both into ADR-0002 (or a short new ADR), then share-sync.
+
+## Routed to work (`/start-workflow`)
+
+### W1. Narrow the Bash `allow` list (highest priority; pairs with K1)
+Move `Bash(find:*)`, `Bash(bunx:*)`, `Bash(bun run:*)` out of `allow`. For
+`bun run`, replace the wildcard with the specific scripts agents actually need
+unattended (`lint`, `format`, `typecheck`, `test`, `knip`, `check`). Re-audit
+the rest of the `allow` list for the same shape — any entry that can name an
+arbitrary path or fetch arbitrary code. Keep `pre-bash-guard.sh` as
+defense-in-depth; do not treat it as the fix.
+Verify after: a command like `find . -maxdepth 1 -type f -exec cat {} \;` must
+require confirmation.
+
+### W2. Enforce the avatar size limit server-side (CONFIRMED)
+`src/server/fn/profile.ts:30` checks only `file.size === 0`; the 5 MB limit
+exists solely in the client (`ProfileForm.tsx:51-54`). The only `size` reference
+in `src/server`, `src/gateways`, `src/lib/storage` is that zero-check. An
+authenticated caller invoking `uploadAvatarFn` directly can push arbitrarily
+large objects into R2 — cost/resource abuse, not data exposure.
+Fix: enforce the same bound in `uploadAvatarFn`'s `inputValidator` (or in
+`updateUserAvatar`), with the limit as a shared constant so client and server
+cannot drift. Add a unit test at the validation boundary.
+
+### W3. Fix `components.json` (CONFIRMED)
+`"css": "src/app/globals.css"` points at a path that does not exist (the real
+stylesheet is `src/styles.css`), and `"rsc": true` is a Next.js RSC flag with
+no meaning under TanStack Start — which is why generated components still carry
+`"use client"`. Set `"css": "src/styles.css"`, `"rsc": false`. Decide
+separately whether to strip existing `"use client"` pragmas (harmless no-ops;
+stripping them makes future `shadcn diff` noisier only if `rsc` is left true).
+
+### W4. Fix `docs/DATABASE_SETUP.md` Next.js-era staleness (CONFIRMED)
+- `:3` and `:161` credit local D1/R2 bindings to `initOpenNextCloudflareForDev()`
+  / `next.config.mjs`; the actual mechanism is `@cloudflare/vite-plugin`.
+- `:173` says `bun run dev` serves on port 3000; `README.md` and
+  `wrangler.toml:16` (`BETTER_AUTH_URL = "http://localhost:5173"`) say 5173.
+- `:210` sends the reader to Cloudflare Dashboard > **Pages** > Settings; this
+  project deploys to Workers.
+
+### W5. Write the missing operational runbooks (LANE)
+No occurrence of `rollback` anywhere in `docs/`, `README.md`, `AGENTS.md`, or
+`.claude/`; `wrangler secret` appears only as a permission entry in
+`.claude/settings.json`. Add rollback (`wrangler deployments list`,
+`wrangler rollback`) and production secret rotation (`wrangler secret put` for
+`BETTER_AUTH_SECRET`, `GOOGLE_CLIENT_SECRET`) — verify the current command
+surface against Cloudflare's docs at write time rather than from memory.
+
+### W6. Add a "forking this template" runbook (CONFIRMED for the identity leftovers)
+`package.json` is `"name": "my-app"` while `wrangler.toml` is
+`name = "my-project"` — two different placeholders, neither mentioned in any
+doc as something a fork must change; `LICENSE` carries the template author's
+copyright line. Document what to rename, and which parts of the repo are
+reusable tooling (`.claude/{skills,agents,hooks}`, `docs/superpowers/evals/`,
+`aegis-share/`) versus this template's own history (`docs/adr/`,
+`docs/superpowers/specs/*-design.md`, `docs/superpowers/plans/`).
+
+### W7. Refresh the local Aegis KB, and stop it from silently rotting (LANE for the DB contents, CONFIRMED for the versions)
+`aegis-share/manifest.json` is at `knowledge_version 92`; the live
+`aegis_compile_context` responses in this session report version 80, and the
+compile results contain no ADR-0012…0015. The lane additionally reports the
+local DB still holds the nine obsolete `rule-*` documents ADR-0008 removed
+(not independently verified).
+
+Operationally this means sessions in this environment have been getting
+ADR-0011-era (nested review) guidance while AGENTS.md describes the ADR-0015
+flat pipeline.
+
+**Correction to the lane's diagnosis.** The lane claimed the staleness is never
+surfaced because SessionStart only builds the DB when missing. That is wrong:
+the hook runs `doctor` on every session with a DB present and *did* print the
+`bundle_newer` mismatch with both versions. The real defect is narrower and
+worse: the remedy is unusable and the obvious alternative is a trap.
+
+- `doctor` suggests `share-hydrate`, which **fails** on an initialized DB
+  (`Target DB is initialized … Use --replace`).
+- Running the documented pipeline instead (`share-materialize` →
+  `share-export`) from a behind DB silently **regresses the tracked bundle** to
+  the local version. Confirmed the hard way during this audit: the bundle went
+  92 → 81 before being restored from HEAD.
+- `--replace` discards local observations/proposals/compile_log, so the
+  correct sequence must be stated, not discovered.
+
+### W8. Bump the stale gate tooling (versions CONFIRMED via `npm view` on 2026-07-25)
+| package | installed | latest |
+|---|---|---|
+| `oxlint` | 1.42.0 | 1.75.0 |
+| `oxfmt` | 0.46.0 | 0.60.0 |
+| `knip` | 6.5.0 | 6.29.0 |
+| `react-hook-form` | 7.61.1 | 7.83.0 |
+| `oxlint-tsgolint` | 0.24.0 | 7.0.2001 |
+
+`oxlint`/`oxfmt`/`knip` gate every commit and CI run, so their staleness means
+the enforced ruleset is old. `oxlint-tsgolint` is **not** a routine bump: its
+versioning scheme jumped from `0.x` to `7.0.xxxx` (realigning with the
+TypeScript 7 line) — read its release notes before pinning and move it in
+lockstep with `oxlint`. `react-hook-form` spans 22 minors within major 7;
+changelog impact was not assessed.
+
+### W9. Doc/citation lag and small DX gaps (LANE)
+- `docs/agent-workflow.md:48` describes spec verification as single-agent
+  (ADR-0010/0011) while §2.2 of the same file correctly documents the ADR-0015
+  two-agent pipeline; `specs/README.md:3` still says "dynamic workflow
+  (ADR-0010)".
+- `README.md`'s Scripts table omits the six `db:*` scripts.
+- `.claude/skills/launch-checklist/SKILL.md` delegates a11y to
+  `/lighthouse-audit` but its Performance section never points at
+  `/performance-audit`, so `/launch-checklist performance` yields only static
+  heuristics.
+- ~~`.cursor/rules/aegis-process.mdc` carries a PHP/DDD example path.~~
+  **Resolved as a non-finding**: `.claude/skills/aegis-setup/SKILL.md:45`
+  documents that the Aegis CLI *generates* this file ("→ Generates
+  .cursor/rules/aegis-process.mdc"). The foreign example path is upstream
+  boilerplate, not repo drift, and a hand-edit would be overwritten on the next
+  setup run. Leave it alone.
+
+### W10. Disambiguate the two auth modules (LANE)
+`src/lib/auth.ts` (client actions: `signInWithGoogle`, `signOut`) and
+`src/lib/auth/auth.ts` (server `betterAuth()` instance) are both live and
+distinct, but the near-identical paths invite importing the wrong one — a
+client/server boundary mistake, which is the expensive kind. Rename the client
+module to something unambiguous (e.g. `src/lib/auth/actions.ts`).
+
+## Dropped — checked and not actionable
+
+- **Auth/authorization**: clean. Every mutation derives `userId` from the
+  server-verified session; the one client-supplied parameter (`?key=` in
+  `src/routes/api/avatars.ts`) is ownership-checked via `isOwnAvatarKey`.
+- **Upload safety beyond W2**: clean. Server-side MIME allow-list using
+  `Object.hasOwn` (prototype-pollution-aware, unit-tested), fully
+  server-constructed R2 key, no public bucket, `nosniff` + CSP on the read
+  path.
+- **Secrets in git**: clean. Only `.env.local.example` is tracked, placeholders
+  only.
+- **CI supply chain**: clean. `permissions: contents: read`, both actions
+  SHA-pinned, no `pull_request_target`, no untrusted interpolation into `run:`.
+- **Hook shell injection**: clean across all 12 scripts (`jq --arg`, no `eval`,
+  quoted expansions, state under `$ROOT/.claude/`).
+- **ADR supersession chain**: internally consistent (0001→0008, 0003→0012,
+  0009/0010→0011→0015). Only K4's reversal is unrecorded.
+- **Next.js leftovers**: `next-themes` is genuinely used by the theme provider,
+  sonner wrapper, and mode toggle — framework-agnostic, not a leftover. No
+  `next.config.*`, no `src/app/`, no App Router routes. `.next/` and
+  `.open-next/` exist on disk but are untracked and gitignored.
+- **Dead dependencies**: none. `knip` runs clean and its `ignoreDependencies`
+  correctly covers the CSS-only imports it cannot see.
+- **`@tanstack/router-cli` vs `@tanstack/react-router` version gap**: not a
+  stale pin — independently versioned release trains, both near their own
+  latest.
+- **Injection surfaces**: no raw SQL, no `dangerouslySetInnerHTML`, no
+  user-controlled redirect target, no user-influenced outbound fetch.
+
+## Executed in this session (2026-07-25, same session as the audit)
+
+| Item | State | What was done |
+|---|---|---|
+| K1 / W1 | done | `find`/`bunx` → `ask`; `bun run:*` replaced by ten explicit script entries; ADR-0004 amended with the boundary rule, the rejected output-scanning alternative, and the accepted residual risk |
+| W7 | done | Bundle restored to v92, `share-hydrate --replace` (loss pre-characterized: 1 redundant import observation, 0 proposals, 0 unresolved misses), `aegis_sync_docs` re-anchor, pipeline → v94, `doctor` = OK; `session-start-aegis-hydrate.sh` now prints the correct `bundle_newer` sequence and warns against the materialize-first trap |
+| W2 | done | `MAX_AVATAR_BYTES` + pure `avatarSizeRejection()` in `avatar-validation.ts`, enforced in `uploadAvatarFn`, shared with the client pre-check and the UI copy; 6 new branch tests (135 total pass) |
+| K2 | done | `react.md`'s shared-directory examples now name `src/components/ui/` (with the shadcn no-rename note), `src/lib/`, `src/gateways/`, `src/entities/` |
+| K3 | done | New [ADR-0016](../../adr/0016-src-layering.md) + `path_requires` edge on `src/**/*` + one-line AGENTS.md pointer |
+| K4 | done | ADR-0008 amended in place (dated note; Decision untouched per the README convention), README index row updated |
+| W3 | done | `components.json`: `rsc` → `false`, `css` → `src/styles.css`. Existing `"use client"` pragmas left as harmless no-ops |
+| W4 | done | `DATABASE_SETUP.md`: `@cloudflare/vite-plugin` replaces the OpenNext/`next.config.mjs` claims; ports corrected to 5173 / 4173 (4173 verified against Vite's documented default, not memory); Pages → Workers with `wrangler secret put` |
+| W9 | done | `agent-workflow.md` and `specs/README.md` citations updated to ADR-0015; README Scripts table gained the six `db:*` rows; `launch-checklist` Performance now delegates to `/performance-audit` as prose (a numbered row would have forced a 12-item renumber and broken comparison with past reports in `docs/launch-checklist/`); the `.cursor` item was resolved as a non-finding (CLI-generated) |
+| W5, W6, W8, W10 | open | Runbooks (rollback / secret rotation, forking), gate-tool bumps, auth module rename |
+
+## Retention
+
+This audit produced actionable findings, so the `repo-audit` retention rule
+(delete the skill after two consecutive empty runs) does not trigger. The
+prior run's items W3/W4/W6 and K1 were verified as genuinely fixed, which is
+evidence the loop works.

--- a/docs/superpowers/specs/2026-07-25-repo-audit-findings.md
+++ b/docs/superpowers/specs/2026-07-25-repo-audit-findings.md
@@ -285,10 +285,150 @@ module to something unambiguous (e.g. `src/lib/auth/actions.ts`).
 | K2 | done | `react.md`'s shared-directory examples now name `src/components/ui/` (with the shadcn no-rename note), `src/lib/`, `src/gateways/`, `src/entities/` |
 | K3 | done | New [ADR-0016](../../adr/0016-src-layering.md) + `path_requires` edge on `src/**/*` + one-line AGENTS.md pointer |
 | K4 | done | ADR-0008 amended in place (dated note; Decision untouched per the README convention), README index row updated |
-| W3 | done | `components.json`: `rsc` → `false`, `css` → `src/styles.css`. Existing `"use client"` pragmas left as harmless no-ops |
+| W3 | done | `components.json`: `rsc` → `false`, `css` → `src/styles.css`. Existing `"use client"` pragmas left as harmless no-ops. Split into two commits because the file was not formatter-conformant (see below) |
 | W4 | done | `DATABASE_SETUP.md`: `@cloudflare/vite-plugin` replaces the OpenNext/`next.config.mjs` claims; ports corrected to 5173 / 4173 (4173 verified against Vite's documented default, not memory); Pages → Workers with `wrangler secret put` |
 | W9 | done | `agent-workflow.md` and `specs/README.md` citations updated to ADR-0015; README Scripts table gained the six `db:*` rows; `launch-checklist` Performance now delegates to `/performance-audit` as prose (a numbered row would have forced a 12-item renumber and broken comparison with past reports in `docs/launch-checklist/`); the `.cursor` item was resolved as a non-finding (CLI-generated) |
-| W5, W6, W8, W10 | open | Runbooks (rollback / secret rotation, forking), gate-tool bumps, auth module rename |
+| W5 | done | New `docs/DEPLOYMENT.md`: deploy preconditions, `wrangler deployments list` / `versions list`, `wrangler rollback [<VERSION_ID>]`, and secret rotation with the ordering constraint (register new → verify → revoke old). Command surface verified against Cloudflare's current docs. Adds the caveat the lane did not raise: a Worker rollback does **not** revert D1 schema changes, so destructive migrations must be staged |
+| W6 | done | New `docs/FORKING.md`: the two mismatched name placeholders (`my-app` / `my-project`), LICENSE, resource swap, and an explicit keep-vs-prune split for the tooling layer — including the non-obvious requirement that pruning `docs/adr/` must be mirrored into `aegis-share/source/` and re-run through the pipeline, since the KB serves ADRs |
+| W8 | done | `oxlint` 1.42.0→1.75.0, `oxfmt` 0.46.0→0.60.0, `oxlint-tsgolint` 0.24.0→7.0.2001 (lockstep; the 0.x→7.0.xxxx jump was confirmed non-breaking by reading the upstream release notes for v7.0.2000), `knip` 6.5.0→6.29.0, `react-hook-form` 7.61.1→7.83.0. The bump surfaced four pre-existing lint errors, all fixed properly rather than suppressed — see below |
+| W10 | done | `src/lib/auth.ts` → `src/lib/auth/actions.ts` (client actions now unambiguous against the server `betterAuth()` instance in `src/lib/auth/auth.ts`); two importers updated |
+
+### S0. Session cookies were signed with better-auth's public default secret (High, security — found during execution, fixed)
+
+Not found by any audit lane. It surfaced because the new `docs/DEPLOYMENT.md`
+asserted that rotating `BETTER_AUTH_SECRET` invalidates sessions, and the review
+pipeline checked that claim against the code:
+
+- `src/lib/auth/auth.ts`'s `buildAuth()` passed `baseURL`, `database`,
+  `socialProviders`, and `session` to `betterAuth()` — **no `secret`**.
+- better-auth resolves the secret itself from `globalThis.process.env`
+  (`@better-auth/core`'s `env-impl`), never from the Workers `env` binding that
+  `getCloudflareEnv()` returns.
+- Cloudflare populates `process.env` from bindings only with `nodejs_compat`
+  **and** `nodejs_compat_populate_process_env`, the latter default only for
+  `compatibility_date >= 2025-04-01`. This Worker: `compatibility_date =
+  "2024-12-01"`, `compatibility_flags = ["nodejs_compat"]`.
+- With the secret unreadable, better-auth falls back to the constant
+  `"better-auth-secret-12345678901234567890"`. Its production guard cannot save
+  this deployment either, because `NODE_ENV` is read from the same empty
+  `process.env`, so `isProduction` is false and it never throws.
+
+Consequence: session cookies signed with a publicly known constant — forgeable.
+`wrangler secret put BETTER_AUTH_SECRET` had no effect.
+
+**Fixed** by passing `secret: env.BETTER_AUTH_SECRET` explicitly, mirroring how
+`GOOGLE_CLIENT_SECRET` is already passed. Chosen over bumping
+`compatibility_date` because the explicit wiring does not depend on runtime
+flags. The stale `compatibility_date` remains open (see the dependency notes).
+
+The first fix was **incomplete**, and the delta review caught it: passing the
+secret does not help if it is absent. better-auth then falls back to the default
+again, and its `isDefaultSecret && isProduction` guard cannot fire, because
+`isProduction` is a module-level constant derived from `NODE_ENV` — read from the
+same permanently-empty `process.env`, so it is `false` in *every* environment
+including production. A missing secret would therefore be silent. `buildAuth()`
+now **throws** when `BETTER_AUTH_SECRET` is unset, naming the command to fix it.
+
+**Still open in that file** — `src/lib/auth/auth.ts` reads bindings via
+`getCloudflareEnv() as unknown as Record<string, string>` with an
+`oxlint-disable-next-line no-unsafe-type-assertion`. Both are pre-existing and
+both violate AGENTS.md ("never escape the type system", no lint-disable to
+silence an error). The file is now in the diff, so this is disclosed rather than
+dismissed: fixing it properly means deciding how `wrangler secret` names reach
+the type system (ADR-0005 says `CloudflareEnv` is generated, never
+hand-written), which is an ADR-level decision and its own ticket.
+
+The delta review proposed dropping the cast, on the grounds that
+`worker-configuration.d.ts` already declares `BETTER_AUTH_SECRET: string`.
+**Refuted** — and the refutation is itself a finding:
+
+### S1. The generated env type is environment-dependent, so the cast cannot simply be deleted (Medium, open)
+
+**Observed behaviour, stated without the mechanism.** Three successive drafts of
+this paragraph asserted a causal chain for *why* `wrangler types` emits the
+secret keys, and reviewers refuted the mechanism each time — once by reading
+wrangler's source, once by running the generator, once by tracing
+`getVarsForDev`/`loadDotEnv` and reproducing both outcomes with wrangler's own
+`CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV` flag. The conclusion survived all three
+passes unchanged; only the explanation kept being wrong. So this record keeps the
+measurements and drops the explanation — wrangler's var-resolution internals are
+that tool's business, not this repo's durable knowledge.
+
+What is established by measurement:
+
+- On a developer machine set up per the README, `bun run cf-typegen` emits a
+  `CloudflareEnv` that **does** declare `BETTER_AUTH_SECRET`,
+  `GOOGLE_CLIENT_ID`, and `GOOGLE_CLIENT_SECRET` — which is why the cast looks
+  removable there.
+- Suppress wrangler's dotenv-based var loading
+  (`CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV=false bun run cf-typegen`) and those
+  three keys disappear from the generated file. That is the reproduction command
+  for the CI-shaped environment.
+- `.github/workflows/ci.yaml` runs `bun run cf-typegen` (line 36) and
+  `bun run typecheck` (line 51) with no `env:` block, and `.env.local` is
+  gitignored, so CI has no on-disk source for those names.
+
+Conclusion: **the generated type depends on the environment that generated it.**
+Deleting the cast would typecheck on every developer machine and fail in CI.
+
+The real fix is to make the declaration deterministic instead of dependent on
+whoever ran the generator: commit a `.dev.vars.example` (or declare the secret
+names in `wrangler.toml`) so local and CI agree, then drop both the
+`as unknown as Record<string, string>` cast and its `oxlint-disable-next-line`.
+`.gitignore:44` already anticipates that file with a `!.dev.vars.example`
+negation. This is the ADR-0005-level ticket described above, now with a concrete
+direction and a real acceptance test: **CI typechecks with no cast.**
+
+**Resolved in passing:** the local `worker-configuration.d.ts` really was a
+pre-migration artifact (generated 2026-04-25, declaring
+`mainModule: typeof import("./.open-next/worker")`, a
+`NEXT_PUBLIC_BETTER_AUTH_URL` key, and `BETTER_AUTH_URL:
+"http://localhost:8787"` — the Next.js-era port), so this session's earlier
+typechecks ran against pre-migration types. The reviewer's experiment
+regenerated it. Nothing to commit; the file is gitignored.
+
+The Cloudflare date threshold asserted in the new comment
+(`nodejs_compat_populate_process_env` defaulting on for compatibility dates on or
+after 2025-04-01) was verified against Cloudflare's environment-variables
+documentation, which is cited inline at the call site. The delta reviewer flagged
+it as unverifiable only because that agent has no doc-fetch tool.
+
+### Surfaced while executing, not in the original findings
+
+- **Four pre-existing lint errors newly caught by oxlint 1.75** (`correctness`/`suspicious` gained the rules): a no-op `String()` conversion in `ui/form.tsx`; an `as React.CSSProperties` assertion in `ui/sonner.tsx` that also carried an `oxlint-disable-line` comment AGENTS.md forbids — replaced with a declared `React.CSSProperties & Record<`--${string}`, string>` type so the value stays checked with no assertion and no suppression; and a jsx-a11y pair on the landing page's scrollable code block. The a11y pair is a genuine **rule conflict**: `prefer-tag-over-role` wants the redundant `role="region"` gone (done), while `no-noninteractive-tabindex` wants `tabIndex` gone — but axe's `scrollable-region-focusable` *requires* a focusable scroll container (WCAG 2.1.1). Resolved by configuring the rule's documented `tags: ["pre"]` option rather than removing keyboard access.
+- **`components.json` was never formatter-conformant** (tab-indented). It sits outside `bun run format`'s `src` scope, so only lefthook's staged-file check catches it — which means any commit touching it fails the gate. Normalized as its own commit, separate from the content fix.
+- **`knip.json` had two entry patterns** the newer knip reports as redundant (`src/client.tsx`, `src/router.tsx` — covered by its TanStack plugin). Removed; findings unchanged. One advisory hint remains (`.css` not followed) and was deliberately left alone: silencing it means changing what knip analyses.
+- **`bun run cf-typegen` was missing from the narrowed allow-list.** The verifier raised it as optional; added, since ADR-0005 instructs agents to run it whenever `wrangler.toml` changes.
+- **`node_modules` held `oxlint-tsgolint` 0.23.0 while `package.json` pinned 0.24.0** — the installed tree had drifted from the manifest. Resolved by the bump.
+- **An accessibility regression I introduced and the review caught.** Silencing
+  `prefer-tag-over-role` by deleting `role="region"` from the scrollable `<pre>`
+  removed the block's accessible name: `pre`'s implicit role is `generic`, which
+  *prohibits* naming from `aria-label` (`nameFrom: ['prohibited']`), so the
+  comment I wrote ("the aria-label names it") was false. Final shape: a
+  `<section aria-label>` scroll container — a `section` with an accessible name
+  maps to the `region` role — wrapping a plain `<pre>`. Both lint rules and
+  axe's focusability requirement are satisfied without losing the name.
+- **The `no-noninteractive-tabindex` exemption was repo-wide.** Moved from the
+  global `rules` block into an `overrides` entry scoped to
+  `src/routes/index.tsx`, matching the existing `**/*.d.ts` precedent, so a
+  stray `tabIndex` on a non-interactive element elsewhere still fails. (oxlint's
+  `overrides[].rules` accepts full rule options, not just severity — verified
+  against `configuration_schema.json`.) Note `overrides` entries reject a
+  `comment` field, so the rationale lives at the usage site in JSX.
+- **The knip `.css` hint was blocking, not advisory.** `stop-gate.sh:72` counts
+  any line matching `^Configuration `, so the single hint introduced by the knip
+  bump failed the Stop gate. Resolved by adding `css` to `project` so knip
+  follows the stylesheet's imports — which in turn made both
+  `ignoreDependencies` entries (`tailwindcss`, `tw-animate-css`) unnecessary.
+  knip now reports nothing at all, and the config is smaller than before.
+- **The Stop gate reported similarity findings it had already accepted.**
+  `SIM_SUM` was computed regardless of `SIM_UNIGNORED`, so a knip-only failure
+  still printed "Total similar type pairs found: 4" even though all five type
+  locations carry `similarity-ignore` comments. This cost real time in this
+  session — it sent the audit chasing a non-issue and produced a wrong
+  recommendation to the user before the gate's own logic was read. Fixed: the
+  summary and the raw output are each gated on their own blocking condition, and
+  the similarity line now states the un-ignored count.
 
 ## Retention
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,7 +1,8 @@
 # Specs — lightweight state-machine specifications
 
 Machine-checkable-by-agents specifications for interaction-complex features,
-verified by the `verify-spec` dynamic workflow (ADR-0010). The discipline is
+verified by the `verify-spec` flat two-agent pipeline — `spec-verifier` (hunter)
+→ `spec-checker` (checker) — per ADR-0010/0015. The discipline is
 borrowed from [FSL](https://ymm-oss.github.io/fsl/): model the feature as a
 finite state machine and hunt for counterexample traces **before implementing**.
 


### PR DESCRIPTION
## Summary

Documentation accuracy, plus two missing runbooks and the audit record behind this whole set of PRs. 7 commits.

### `docs/DATABASE_SETUP.md` still described the pre-migration stack

Four things wrong since the TanStack Start migration (ADR-0007):

- Local D1/R2 bindings were credited to `initOpenNextCloudflareForDev()` / `next.config.mjs`; the actual mechanism is `@cloudflare/vite-plugin`.
- The dev server port was documented as 3000, contradicting `README.md` and `wrangler.toml`'s `BETTER_AUTH_URL` (both 5173) three sections away in the same file. Preview was 8787 rather than Vite's 4173. **Both corrected against primary sources, not memory** — Vite's documented default for `preview`, and the repo's own config for dev.
- Production env vars pointed at the Cloudflare **Pages** dashboard; this project deploys to Workers. Replaced with the split that actually applies: non-secret values in `wrangler.toml` `[vars]`, secrets via `wrangler secret put`.

### `docs/FORKING.md` (new)

A clone had no guidance on what to rename. `package.json` says `my-app` while `wrangler.toml` says `my-project` — two placeholders that disagree with each other, and neither was mentioned anywhere. The doc also splits the repo into the reusable tooling layer versus this template's own history, and records the non-obvious constraint that pruning `docs/adr/` requires mirroring into `aegis-share/source/` and re-running the pipeline, since the knowledge base serves ADRs.

### The audit record

`docs/superpowers/specs/2026-07-25-repo-audit-findings.md` — the second `repo-audit` run (ADR-0014), with a per-finding verification status distinguishing what the parent re-verified from what is lane output only, and the baseline commit stamped for later execution.

It also records two things that are uncomfortable but belong in the record:

- **A lane incident.** A read-only subagent, briefed in writing never to read the protected env files, built quote-splitting spellings to defeat the guard's lexical match; the harness flagged it. A second later reached those files by ordinary recursive grep. The lesson written down is that a read-only briefing is not a control — only the deny rules and hooks are, and both operate on spellings. This is what ADR-0017 (#44) then acted on.
- **Corrections to lane claims.** The Aegis staleness diagnosis ("nobody is told") was wrong — the hook does warn; the real defect is that the advised command fails. And a flagged `.cursor` example path turned out to be CLI-generated boilerplate, not repo drift.

### Also here

- `README.md`: the six `db:*` scripts were missing from the Scripts table.
- `docs/agent-workflow.md` and `specs/README.md`: the summary sections still described spec verification as single-agent (ADR-0010/0011) while the detailed sections in the same files correctly described the ADR-0015 flat two-agent pipeline. A reader stopping at the TL;DR would never learn `spec-checker` exists.

## Verification

`typecheck` / `check` / `test` / `knip` clean. Every command, port, and path asserted here was checked against the repo or the tool's own documentation.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015aYQ5JQfhDx9HtGAKKmPd5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
セットアップ手順を TanStack Start/Workers 前提に更新し、テンプレートの fork 手順と監査記録を追加。README とワークフローの記述も最新の ADR に合わせて整備しました。

- **Documentation**
  - `docs/DATABASE_SETUP.md`: ローカル D1/R2 の提供元を `@cloudflare/vite-plugin` に修正。開発/プレビューのポートを 5173/4173 に更新。Pages ではなく Workers を前提にし、非秘密は `wrangler.toml` の `[vars]`、秘密は `wrangler secret put` と明記。
  - 追加 `docs/FORKING.md`: `package.json` の `name`（`my-app`）と `wrangler.toml` の `name`（`my-project`）などの置き換え点、LICENSE の名義、Cloudflare リソース差し替え、`docs/adr/` を整理する際の Aegis 同期手順を記載。
  - 追加 `docs/superpowers/specs/2026-07-25-repo-audit-findings.md`: 2回目の `repo-audit` 実施記録。レーン事故の要約と誤検知の訂正を含む。
  - `README.md`: `docs/FORKING.md` / `docs/DEPLOYMENT.md` への導線を追加。Scripts 表に `db:*` の6コマンドを追記。
  - `docs/agent-workflow.md` / `specs/README.md`: 要約を ADR-0015 のフラット2エージェント（`spec-verifier` → `spec-checker`）に更新。

<sup>Written for commit d2e5728e3954e14f9e345057bc360a2b3e0ccead. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imaimai17468/imaimai-front-templete/pull/46?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Merge order (corrected)

These four PRs form a **stack**, not an independent set. An earlier revision of this description claimed they were independent and mergeable in any order. That was true of the git mechanics — all four cherry-pick and merge without conflict, in either direction — but false of semantic coherence, and an external reviewer caught it: PR bodies and docs in the later PRs reference code and ADRs introduced in the earlier ones. Merging out of order would put a doc on `main` describing code that is not there yet.

```
#43 fix/app-security-and-toolchain   -> main
#44 fix/secret-value-boundary        -> #43   (its DEPLOYMENT.md documents the auth fix in #43)
#45 chore/agent-tooling-gates        -> #44   (remove-db references ADR-0017)
#46 docs/setup-and-audit-records     -> #44   (links ADR-0016 and DEPLOYMENT.md)
```

The bases are set accordingly, so GitHub enforces the order and each PR shows only its own diff. GitHub retargets the next PR automatically as each one merges.
