### PR TITLE
fix: track compatibility_date to the installed workerd, not the calendar

### DIFF
--- a/aegis-share/canonical.json
+++ b/aegis-share/canonical.json
@@ -1,7 +1,7 @@
 {
   "format_version": 1,
-  "snapshot_id": "e388243814cf9b107cf44450f2195f67ce125a89ccfc680fd4a22dca5b138a1b",
-  "knowledge_version": 106,
+  "snapshot_id": "28b8072a93439ee7d7e25e9825f362c2fadb6d92677742dccd82f90c67a1aa45",
+  "knowledge_version": 108,
   "documents": [
     {
       "doc_id": "adr-0001",
@@ -189,6 +189,17 @@
       "template_origin": null,
       "source_path": "docs/adr/0017-secret-value-boundary.md",
       "source_refs_json": null
+    },
+    {
+      "doc_id": "adr-0018",
+      "title": "Compatibility Date Tracks Installed Workerd",
+      "kind": "reference",
+      "content": "# 0018. `compatibility_date` tracks the installed workerd, not today's date\n\n- Status: accepted\n- Date: 2026-07-28\n\n## Context\n\n`compatibility_date` in `wrangler.toml` selects the Workers runtime behaviour\nthis project opts into. Cloudflare's guidance is to set it to the current date\nwhen starting a project and to update it occasionally, and it holds old dates\nforever — so a stale date is not a fault that any gate reports. This project's\ndate sat at `2024-12-01` from the Next.js era through the TanStack Start\nmigration ([ADR-0007](0007-tanstack-start-migration.md)), which the 2026-07-25\nrepo audit recorded as its last open item.\n\nThe obvious reading of \"set it to the current date\" is wrong here, and the\nfailure is not graceful. The local runtime is the `workerd` binary that comes in\nwith `wrangler`, and it refuses to start when the config asks for a date newer\nthan that binary supports:\n\n```\nservice core:user:t: This Worker requires compatibility date \"2026-07-28\",\nbut the newest date supported by this server binary is \"2026-07-15\".\n```\n\nThat is an error, not a warning — `vite dev` dies for everyone on the project,\nwhile `wrangler deploy` would have been fine, because Cloudflare's edge runs a\ncurrent runtime. So the ceiling is a property of the installed toolchain, and it\ndoes not track the calendar: with `wrangler` 4.110.0 / `workerd` 1.20260708.1 it\nis `2026-07-15`, ahead of the workerd package's own version date.\n\nThe bump also flips every compatibility flag whose default date falls in the\nskipped window: 44 flags carrying their own date, plus 27 that `nodejs_compat`\nimplies, which this project enables. Most are inert here (no Durable Objects, Queues,\nWorkflows, Containers, or Python; the app code uses no WebSocket, Cache API,\n`URLPattern`, timers, `node:` imports, or `AsyncLocalStorage`), and\n`assets_navigation_prefers_asset_serving` needs an `assets.not_found_handling`\nthat the generated deploy config does not set. The one flag that reaches this\ncodebase is `nodejs_compat_populate_process_env` (default from 2025-04-01),\nwhich is why `src/lib/auth/auth.ts` and `docs/DEPLOYMENT.md` had to be corrected\nalongside the date.\n\n## Decision\n\n`compatibility_date` is pinned to **the newest date the installed `workerd`\nsupports**, not to today's date. Raising it is part of raising `wrangler` — the\ntwo move together, and the ceiling is discovered from the runtime rather than\nassumed: set the date, run `bun run dev`, and read the error, which names the\nsupported date. `bun run cf-typegen` follows every change per\n[ADR-0005](0005-wrangler-types-for-cloudflare-env.md), and the flag deltas for\nthe skipped window are enumerated from `compatibility-date.capnp` in\n`cloudflare/workerd`, which carries every flag's `compatEnableDate` and\n`impliedByAfterDate` annotation in one machine-readable file. Cloudflare's flags\npage documents the same flags, but one prose section per flag — which answers\n\"what does this flag do\", not \"what changed between these two dates\".\n\n## Alternatives considered\n\n- **Today's date, per Cloudflare's starting-a-project guidance**: rejected — it\n  breaks the local runtime, and the breakage is invisible until someone runs\n  `dev`. The guidance is written for the case where the toolchain is current.\n- **Bump `wrangler` first so the ceiling reaches today**: rejected as part of\n  this change, not in general. `@cloudflare/vite-plugin`'s `peerDependencies`\n  pin a `wrangler` floor that climbs with each plugin release, so the two are\n  bumped in lockstep as their own ticket.\n- **Leave the date alone, since Cloudflare supports old dates forever**:\n  rejected — new features are gated on a current date, and the gap only ever\n  grows, so the eventual bump reviews more flag changes at once.\n- **Pin flags explicitly instead of leaning on the date's defaults**: rejected —\n  it duplicates the runtime's own defaults into config that then needs its own\n  maintenance, for a project whose surface the flags do not touch.\n\n## Consequences\n\n- The date is bounded by the toolchain, so it can lag the calendar. That is\n  intended: the number states which runtime the project has actually been run\n  against, which a calendar date does not.\n- A `wrangler` bump now has a second step (re-check the ceiling, move the date)\n  and a review obligation (the flags in the newly crossed window).\n- `process.env` is populated from text bindings from now on. Nothing in the app\n  reads it, and better-auth's secret still arrives explicitly, but code that\n  starts depending on `process.env` would be depending on a flag default.\n- Verified for this bump: `typecheck`, 135 tests, `build`, and a `dev` smoke\n  test of `/`, `/profile`, and better-auth's session endpoint.\n",
+      "content_hash": "b95d4a43adf5daf6b7b0d822b9da54d0deaee6c9e59fd5ac83ba0c6c061a787e",
+      "ownership": "file-anchored",
+      "template_origin": null,
+      "source_path": "docs/adr/0018-compatibility-date-tracks-installed-workerd.md",
+      "source_refs_json": null
     }
   ],
   "edges": [
@@ -287,6 +298,15 @@
       "source_type": "path",
       "source_value": "wrangler.toml",
       "target_doc_id": "adr-0005",
+      "edge_type": "path_requires",
+      "priority": -1,
+      "specificity": 0
+    },
+    {
+      "edge_id": "8f2f1800-4798-49b4-b5fe-95b53503a4c5",
+      "source_type": "path",
+      "source_value": "wrangler.toml",
+      "target_doc_id": "adr-0018",
       "edge_type": "path_requires",
       "priority": -1,
       "specificity": 0

--- a/aegis-share/manifest.json
+++ b/aegis-share/manifest.json
@@ -1,8 +1,8 @@
 {
   "format_version": 1,
   "bundle_file": "canonical.json",
-  "snapshot_id": "e388243814cf9b107cf44450f2195f67ce125a89ccfc680fd4a22dca5b138a1b",
-  "knowledge_version": 106,
-  "bundle_sha256": "26ec56c07d979376933d3ba19b5fee776b922638cbabb697c78a150aba29d401",
+  "snapshot_id": "28b8072a93439ee7d7e25e9825f362c2fadb6d92677742dccd82f90c67a1aa45",
+  "knowledge_version": 108,
+  "bundle_sha256": "41d8438ff911462d4a25e0b669b25f1065a129dc9d888f39f818c0d05e205311",
   "includes_tag_mappings": false
 }

--- a/aegis-share/source/documents/adr-0018.md
+++ b/aegis-share/source/documents/adr-0018.md
@@ -1,0 +1,91 @@
+---
+doc_id: adr-0018
+title: Compatibility Date Tracks Installed Workerd
+kind: reference
+ownership: file-anchored
+source_path: docs/adr/0018-compatibility-date-tracks-installed-workerd.md
+---
+# 0018. `compatibility_date` tracks the installed workerd, not today's date
+
+- Status: accepted
+- Date: 2026-07-28
+
+## Context
+
+`compatibility_date` in `wrangler.toml` selects the Workers runtime behaviour
+this project opts into. Cloudflare's guidance is to set it to the current date
+when starting a project and to update it occasionally, and it holds old dates
+forever — so a stale date is not a fault that any gate reports. This project's
+date sat at `2024-12-01` from the Next.js era through the TanStack Start
+migration ([ADR-0007](0007-tanstack-start-migration.md)), which the 2026-07-25
+repo audit recorded as its last open item.
+
+The obvious reading of "set it to the current date" is wrong here, and the
+failure is not graceful. The local runtime is the `workerd` binary that comes in
+with `wrangler`, and it refuses to start when the config asks for a date newer
+than that binary supports:
+
+```
+service core:user:t: This Worker requires compatibility date "2026-07-28",
+but the newest date supported by this server binary is "2026-07-15".
+```
+
+That is an error, not a warning — `vite dev` dies for everyone on the project,
+while `wrangler deploy` would have been fine, because Cloudflare's edge runs a
+current runtime. So the ceiling is a property of the installed toolchain, and it
+does not track the calendar: with `wrangler` 4.110.0 / `workerd` 1.20260708.1 it
+is `2026-07-15`, ahead of the workerd package's own version date.
+
+The bump also flips every compatibility flag whose default date falls in the
+skipped window: 44 flags carrying their own date, plus 27 that `nodejs_compat`
+implies, which this project enables. Most are inert here (no Durable Objects, Queues,
+Workflows, Containers, or Python; the app code uses no WebSocket, Cache API,
+`URLPattern`, timers, `node:` imports, or `AsyncLocalStorage`), and
+`assets_navigation_prefers_asset_serving` needs an `assets.not_found_handling`
+that the generated deploy config does not set. The one flag that reaches this
+codebase is `nodejs_compat_populate_process_env` (default from 2025-04-01),
+which is why `src/lib/auth/auth.ts` and `docs/DEPLOYMENT.md` had to be corrected
+alongside the date.
+
+## Decision
+
+`compatibility_date` is pinned to **the newest date the installed `workerd`
+supports**, not to today's date. Raising it is part of raising `wrangler` — the
+two move together, and the ceiling is discovered from the runtime rather than
+assumed: set the date, run `bun run dev`, and read the error, which names the
+supported date. `bun run cf-typegen` follows every change per
+[ADR-0005](0005-wrangler-types-for-cloudflare-env.md), and the flag deltas for
+the skipped window are enumerated from `compatibility-date.capnp` in
+`cloudflare/workerd`, which carries every flag's `compatEnableDate` and
+`impliedByAfterDate` annotation in one machine-readable file. Cloudflare's flags
+page documents the same flags, but one prose section per flag — which answers
+"what does this flag do", not "what changed between these two dates".
+
+## Alternatives considered
+
+- **Today's date, per Cloudflare's starting-a-project guidance**: rejected — it
+  breaks the local runtime, and the breakage is invisible until someone runs
+  `dev`. The guidance is written for the case where the toolchain is current.
+- **Bump `wrangler` first so the ceiling reaches today**: rejected as part of
+  this change, not in general. `@cloudflare/vite-plugin`'s `peerDependencies`
+  pin a `wrangler` floor that climbs with each plugin release, so the two are
+  bumped in lockstep as their own ticket.
+- **Leave the date alone, since Cloudflare supports old dates forever**:
+  rejected — new features are gated on a current date, and the gap only ever
+  grows, so the eventual bump reviews more flag changes at once.
+- **Pin flags explicitly instead of leaning on the date's defaults**: rejected —
+  it duplicates the runtime's own defaults into config that then needs its own
+  maintenance, for a project whose surface the flags do not touch.
+
+## Consequences
+
+- The date is bounded by the toolchain, so it can lag the calendar. That is
+  intended: the number states which runtime the project has actually been run
+  against, which a calendar date does not.
+- A `wrangler` bump now has a second step (re-check the ceiling, move the date)
+  and a review obligation (the flags in the newly crossed window).
+- `process.env` is populated from text bindings from now on. Nothing in the app
+  reads it, and better-auth's secret still arrives explicitly, but code that
+  starts depending on `process.env` would be depending on a flag default.
+- Verified for this bump: `typecheck`, 135 tests, `build`, and a `dev` smoke
+  test of `/`, `/profile`, and better-auth's session endpoint.

--- a/aegis-share/source/edges/path-requires.json
+++ b/aegis-share/source/edges/path-requires.json
@@ -42,6 +42,13 @@
     "specificity": 0
   },
   {
+    "edge_id": "8f2f1800-4798-49b4-b5fe-95b53503a4c5",
+    "source_value": "wrangler.toml",
+    "target_doc_id": "adr-0018",
+    "priority": -1,
+    "specificity": 0
+  },
+  {
     "edge_id": "906b2023-0ae5-491a-9057-5888c48d21f1",
     "source_value": ".claude/agents/**",
     "target_doc_id": "adr-0014",

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -93,18 +93,18 @@ wrangler secret delete <NAME>               # 不要になった名前を削除
 | `GOOGLE_CLIENT_SECRET` | Google Cloud Console | 先に新しいシークレットを発行し、登録後に旧シークレットを失効させる |
 
 `BETTER_AUTH_SECRET` は `src/lib/auth/auth.ts` で `betterAuth({ secret: ... })` に
-**明示的に渡している**。better-auth 自身のフォールバックは `process.env` を読むが、
+**明示的に渡している**。better-auth 自身のフォールバックは `process.env` を読み、
 Workers が `process.env` を埋めるのは `nodejs_compat_populate_process_env` が有効な
-場合のみ（既定になるのは `compatibility_date` が 2025-04-01 以降）で、この Worker は
-2024-12-01 + `nodejs_compat` のみ。明示的に渡さないと登録した値が読まれず、
-公開されている既定シークレットで署名され続ける。この配線を外さないこと。
+場合（既定になるのは `compatibility_date` が 2025-04-01 以降）に限られる。現在の
+`compatibility_date` はこれを満たすが、明示的な配線はそのフラグの既定値に依存しない
+（ADR-0018）ので外さないこと。
 
 値が未設定の場合、`buildAuth()` は既定シークレットにフォールバックせず**例外を
 投げる**（メッセージに `wrangler secret put BETTER_AUTH_SECRET` を明示）。
 つまり登録漏れの症状は「認証が静かに脆弱になる」ではなく「認証経路が失敗する」。
-better-auth 自身の既定シークレット検出は本番判定に `NODE_ENV` を使い、それも
-埋まらない `process.env` から読むため全環境で作動しない。この throw が唯一の
-検出手段になる。
+better-auth 自身の既定シークレット検出は本番判定に `NODE_ENV` を使うが、`NODE_ENV`
+は Worker の binding ではないため `process.env` が埋まっても現れず、全環境で作動
+しない。この throw が唯一の検出手段になる。
 
 `wrangler secret put` は即時反映される（再デプロイ不要）。手順は「新しい値を
 登録 → 動作確認 → 発行元で旧い値を失効」の順にする。逆順にすると失効から

--- a/docs/adr/0018-compatibility-date-tracks-installed-workerd.md
+++ b/docs/adr/0018-compatibility-date-tracks-installed-workerd.md
@@ -1,0 +1,84 @@
+# 0018. `compatibility_date` tracks the installed workerd, not today's date
+
+- Status: accepted
+- Date: 2026-07-28
+
+## Context
+
+`compatibility_date` in `wrangler.toml` selects the Workers runtime behaviour
+this project opts into. Cloudflare's guidance is to set it to the current date
+when starting a project and to update it occasionally, and it holds old dates
+forever — so a stale date is not a fault that any gate reports. This project's
+date sat at `2024-12-01` from the Next.js era through the TanStack Start
+migration ([ADR-0007](0007-tanstack-start-migration.md)), which the 2026-07-25
+repo audit recorded as its last open item.
+
+The obvious reading of "set it to the current date" is wrong here, and the
+failure is not graceful. The local runtime is the `workerd` binary that comes in
+with `wrangler`, and it refuses to start when the config asks for a date newer
+than that binary supports:
+
+```
+service core:user:t: This Worker requires compatibility date "2026-07-28",
+but the newest date supported by this server binary is "2026-07-15".
+```
+
+That is an error, not a warning — `vite dev` dies for everyone on the project,
+while `wrangler deploy` would have been fine, because Cloudflare's edge runs a
+current runtime. So the ceiling is a property of the installed toolchain, and it
+does not track the calendar: with `wrangler` 4.110.0 / `workerd` 1.20260708.1 it
+is `2026-07-15`, ahead of the workerd package's own version date.
+
+The bump also flips every compatibility flag whose default date falls in the
+skipped window: 44 flags carrying their own date, plus 27 that `nodejs_compat`
+implies, which this project enables. Most are inert here (no Durable Objects, Queues,
+Workflows, Containers, or Python; the app code uses no WebSocket, Cache API,
+`URLPattern`, timers, `node:` imports, or `AsyncLocalStorage`), and
+`assets_navigation_prefers_asset_serving` needs an `assets.not_found_handling`
+that the generated deploy config does not set. The one flag that reaches this
+codebase is `nodejs_compat_populate_process_env` (default from 2025-04-01),
+which is why `src/lib/auth/auth.ts` and `docs/DEPLOYMENT.md` had to be corrected
+alongside the date.
+
+## Decision
+
+`compatibility_date` is pinned to **the newest date the installed `workerd`
+supports**, not to today's date. Raising it is part of raising `wrangler` — the
+two move together, and the ceiling is discovered from the runtime rather than
+assumed: set the date, run `bun run dev`, and read the error, which names the
+supported date. `bun run cf-typegen` follows every change per
+[ADR-0005](0005-wrangler-types-for-cloudflare-env.md), and the flag deltas for
+the skipped window are enumerated from `compatibility-date.capnp` in
+`cloudflare/workerd`, which carries every flag's `compatEnableDate` and
+`impliedByAfterDate` annotation in one machine-readable file. Cloudflare's flags
+page documents the same flags, but one prose section per flag — which answers
+"what does this flag do", not "what changed between these two dates".
+
+## Alternatives considered
+
+- **Today's date, per Cloudflare's starting-a-project guidance**: rejected — it
+  breaks the local runtime, and the breakage is invisible until someone runs
+  `dev`. The guidance is written for the case where the toolchain is current.
+- **Bump `wrangler` first so the ceiling reaches today**: rejected as part of
+  this change, not in general. `@cloudflare/vite-plugin`'s `peerDependencies`
+  pin a `wrangler` floor that climbs with each plugin release, so the two are
+  bumped in lockstep as their own ticket.
+- **Leave the date alone, since Cloudflare supports old dates forever**:
+  rejected — new features are gated on a current date, and the gap only ever
+  grows, so the eventual bump reviews more flag changes at once.
+- **Pin flags explicitly instead of leaning on the date's defaults**: rejected —
+  it duplicates the runtime's own defaults into config that then needs its own
+  maintenance, for a project whose surface the flags do not touch.
+
+## Consequences
+
+- The date is bounded by the toolchain, so it can lag the calendar. That is
+  intended: the number states which runtime the project has actually been run
+  against, which a calendar date does not.
+- A `wrangler` bump now has a second step (re-check the ceiling, move the date)
+  and a review obligation (the flags in the newly crossed window).
+- `process.env` is populated from text bindings from now on. Nothing in the app
+  reads it, and better-auth's secret still arrives explicitly, but code that
+  starts depending on `process.env` would be depending on a flag default.
+- Verified for this bump: `typecheck`, 135 tests, `build`, and a `dev` smoke
+  test of `/`, `/profile`, and better-auth's session endpoint.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -67,3 +67,4 @@ Strictly sequential, four zero-padded digits. Never renumber. When an ADR is rep
 | [0015](0015-flat-review-pipeline.md) | Review and spec verification are flat finder → verifier pipelines (verifier unnested) | accepted |
 | [0016](0016-src-layering.md) | `src/` is layered: routes → server functions → gateways → entities | accepted |
 | [0017](0017-secret-value-boundary.md) | The boundary is the secret's value, not access to the file holding it | accepted |
+| [0018](0018-compatibility-date-tracks-installed-workerd.md) | `compatibility_date` tracks the installed workerd, not today's date | accepted |

--- a/docs/superpowers/specs/2026-07-25-repo-audit-findings.md
+++ b/docs/superpowers/specs/2026-07-25-repo-audit-findings.md
@@ -337,14 +337,15 @@ same permanently-empty `process.env`, so it is `false` in *every* environment
 including production. A missing secret would therefore be silent. `buildAuth()`
 now **throws** when `BETTER_AUTH_SECRET` is unset, naming the command to fix it.
 
-**Still open in that file** — `src/lib/auth/auth.ts` reads bindings via
+**Left open in that file at the time, resolved later as S1 below** —
+`src/lib/auth/auth.ts` read bindings via
 `getCloudflareEnv() as unknown as Record<string, string>` with an
-`oxlint-disable-next-line no-unsafe-type-assertion`. Both are pre-existing and
-both violate AGENTS.md ("never escape the type system", no lint-disable to
-silence an error). The file is now in the diff, so this is disclosed rather than
-dismissed: fixing it properly means deciding how `wrangler secret` names reach
+`oxlint-disable-next-line no-unsafe-type-assertion`. Both were pre-existing and
+both violated AGENTS.md ("never escape the type system", no lint-disable to
+silence an error). The file was in the diff, so this was disclosed rather than
+dismissed: fixing it properly meant deciding how `wrangler secret` names reach
 the type system (ADR-0005 says `CloudflareEnv` is generated, never
-hand-written), which is an ADR-level decision and its own ticket.
+hand-written), which was an ADR-level decision and became its own ticket.
 
 The delta review proposed dropping the cast, on the grounds that
 `worker-configuration.d.ts` already declares `BETTER_AUTH_SECRET: string`.

--- a/docs/superpowers/specs/2026-07-25-repo-audit-findings.md
+++ b/docs/superpowers/specs/2026-07-25-repo-audit-findings.md
@@ -319,7 +319,15 @@ Consequence: session cookies signed with a publicly known constant — forgeable
 **Fixed** by passing `secret: env.BETTER_AUTH_SECRET` explicitly, mirroring how
 `GOOGLE_CLIENT_SECRET` is already passed. Chosen over bumping
 `compatibility_date` because the explicit wiring does not depend on runtime
-flags. The stale `compatibility_date` remains open (see the dependency notes).
+flags. The stale `compatibility_date` was **resolved 2026-07-28**: it now tracks
+the newest date the installed workerd supports (`2026-07-15`) rather than the
+calendar, because a date past that ceiling makes the local runtime refuse to
+start — see [ADR-0018](../../adr/0018-compatibility-date-tracks-installed-workerd.md).
+The bump crossed `nodejs_compat_populate_process_env`, so the analysis below —
+which turns on `process.env` being unpopulated — describes the pre-bump state.
+`process.env` now carries the text bindings; `NODE_ENV` is not among them, so
+better-auth's `isProduction` is still false everywhere and the `buildAuth()`
+throw is still the only guard.
 
 The first fix was **incomplete**, and the delta review caught it: passing the
 secret does not help if it is absent. better-auth then falls back to the default

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -7,16 +7,18 @@ import { getCloudflareEnv } from "@/server/cloudflare";
 const buildAuth = () => {
   const env = getCloudflareEnv();
   // better-auth resolves BETTER_AUTH_SECRET from `globalThis.process.env`,
-  // which workerd only populates when `nodejs_compat_populate_process_env` is
-  // on — default only for compatibility_date >= 2025-04-01, while this Worker
-  // is on 2024-12-01 with `nodejs_compat` alone
+  // which workerd populates from text bindings only while
+  // `nodejs_compat_populate_process_env` is on — default for
+  // compatibility_date >= 2025-04-01
   // (https://developers.cloudflare.com/workers/configuration/environment-variables/).
-  // So the secret has to be handed over explicitly, and the absence has to be
-  // fatal here: better-auth's own guard against its public default secret only
-  // fires when it believes it is in production, and it decides that from
-  // NODE_ENV — read from the same unpopulated `process.env`, so it is false in
-  // every environment. Without this throw, a missing secret silently signs
-  // sessions with a published constant.
+  // The secret is still handed over explicitly, because explicit wiring does
+  // not depend on that runtime flag staying default (ADR-0018).
+  // The absence has to be fatal here: better-auth's own guard against its
+  // public default secret only fires when it believes it is in production, and
+  // it decides that from NODE_ENV — which is not a Worker binding, so it is
+  // absent from the populated `process.env` and the guard is false in every
+  // environment. Without this throw, a missing secret silently signs sessions
+  // with a published constant.
   if (!env.BETTER_AUTH_SECRET) {
     throw new Error(
       "BETTER_AUTH_SECRET is not set. Register it with `wrangler secret put BETTER_AUTH_SECRET` for a deployed Worker, or set it in .env.local for local development."

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,10 @@
 name = "my-project"
 main = "./src/ssr.tsx"
-compatibility_date = "2024-12-01"
+# Pinned to the newest date the installed workerd supports, not to today's date:
+# a date beyond that ceiling makes the local runtime refuse to start, so
+# `vite dev` breaks for everyone. Raise it only together with wrangler
+# (ADR-0018).
+compatibility_date = "2026-07-15"
 compatibility_flags = ["nodejs_compat"]
 
 [[d1_databases]]


### PR DESCRIPTION
## Summary

Resolves the last open item of the 2026-07-25 repo audit: `wrangler.toml`'s `compatibility_date` had been stuck at `2024-12-01` since the Next.js era, surviving the TanStack Start migration.

It is now `2026-07-15` — **the newest date the installed workerd supports, not today's date**. Cloudflare's "set it to the current date" guidance breaks this project: the local runtime refuses to *start* (an error, not a warning) when the configured date exceeds what the bundled `workerd` binary supports, so today's `2026-07-28` would kill `vite dev` for everyone while `wrangler deploy` stayed fine. Measured, not assumed:

```
service core:user:t: This Worker requires compatibility date "2026-07-28",
but the newest date supported by this server binary is "2026-07-15".
```

The ceiling is a property of the toolchain and does not track the calendar — `workerd` 1.20260708.1 supports up to `2026-07-15`, ahead of its own package version date. [ADR-0018](docs/adr/0018-compatibility-date-tracks-installed-workerd.md) records the policy: the date moves together with `wrangler`, and the ceiling is discovered from the runtime rather than guessed.

## Flag review

The bump crosses 44 flags carrying their own default date plus 27 implied by `nodejs_compat`, enumerated from `compatibility-date.capnp` in `cloudflare/workerd` rather than from the published flags page (which is one prose section per flag — the wrong shape for "what changed between two dates").

Almost all are inert here: no Durable Objects, Queues, Workflows, Containers or Python, and the app code uses no WebSocket, Cache API, `URLPattern`, timers, `node:` imports or `AsyncLocalStorage`. `assets_navigation_prefers_asset_serving` needs an `assets.not_found_handling` that the generated deploy config does not set.

The one flag that reaches this codebase is `nodejs_compat_populate_process_env` (default from 2025-04-01), so `process.env` now carries the text bindings. That falsified the comments in `src/lib/auth/auth.ts` and the secret-rotation section of `docs/DEPLOYMENT.md`, which both explained the auth wiring in terms of `process.env` being permanently empty. Corrected against measurement: with this repo's `no_bundle: true` shape, `process.env.NODE_ENV` is still undefined after the bump (the `"development"` value observable under wrangler's own bundling is an esbuild build-time replacement, not a runtime value), so better-auth's `isProduction` remains false in every environment and its default-secret guard still never fires. The `buildAuth()` throw is unchanged and remains the only guard.

## Verification

- `bun run typecheck`, `bun run check` (oxlint + oxfmt), `bun run knip`, `bun run test` (135 passed), `bun run build`
- `bun run cf-typegen` regenerated per ADR-0005 — `CloudflareEnv` now also emits `NodeJS.ProcessEnv`
- dev smoke test: `/` → 200, `/profile` → 307 to `/login`, better-auth `get-session` → 200, no runtime errors
- aegis `doctor`: in_sync at knowledge_version 108

## Commits

| commit | purpose |
|---|---|
| `d670744` | ADR-0018 recording the policy |
| `2fe0006` | the date bump plus the two corrected descriptions |
| `2e11a09` | audit record: the open item marked resolved |
| `7c7d161` | audit record: a self-contradicting status about S1 (found in review, split out as a drive-by) |
| `4f9a254` | aegis KB synced to v108 |

## Out of scope

Bumping `wrangler` 4.110.0 → 4.114.0, which would raise the ceiling and let the date advance further. It is coupled to `@cloudflare/vite-plugin`'s peer floor (audit finding K5) and belongs in its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned `wrangler.toml` `compatibility_date` to `2026-07-15` (the latest our installed `workerd` supports) to keep local dev from failing, and documented the policy in ADR-0018.

- **Bug Fixes**
  - Set `compatibility_date` to the installed `workerd` ceiling so the local runtime starts reliably; advance the date only when bumping `wrangler` (per ADR-0018).
  - Crossing this date makes `nodejs_compat_populate_process_env` default: `process.env` is now filled from text bindings. Kept explicit `BETTER_AUTH_SECRET` wiring and the `buildAuth()` throw; `NODE_ENV` remains undefined in Workers.

- **Refactors**
  - Added ADR-0018 and linked it from config; updated `docs/DEPLOYMENT.md` and auth comments to reflect the new `process.env` behavior; synced `aegis-share` metadata.

<sup>Written for commit 4f9a25424e1785fe7f2b62fb394bd7c9f7e637c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imaimai17468/imaimai-front-templete/pull/48?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

