### PR TITLE
fix: 秘密名を wrangler.toml で宣言し、認証コードの型アサーションと lint 抑制を外す

### DIFF
--- a/.claude/rules/authoring.md
+++ b/.claude/rules/authoring.md
@@ -4,15 +4,21 @@ paths:
   - ".claude/agents/*.md"
   - ".claude/rules/*.md"
   - "AGENTS.md"
-  - "docs/*.md"
+  - "docs/**/*.md"
 ---
 
 # Authoring Instruction Documents (not caught by linters)
 
 Applies to text that **instructs** — a procedure someone executes against other
-files. ADRs and audit records describe state rather than direct action; they
-still have to be accurate, but the restatement rule below is aimed at
-procedures.
+files. ADRs and audit records describe state rather than direct action, so the
+restatement rule below is aimed at procedures rather than at them.
+
+The **verify-every-claim** rule applies to all of it, records included. An
+earlier revision scoped this file to `docs/*.md` only, on the reasoning that
+ADRs are records; an ADR amendment then shipped two invented claims — a
+cross-reference to an ADR that says nothing of the kind, and a "this already
+happened once" anecdote with no commit behind it. A reviewer caught both. The
+scope now covers `docs/**` for exactly that reason.
 
 No gate checks any of this. Typecheck, lint, knip, and tests all pass on a
 document that is confidently wrong about every file it names, so the review

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ Path-scoped rules are auto-loaded from `.claude/rules/`:
 
 - **`.claude/rules/react.md`** (`**/*.tsx`) — Rules of React: purity, hooks, component splitting, module organization
 - **`.claude/rules/design.md`** (`src/**/*.css`, `src/**/*.tsx`) — Design system: Wairo (和色) palette, squircle corners, typography, spacing, component conventions
-- **`.claude/rules/authoring.md`** (`.claude/skills/**/*.md`, `.claude/agents/*.md`, `.claude/rules/*.md`, `AGENTS.md`, `docs/*.md`) — Writing instruction documents: point instead of restating, verify every claim about another file before review, keep the document consistent with itself
+- **`.claude/rules/authoring.md`** (`.claude/skills/**/*.md`, `.claude/agents/*.md`, `.claude/rules/*.md`, `AGENTS.md`, `docs/**/*.md`) — Writing instruction documents: point instead of restating, verify every claim about another file before review, keep the document consistent with itself
 
 `src/` is layered — `routes/` → `server/fn/` → `gateways/` → `entities/`, imports flow downward only, and `server/fn/` is the authorization boundary. The contract is ADR-0016; Aegis serves it for any `src/**` edit.
 

--- a/aegis-share/canonical.json
+++ b/aegis-share/canonical.json
@@ -1,7 +1,7 @@
 {
   "format_version": 1,
-  "snapshot_id": "0f0d9c774ca03ae3df0f419262cfc5b21c5ada1e5afff9406f6b61756a4a24a5",
-  "knowledge_version": 102,
+  "snapshot_id": "e388243814cf9b107cf44450f2195f67ce125a89ccfc680fd4a22dca5b138a1b",
+  "knowledge_version": 106,
   "documents": [
     {
       "doc_id": "adr-0001",

--- a/aegis-share/manifest.json
+++ b/aegis-share/manifest.json
@@ -1,8 +1,8 @@
 {
   "format_version": 1,
   "bundle_file": "canonical.json",
-  "snapshot_id": "0f0d9c774ca03ae3df0f419262cfc5b21c5ada1e5afff9406f6b61756a4a24a5",
-  "knowledge_version": 102,
-  "bundle_sha256": "80a09d5be83b2173cfe670f42ebca37d101f9a4db5f9f87950b4431c16bc028d",
+  "snapshot_id": "e388243814cf9b107cf44450f2195f67ce125a89ccfc680fd4a22dca5b138a1b",
+  "knowledge_version": 106,
+  "bundle_sha256": "26ec56c07d979376933d3ba19b5fee776b922638cbabb697c78a150aba29d401",
   "includes_tag_mappings": false
 }

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -49,6 +49,31 @@ wrangler rollback <VERSION_ID>     # 指定バージョンへ戻す
 
 という順序に分けること。切り戻しが必要になった時点で選択肢を残すのが目的。
 
+## 秘密の初期登録（デプロイより先に）
+
+`wrangler.toml` の `[secrets]` に列挙した名前は `required` 扱いなので、未登録の
+まま `wrangler deploy` すると失敗する。名前を宣言する前に登録を済ませる、という
+順序を守れば済む。
+
+Worker がまだ存在しない場合も同じ順序でよい。`wrangler secret put` は登録先が
+無いことを検出すると、プレースホルダの Worker を作ってよいか尋ね、承諾すれば
+それを作ってから登録する。デプロイを先に済ませる必要はない。
+
+```bash
+wrangler secret put BETTER_AUTH_SECRET     # 値は対話的に入力する
+wrangler secret put GOOGLE_CLIENT_ID
+wrangler secret put GOOGLE_CLIENT_SECRET
+bun run deploy
+```
+
+**値をコマンドラインに書かないこと。** `wrangler secret put` は値を対話的に受け取り
+エコーもしない。`wrangler secret bulk` に JSON をパイプする形は、既定のシェルでは
+実値がヒストリファイルに残るので使わない (ADR-0017: 秘密は一時的にもファイルへ
+書かない)。同じ理由で `wrangler deploy --secrets-file <path>` も使わない。
+
+秘密を**後から追加**する場合も順序は同じ。`[secrets]` に名前を足す前に登録する。
+逆順にすると、既存 Worker のデプロイが必須チェックで失敗する。
+
 ## シークレットのローテーション
 
 秘密情報はファイルに置かず `wrangler secret` で管理する（ADR-0017）。

--- a/docs/superpowers/specs/2026-07-25-repo-audit-findings.md
+++ b/docs/superpowers/specs/2026-07-25-repo-audit-findings.md
@@ -31,13 +31,13 @@ Consequences:
   but that was luck, not containment.
 - Its Finding 1 was therefore re-derived by the parent from static reading of
   `.claude/hooks/pre-bash-guard.sh` alone (no execution). The conclusion holds
-  on the regex as written; see S1.
+  on the regex as written; see K1.
 - Its report also mis-stated `.env.local` as git-tracked in one place while
   correctly finding it untracked elsewhere. Treat unverified LANE claims from
   this lane with extra suspicion.
 
 Process consequence worth recording: a read-only briefing that forbids reading
-a file is not a control. Only the deny rules and hooks are, and S1 shows those
+a file is not a control. Only the deny rules and hooks are, and K1 shows those
 have a hole.
 
 ## Routed to knowledge (ADR / AGENTS.md / rules)
@@ -342,7 +342,27 @@ The delta review proposed dropping the cast, on the grounds that
 `worker-configuration.d.ts` already declares `BETTER_AUTH_SECRET: string`.
 **Refuted** — and the refutation is itself a finding:
 
-### S1. The generated env type is environment-dependent, so the cast cannot simply be deleted (Medium, open)
+### S1. The generated env type is environment-dependent, so the cast cannot simply be deleted (Medium, **resolved 2026-07-28**)
+
+> **Resolved 2026-07-28.** The cast and its `oxlint-disable` are gone. The fix is
+> a `[secrets] required = [...]` block in `wrangler.toml`: `wrangler types` emits
+> those names on `CloudflareEnv` from the config rather than from whatever local
+> env file it happens to find, so the generated type is identical on a developer
+> machine and in CI. ADR-0005 needs no amendment — this stays inside its
+> "generated, never hand-written" rule.
+>
+> Worth recording because it was nearly missed: the first attempt declared the
+> three names by hand in a `src/worker-secrets.d.ts` that declaration-merged into
+> the generated interface, and amended ADR-0005 to carve out an exception for
+> secrets. That worked, but it was the wrong shape — and the reason it was chosen
+> is that "is this declarable in `wrangler.toml`?" was checked against Cloudflare's
+> `wrangler types` docs page and `--help`, neither of which mentions `[secrets]`,
+> instead of against wrangler's own config schema. A reviewer found the field and
+> demonstrated it. Checking the documentation is not the same as checking the tool.
+>
+> The acceptance test below — CI typechecks with no cast — is met, verified with
+> the secret names present and absent from the local environment. The analysis
+> that follows is left as written.
 
 **Observed behaviour, stated without the mechanism.** Three successive drafts of
 this paragraph asserted a causal chain for *why* `wrangler types` emits the

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -5,8 +5,7 @@ import * as schema from "@/lib/drizzle/schema";
 import { getCloudflareEnv } from "@/server/cloudflare";
 
 const buildAuth = () => {
-  // oxlint-disable-next-line no-unsafe-type-assertion -- wrangler secrets are not in CloudflareEnv type
-  const env = getCloudflareEnv() as unknown as Record<string, string>;
+  const env = getCloudflareEnv();
   // better-auth resolves BETTER_AUTH_SECRET from `globalThis.process.env`,
   // which workerd only populates when `nodejs_compat_populate_process_env` is
   // on — default only for compatibility_date >= 2025-04-01, while this Worker

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -14,3 +14,13 @@ bucket_name = "local-avatars"
 
 [vars]
 BETTER_AUTH_URL = "http://localhost:5173"
+
+# Declared so `wrangler types` emits these on CloudflareEnv deterministically.
+# Values are never here — they are registered with `wrangler secret put`
+# (ADR-0017). Without this block the generator falls back to whatever local env
+# file it finds, so the type differs between a developer machine and CI.
+#
+# Naming a secret here also makes it required at deploy time, so register it with
+# `wrangler secret put` before adding the name — see docs/DEPLOYMENT.md.
+[secrets]
+required = ["BETTER_AUTH_SECRET", "GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"]


### PR DESCRIPTION
## Summary

Closes carryover item **S1** from the 2026-07-25 repo audit. 4 commits.

`buildAuth()` reached Cloudflare bindings through `getCloudflareEnv() as unknown as Record<string, string>` with an `oxlint-disable-next-line no-unsafe-type-assertion` above it. AGENTS.md forbids both outright. They survived earlier attempts because deleting them typechecks locally and fails in CI.

**Why the naive removal fails.** Secrets are registered with `wrangler secret put` and appear in no config file, so `wrangler types` cannot read them from `wrangler.toml` — it reads the machine instead. A developer who followed the README gets a `CloudflareEnv` **with** the secret keys; CI, having no local env file, gets one **without**. The same command produced two different types, and the cast papered over the difference. Reproduce the CI shape with `CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV=false bun run cf-typegen`.

**The fix** is a `[secrets] required = [...]` block in `wrangler.toml`. The generator reads names from there and stops consulting local env files entirely, so the type is identical everywhere and the cast has nothing left to hide. This stays inside ADR-0005's "generated, never hand-written" rule — the block is config the generator reads, exactly like the D1 and R2 bindings — so **no ADR amendment was needed**.

## Operational consequence, documented

Naming a secret in that block makes it required at deploy time: declare before registering and the deploy fails. `docs/DEPLOYMENT.md` gains a section putting registration first. A brand-new Worker needs no special handling — `wrangler secret put` detects the missing Worker and offers to create a placeholder, so deploying first is unnecessary.

Values go in through the interactive, non-echoing prompt only. Both alternatives are rejected in the doc with their reasons: piping JSON to `wrangler secret bulk` puts real values on a command line that a default shell writes to a history file, and `wrangler deploy --secrets-file` writes them to disk — each violating ADR-0017's "never written to a file, not even temporarily".

## Also here

- **`.claude/rules/authoring.md` scope widened** to `docs/**/*.md`. It had been `docs/*.md`, which does not match `docs/adr/**` — so the rule requiring claims about other files to be verified before review was not loading for the ADR edit that then shipped two invented claims. The rule body records what happened.
- **Audit record updated.** S1 marked resolved, plus why the wrong shape was nearly shipped: "is this declarable in `wrangler.toml`?" was checked against Cloudflare's docs page and `--help`, neither of which mentions `[secrets]`, instead of against wrangler's own config schema. Checking the documentation is not the same as checking the tool. Two stale `S1` cross-references corrected to `K1`.
- **Aegis bundle resynced** (`knowledge_version` 106). Reverting the withdrawn ADR-0005 amendment had left `canonical.json` still serving it, so the KB pointed at a file that never existed.

## Verification

`typecheck` / `check` / `test` (135) / `knip` clean, and specifically **verified in both environment shapes** — with the secret names present in the local environment and with dotenv loading disabled — producing a byte-identical generated interface. `aegis doctor` in sync.

## Review focus

`docs/DEPLOYMENT.md`'s registration section. Two earlier revisions of it each violated ADR-0017 in a different way; the current one routes only through the interactive prompt. Every behavioural claim in it was traced to wrangler 4.110.0's source rather than its documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015aYQ5JQfhDx9HtGAKKmPd5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Declare Worker secret names in `wrangler.toml` and remove the unsafe type assertion in auth. This makes `CloudflareEnv` types consistent across dev and CI and fails deploys when required secrets are missing.

- **Bug Fixes**
  - Added `[secrets].required` in `wrangler.toml` for `BETTER_AUTH_SECRET`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` so `wrangler types` no longer reads local dotenv; removed the cast and `oxlint` suppression in auth.
  - Updated `docs/DEPLOYMENT.md` to register secrets first via interactive `wrangler secret put`; do not use `wrangler secret bulk` or `wrangler deploy --secrets-file` (ADR-0017).
  - Expanded `.claude/rules/authoring.md` to `docs/**`, marked audit S1 resolved and fixed K1 refs, and resynced Aegis bundle to `knowledge_version` 106.

- **Migration**
  - Before the next deploy, run `wrangler secret put` for the three secrets in each environment; deploys now fail if any are missing.

<sup>Written for commit 1b427dee0f4c9ba5a02589a97d9af62713b192d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imaimai17468/imaimai-front-templete/pull/47?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

