### PR TITLE
fix: the Aegis dispatch gate was never able to stamp on bash 3.2

### DIFF
--- a/.claude/hooks/post-aegis-compile.sh
+++ b/.claude/hooks/post-aegis-compile.sh
@@ -4,12 +4,13 @@
 #    pre-agent-aegis-guard keys on (cleared per prompt by user-prompt-gate.sh).
 # 2. Near-miss warning:
 # When the aegis_compile_context response contains glob_no_match near_miss_edges,
-# cross-match those patterns against target_files using bash extglob + globstar.
+# cross-match those patterns against target_files using bash `[[ ]]` glob
+# matching (extglob).
 # Inject an additionalContext warning only for patterns that bash matches but
 # Aegis reports as glob_no_match (suspicious — likely an Aegis glob bug).
 #
 # Decision logic:
-#   A) Pattern matches a target_file via bash extglob + globstar
+#   A) Pattern matches a target_file via bash `[[ ]]` glob matching
 #      → Divergence between Aegis and bash glob implementations = suspicious (confirmed bug)
 #   B) bash also does not match → routine no-match → skip
 #   C) reason is command_mismatch → always skip
@@ -20,7 +21,20 @@
 #   - 4+ entries → first 3 + "and N more" abbreviation
 
 set -euo pipefail
-shopt -s extglob globstar nullglob
+# macOS ships bash 3.2, which has neither `mapfile` nor `globstar`. Under
+# `set -e` an unknown shopt name aborts the script — and this line sits above
+# the stamp below, so the gate artifact was never created on such a machine and
+# every non-exempt `Agent` dispatch was blocked (the four pinned review agents
+# are exempt in pre-agent-aegis-guard.sh, which is why the review pipeline kept
+# working and this stayed invisible from 4ff5e81 until 2026-07-29). The options
+# are therefore requested, not required.
+shopt -s extglob nullglob 2>/dev/null || true
+# `globstar` was in that list and is deliberately gone. It governs pathname
+# expansion, while the cross-check below matches with `[[ str == pattern ]]`,
+# where a `*` already spans `/`. Verified on bash 3.2.57, where the option does
+# not exist at all: `[[ a/b/c/index.ts == a/**/index.ts ]]` matches, and so does
+# the same test with a single `*`. Setting it would change nothing here, and the
+# comment claiming otherwise sent a reviewer looking for a bug that was not one.
 
 INPUT=$(cat)
 
@@ -47,8 +61,15 @@ fi
 ROOT="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
 touch "$ROOT/.claude/.aegis-stamp"
 
-# Extract target_files into an array
-mapfile -t TARGET_FILES < <(printf '%s' "$INPUT" | jq -r '.tool_input.target_files // [] | .[]' 2>/dev/null || true)
+# Extract target_files into an array. Written as a read loop rather than
+# `mapfile`, which bash 3.2 does not have — and this runs after the stamp, so a
+# failure here would surface as a hook error on an otherwise successful gate.
+# No blank-line filter: `mapfile -t` keeps an empty line as an empty element, so
+# skipping them would make the count differ from the builtin this replaces.
+TARGET_FILES=()
+while IFS= read -r LINE; do
+  TARGET_FILES+=("$LINE")
+done < <(printf '%s' "$INPUT" | jq -r '.tool_input.target_files // [] | .[]' 2>/dev/null || true)
 
 # Extract near_miss_edges that are glob_no_match and not command_mismatch
 NEAR_MISS_JSON=$(printf '%s' "$INPUT" | jq -c '
@@ -78,7 +99,7 @@ while IFS= read -r EDGE; do
     continue
   fi
 
-  # Test each target_file against the pattern using bash extglob + globstar
+  # Test each target_file against the pattern using bash `[[ ]]` glob matching
   MATCHED=false
   for TARGET in "${TARGET_FILES[@]}"; do
     # shellcheck disable=SC2053
@@ -110,7 +131,7 @@ else
   ...and ${REMAINING} more (see debug_info.near_miss_edges for the full list)"
 fi
 
-CONTEXT="[Aegis near_miss_edges warning] The following edge_hints match target_files in bash (extglob + globstar) but are reported as glob_no_match by Aegis. This is likely an Aegis glob implementation bug. Report via \`aegis_observe({event_type: \"compile_miss\", ...})\` or fix the glob pattern in the admin surface (aegis_import_doc / edge edit).
+CONTEXT="[Aegis near_miss_edges warning] The following edge_hints match target_files under bash \`[[ ]]\` glob matching but are reported as glob_no_match by Aegis. This is likely an Aegis glob implementation bug. Report via \`aegis_observe({event_type: \"compile_miss\", ...})\` or fix the glob pattern in the admin surface (aegis_import_doc / edge edit).
 
 Affected edge_hints:
 ${LIST}${SUFFIX}"

--- a/scripts/test-aegis-gate.py
+++ b/scripts/test-aegis-gate.py
@@ -68,32 +68,62 @@ STAMP = WORK / ".claude/.aegis-stamp"
 UNAVAILABLE = WORK / ".claude/.aegis-unavailable"
 
 
-def executable_part(line):
-    """`line` with any trailing comment removed, approximating shell word rules.
+def shopt_is_guarded(line):
+    """True when every `shopt` on `line` is guarded the way bash 3.2 requires.
 
-    Hand-rolled cuts kept missing a variant: first a literal space before `#`,
-    then a tab, then `;#` with no whitespace at all — each one let a comment
-    supply the `|| true` the check looks for, which fails open. `shlex`
-    generalizes across separators and understands quoting, so a `#` inside a
-    quoted argument is no longer mistaken for a comment.
+    `set -e` aborts on a failing command unless that command is a non-final part
+    of an `&&` / `||` list, so the guard has to sit at the end of the same
+    statement as the `shopt` — not merely somewhere on the line. The line is
+    tokenized (`shlex` with `punctuation_chars`, so `||` and `;` are their own
+    tokens), split into statements on top-level `;` and `&`, and every statement
+    containing `shopt` must end in the token pair `||` `true`.
 
-    It is stricter than bash, deliberately left so: bash opens a comment only on
-    a `#` that begins a word, while `shlex` opens one on any unquoted `#`,
-    including mid-word — `globstar#opt` is a single invalid option name to bash,
-    not `globstar` followed by a comment. That can only strip more than bash
-    would, so the check may fail on a line bash accepts and can never miss a
-    guard that is not there.
+    Each earlier version of this check was fail-open in a way hand-testing
+    missed, which is why the cases below the definition are asserted on every
+    run rather than checked by hand:
+
+    - a substring search for `|| true` accepted `shopt -s globstar "|| true"`,
+      where bash sees an argument and exits;
+    - stripping comments by cutting at `" #"` missed a tab and then `;#`;
+    - looking for the token pair anywhere accepted
+      `shopt -s globstar; false || true` and `true || true && shopt -s globstar`,
+      both of which abort, and missed the second `shopt` in
+      `shopt -s globstar || true; shopt -s bogusopt`.
+
+    A backgrounded statement (`shopt -s x &`) is exempt: its exit status is never
+    checked, so it cannot abort the script.
+
+    Two imprecisions remain, and both can only report a guarded line as
+    unguarded — never the reverse:
+
+    - `shlex` opens a comment on any unquoted `#`, while bash opens one only on a
+      `#` that begins a word. `globstar#opt` is a single invalid option name to
+      bash, not `globstar` plus a comment.
+    - A line `shlex` cannot tokenize (an unbalanced quote) yields no tokens and
+      is reported unguarded rather than guessed at.
     """
     lex = shlex.shlex(line, posix=False, punctuation_chars=True)
     lex.whitespace_split = True
     try:
-        return " ".join(lex)
+        tokens = list(lex)
     except ValueError:
-        # Unbalanced quote: shlex cannot tokenize it. Returning the raw line
-        # would keep whatever `|| true` sits after the broken quote and mark the
-        # line guarded on that alone — fail-open. Return nothing instead, so an
-        # unparseable line is always flagged.
-        return ""
+        return False
+
+    statements = []
+    current = []
+    for token in tokens:
+        if token in (";", "&"):
+            statements.append((current, token == "&"))
+            current = []
+        else:
+            current.append(token)
+    statements.append((current, False))
+
+    return all(
+        backgrounded or stmt[-2:] == ["||", "true"]
+        for stmt, backgrounded in statements
+        if "shopt" in stmt
+    )
 
 
 def check(label, actual, expected):
@@ -140,6 +170,30 @@ def clear():
     UNAVAILABLE.unlink(missing_ok=True)
 
 
+# `shopt_is_guarded` is asserted on every run, because five successive versions of
+# it were fail-open in a way hand-testing missed. Each expectation below was taken
+# from what real bash 3.2.57 does with that line under `set -e`, not from reading
+# the implementation.
+print("shopt_is_guarded agrees with bash 3.2 on the known shapes")
+for _line, _guarded in (
+    ("shopt -s extglob nullglob 2>/dev/null || true", True),
+    ("shopt -s globstar || true", True),
+    ("shopt -s globstar && shopt -s nullglob || true", True),
+    ("shopt -s globstar &", True),
+    ("shopt -s globstar", False),
+    ('shopt -s globstar "|| true"', False),
+    ("shopt -s globstar '|| true'", False),
+    ("shopt -s globstar # || true", False),
+    ("shopt -s globstar\t# || true", False),
+    ("shopt -s globstar;# || true", False),
+    ("shopt -s globstar; false || true", False),
+    ("shopt -s globstar; shopt -s nullglob || true", False),
+    ("shopt -s globstar || true; shopt -s bogusopt", False),
+    ("true || true && shopt -s globstar", False),
+    ('shopt -s "globstar || true', False),
+):
+    check(f"guarded({_line!r})", shopt_is_guarded(_line), _guarded)
+
 print(f"shell under test: {subprocess.run(['bash', '--version'], capture_output=True, text=True).stdout.splitlines()[0]}")
 print()
 
@@ -155,12 +209,13 @@ print("no gate hook may use a construct that aborts on bash 3.2")
 # Both are read with whole-line comments stripped — naming a construct in a comment
 # to explain why it is avoided is exactly what these hooks should do, and the first
 # version of this check failed on its own explanatory comment. The guard test then
-# lexes each `shopt` line (see `executable_part`); the builtin test is a substring
-# match. Neither is a shell parser: they catch the construct written plainly, which
-# is how it gets reintroduced by accident, and they do not survive indirection
-# (`command shopt …`, `eval "shopt …"`, a builtin name assembled from a variable).
-# That is the intended strength — this guards against a careless edit, not against
-# someone working around it.
+# lexes each `shopt` line and requires the `||` guard on that statement itself (see
+# `shopt_is_guarded`); the builtin test is a plain substring match. Neither is a
+# shell parser: they catch the construct written plainly, which is how it gets
+# reintroduced by accident, and they do not survive indirection (`command shopt …`,
+# `eval "shopt …"`, a builtin name assembled from a variable). That is the intended
+# strength — this guards against a careless edit, not against someone working
+# around it.
 #
 # One gap is known and left as a gap, because it fails closed — it can fail the
 # test on a harmless line, never pass an aborting one. The builtin check matches
@@ -173,12 +228,10 @@ for hook_name in HOOKS:
         for line in (REPO / ".claude/hooks" / hook_name).read_text().splitlines()
         if not line.lstrip().startswith("#")
     )
-    # The guard has to be executable, so a comment must not be able to supply it:
-    # `shopt -s globstar # || true` aborts on 3.2 exactly like the unguarded form.
     unguarded = [
         line.strip()
         for line in code.splitlines()
-        if re.match(r"\s*shopt\s", line) and "|| true" not in executable_part(line)
+        if re.match(r"\s*shopt\s", line) and not shopt_is_guarded(line)
     ]
     check(f"no unguarded shopt: {hook_name}", unguarded, [])
     check(

--- a/scripts/test-aegis-gate.py
+++ b/scripts/test-aegis-gate.py
@@ -26,6 +26,7 @@ The static invariant is the part that generalizes: nothing in a gate hook may us
 a construct that aborts on the oldest shell the project runs on.
 """
 
+import atexit
 import json
 import os
 import pathlib
@@ -36,7 +37,17 @@ import sys
 import tempfile
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
-WORK = pathlib.Path(tempfile.gettempdir()) / "aegis-gate-check"
+# A unique directory per run, removed at exit. A fixed shared path under the
+# system temp dir would let two concurrent runs clobber each other, and the
+# `rmtree` that kept it clean would delete whatever else occupied that name.
+# `atexit` runs on a normal exit and on an uncaught exception, but not on SIGKILL,
+# an OOM kill, or a segfault — a hard-killed run leaves its directory behind, and
+# no later run will match the random name to clean it. Sweeping the prefix at
+# startup would restore that self-healing and delete the live directory of a
+# concurrent run, which is the bug this replaced, so it is deliberately not done.
+_WORK_TMP = tempfile.TemporaryDirectory(prefix="aegis-gate-check-")
+atexit.register(_WORK_TMP.cleanup)
+WORK = pathlib.Path(_WORK_TMP.name)
 
 HOOKS = (
     "post-aegis-compile.sh",
@@ -46,7 +57,6 @@ HOOKS = (
 
 COMPILE_TOOL = "mcp__aegis__aegis_compile_context"
 
-shutil.rmtree(WORK, ignore_errors=True)
 (WORK / ".claude/hooks").mkdir(parents=True)
 for hook_name in HOOKS:
     shutil.copy(REPO / ".claude/hooks" / hook_name, WORK / ".claude/hooks" / hook_name)

--- a/scripts/test-aegis-gate.py
+++ b/scripts/test-aegis-gate.py
@@ -31,6 +31,7 @@ import json
 import os
 import pathlib
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -65,6 +66,34 @@ os.chdir(WORK)
 failures = []
 STAMP = WORK / ".claude/.aegis-stamp"
 UNAVAILABLE = WORK / ".claude/.aegis-unavailable"
+
+
+def executable_part(line):
+    """`line` with any trailing comment removed, approximating shell word rules.
+
+    Hand-rolled cuts kept missing a variant: first a literal space before `#`,
+    then a tab, then `;#` with no whitespace at all — each one let a comment
+    supply the `|| true` the check looks for, which fails open. `shlex`
+    generalizes across separators and understands quoting, so a `#` inside a
+    quoted argument is no longer mistaken for a comment.
+
+    It is stricter than bash, deliberately left so: bash opens a comment only on
+    a `#` that begins a word, while `shlex` opens one on any unquoted `#`,
+    including mid-word — `globstar#opt` is a single invalid option name to bash,
+    not `globstar` followed by a comment. That can only strip more than bash
+    would, so the check may fail on a line bash accepts and can never miss a
+    guard that is not there.
+    """
+    lex = shlex.shlex(line, posix=False, punctuation_chars=True)
+    lex.whitespace_split = True
+    try:
+        return " ".join(lex)
+    except ValueError:
+        # Unbalanced quote: shlex cannot tokenize it. Returning the raw line
+        # would keep whatever `|| true` sits after the broken quote and mark the
+        # line guarded on that alone — fail-open. Return nothing instead, so an
+        # unparseable line is always flagged.
+        return ""
 
 
 def check(label, actual, expected):
@@ -123,38 +152,33 @@ print("no gate hook may use a construct that aborts on bash 3.2")
 # an abort. Guarding each one keeps a newer option optional rather than required.
 # `mapfile` / `readarray` / `declare -A` do not exist in 3.2 at all.
 #
-# Both checks are textual heuristics, not a shell parser, and are read with
-# whole-line comments stripped — naming a construct in a comment to explain why it
-# is avoided is exactly what these hooks should do, and the first version of this
-# check failed on its own explanatory comment. They catch the construct written
-# plainly, which is how it gets reintroduced by accident; they do not survive
-# indirection (`command shopt …`, `eval "shopt …"`, a builtin name assembled from a
-# variable). That is the intended strength — this guards against a careless edit,
-# not against someone working around it.
+# Both are read with whole-line comments stripped — naming a construct in a comment
+# to explain why it is avoided is exactly what these hooks should do, and the first
+# version of this check failed on its own explanatory comment. The guard test then
+# lexes each `shopt` line (see `executable_part`); the builtin test is a substring
+# match. Neither is a shell parser: they catch the construct written plainly, which
+# is how it gets reintroduced by accident, and they do not survive indirection
+# (`command shopt …`, `eval "shopt …"`, a builtin name assembled from a variable).
+# That is the intended strength — this guards against a careless edit, not against
+# someone working around it.
 #
-# Two further gaps are known and left as gaps, because both fail closed — they can
-# fail the test on a harmless line, never pass an aborting one. The builtin check
-# matches against the whole per-hook text rather than line by line, so a trailing
-# comment naming `mapfile` / `readarray` / `declare -A` would fail it even though no
-# such builtin is called. And the trailing-comment strip below is textual, not
-# quote-aware, so a `#` inside a quoted `shopt` argument would be cut — not a
-# construct that occurs, since option names are bare identifiers.
+# One gap is known and left as a gap, because it fails closed — it can fail the
+# test on a harmless line, never pass an aborting one. The builtin check matches
+# against the whole per-hook text rather than line by line, so a trailing comment
+# naming `mapfile` / `readarray` / `declare -A` would fail it even though no such
+# builtin is called.
 for hook_name in HOOKS:
     code = "\n".join(
         line
         for line in (REPO / ".claude/hooks" / hook_name).read_text().splitlines()
         if not line.lstrip().startswith("#")
     )
-    # The guard has to be executable, so an inline comment must not be able to
-    # supply it: `shopt -s globstar # || true` aborts on 3.2 exactly like the
-    # unguarded form. Whole-line comments are already gone above; this drops a
-    # trailing one before the test. Split on `\s#` rather than a literal " #" —
-    # bash opens a comment after any whitespace, so a tab before the `#` is the
-    # same construct and a literal-space cut would miss it.
+    # The guard has to be executable, so a comment must not be able to supply it:
+    # `shopt -s globstar # || true` aborts on 3.2 exactly like the unguarded form.
     unguarded = [
         line.strip()
         for line in code.splitlines()
-        if re.match(r"\s*shopt\s", line) and "|| true" not in re.split(r"\s#", line, maxsplit=1)[0]
+        if re.match(r"\s*shopt\s", line) and "|| true" not in executable_part(line)
     ]
     check(f"no unguarded shopt: {hook_name}", unguarded, [])
     check(

--- a/scripts/test-aegis-gate.py
+++ b/scripts/test-aegis-gate.py
@@ -104,35 +104,38 @@ def clear():
 print(f"shell under test: {subprocess.run(['bash', '--version'], capture_output=True, text=True).stdout.splitlines()[0]}")
 print()
 
-print("a gate hook must not use a construct that aborts on bash 3.2")
-# Scanned with whole-line comments removed. Naming a construct in a comment to
-# explain why it is avoided is exactly what these hooks should do, and the first
-# version of this check failed on its own explanatory comment.
-code = "\n".join(
-    line
-    for line in (REPO / ".claude/hooks/post-aegis-compile.sh").read_text().splitlines()
-    if not line.lstrip().startswith("#")
-)
-# `shopt -s <name>` exits non-zero on an unknown option, which `set -e` turns
-# into an abort. Guarding each one keeps a newer option optional rather than
-# required.
+print("no gate hook may use a construct that aborts on bash 3.2")
+# Every hook this file drives, not just the one that broke: the invariant is about
+# the gate, and a bash-4-only construct reintroduced into any of them fails the
+# same way.
 #
-# Both checks below are textual heuristics, not a shell parser. They catch the
-# construct written plainly, which is how it gets reintroduced by accident; they
-# do not survive indirection (`command shopt …`, `eval "shopt …"`, a builtin name
-# assembled from a variable). That is the intended strength — this guards against
-# a careless edit, not against someone working around it.
-unguarded = [
-    line.strip() for line in code.splitlines() if re.match(r"\s*shopt\s", line) and "|| true" not in line
-]
-check("no unguarded shopt", unguarded, [])
-# Builtins bash 3.2 does not have. `declare -A` is included for the same reason
-# even though the hook does not currently use one.
-check(
-    "no bash-4-only builtins",
-    sorted({w for w in ("mapfile", "readarray", "declare -A") if w in code}),
-    [],
-)
+# `shopt -s <name>` exits non-zero on an unknown option, which `set -e` turns into
+# an abort. Guarding each one keeps a newer option optional rather than required.
+# `mapfile` / `readarray` / `declare -A` do not exist in 3.2 at all.
+#
+# Both checks are textual heuristics, not a shell parser, and are read with
+# whole-line comments stripped — naming a construct in a comment to explain why it
+# is avoided is exactly what these hooks should do, and the first version of this
+# check failed on its own explanatory comment. They catch the construct written
+# plainly, which is how it gets reintroduced by accident; they do not survive
+# indirection (`command shopt …`, `eval "shopt …"`, a builtin name assembled from a
+# variable). That is the intended strength — this guards against a careless edit,
+# not against someone working around it.
+for hook_name in HOOKS:
+    code = "\n".join(
+        line
+        for line in (REPO / ".claude/hooks" / hook_name).read_text().splitlines()
+        if not line.lstrip().startswith("#")
+    )
+    unguarded = [
+        line.strip() for line in code.splitlines() if re.match(r"\s*shopt\s", line) and "|| true" not in line
+    ]
+    check(f"no unguarded shopt: {hook_name}", unguarded, [])
+    check(
+        f"no bash-4-only builtins: {hook_name}",
+        sorted({w for w in ("mapfile", "readarray", "declare -A") if w in code}),
+        [],
+    )
 
 print("a successful consultation stamps the gate")
 clear()

--- a/scripts/test-aegis-gate.py
+++ b/scripts/test-aegis-gate.py
@@ -131,14 +131,30 @@ print("no gate hook may use a construct that aborts on bash 3.2")
 # indirection (`command shopt …`, `eval "shopt …"`, a builtin name assembled from a
 # variable). That is the intended strength — this guards against a careless edit,
 # not against someone working around it.
+#
+# Two further gaps are known and left as gaps, because both fail closed — they can
+# fail the test on a harmless line, never pass an aborting one. The builtin check
+# matches against the whole per-hook text rather than line by line, so a trailing
+# comment naming `mapfile` / `readarray` / `declare -A` would fail it even though no
+# such builtin is called. And the trailing-comment strip below is textual, not
+# quote-aware, so a `#` inside a quoted `shopt` argument would be cut — not a
+# construct that occurs, since option names are bare identifiers.
 for hook_name in HOOKS:
     code = "\n".join(
         line
         for line in (REPO / ".claude/hooks" / hook_name).read_text().splitlines()
         if not line.lstrip().startswith("#")
     )
+    # The guard has to be executable, so an inline comment must not be able to
+    # supply it: `shopt -s globstar # || true` aborts on 3.2 exactly like the
+    # unguarded form. Whole-line comments are already gone above; this drops a
+    # trailing one before the test. Split on `\s#` rather than a literal " #" —
+    # bash opens a comment after any whitespace, so a tab before the `#` is the
+    # same construct and a literal-space cut would miss it.
     unguarded = [
-        line.strip() for line in code.splitlines() if re.match(r"\s*shopt\s", line) and "|| true" not in line
+        line.strip()
+        for line in code.splitlines()
+        if re.match(r"\s*shopt\s", line) and "|| true" not in re.split(r"\s#", line, maxsplit=1)[0]
     ]
     check(f"no unguarded shopt: {hook_name}", unguarded, [])
     check(

--- a/scripts/test-aegis-gate.py
+++ b/scripts/test-aegis-gate.py
@@ -1,0 +1,234 @@
+"""Exercise the Aegis dispatch gate (ADR-0013) against the real hook scripts.
+
+    python3 scripts/test-aegis-gate.py
+
+Builds a throwaway project directory under the system temp directory, copies the
+hooks into it, and drives the sequences the gate has to get right: a successful
+consultation stamps, a failed one does not, a user prompt clears the stamp, and
+`Agent` dispatch is admitted or blocked accordingly. Nothing touches this
+repository.
+
+Run it after changing post-aegis-compile.sh, user-prompt-gate.sh, or
+pre-agent-aegis-guard.sh. Exits non-zero on a mismatch, so it works as a
+pre-flight check rather than a report to read.
+
+Why this file exists. Between 4ff5e81 and 2026-07-29 the stamp was never created
+on macOS: `shopt -s extglob globstar nullglob` sat above the `touch`, bash 3.2
+has no `globstar`, and `set -e` aborted the hook there. Every non-exempt dispatch
+was blocked for weeks, and it stayed invisible because the four pinned review
+agents are exempt in pre-agent-aegis-guard.sh — so the review pipeline, the part
+anyone would notice, kept working. That is ADR-0013's own audit finding 3 (gates
+degrading silently per machine) happening again to the gate the ADR introduced.
+
+The dynamic checks below only catch it on a shell that lacks the construct, so
+they would pass on a bash-4 container while the developer's Mac stayed broken.
+The static invariant is the part that generalizes: nothing in a gate hook may use
+a construct that aborts on the oldest shell the project runs on.
+"""
+
+import json
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+WORK = pathlib.Path(tempfile.gettempdir()) / "aegis-gate-check"
+
+HOOKS = (
+    "post-aegis-compile.sh",
+    "user-prompt-gate.sh",
+    "pre-agent-aegis-guard.sh",
+)
+
+COMPILE_TOOL = "mcp__aegis__aegis_compile_context"
+
+shutil.rmtree(WORK, ignore_errors=True)
+(WORK / ".claude/hooks").mkdir(parents=True)
+for hook_name in HOOKS:
+    shutil.copy(REPO / ".claude/hooks" / hook_name, WORK / ".claude/hooks" / hook_name)
+os.chdir(WORK)
+
+failures = []
+STAMP = WORK / ".claude/.aegis-stamp"
+UNAVAILABLE = WORK / ".claude/.aegis-unavailable"
+
+
+def check(label, actual, expected):
+    ok = actual == expected
+    if not ok:
+        failures.append(label)
+    print(f"  {'ok  ' if ok else 'FAIL'} {label}: {actual} (expected {expected})")
+
+
+def hook(name, payload):
+    return subprocess.run(
+        ["bash", f".claude/hooks/{name}"],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env={**os.environ, "CLAUDE_PROJECT_DIR": str(WORK)},
+    )
+
+
+def compile_hook(tool_response, target_files=(".claude/rules/authoring.md",)):
+    """Drive PostToolUse for a compile_context call. `tool_response=None` omits it."""
+    payload = {
+        "tool_name": COMPILE_TOOL,
+        "tool_input": {"target_files": list(target_files)},
+    }
+    if tool_response is not None:
+        payload["tool_response"] = tool_response
+    return hook("post-aegis-compile.sh", payload)
+
+
+def dispatch(subagent_type="general-purpose", transcript=None):
+    payload = {"tool_name": "Agent", "tool_input": {"subagent_type": subagent_type}}
+    if transcript is not None:
+        payload["transcript_path"] = str(transcript)
+    return "BLOCK" if '"block"' in hook("pre-agent-aegis-guard.sh", payload).stdout else "PASS"
+
+
+def stamped():
+    return STAMP.exists()
+
+
+def clear():
+    STAMP.unlink(missing_ok=True)
+    UNAVAILABLE.unlink(missing_ok=True)
+
+
+print(f"shell under test: {subprocess.run(['bash', '--version'], capture_output=True, text=True).stdout.splitlines()[0]}")
+print()
+
+print("a gate hook must not use a construct that aborts on bash 3.2")
+# Scanned with whole-line comments removed. Naming a construct in a comment to
+# explain why it is avoided is exactly what these hooks should do, and the first
+# version of this check failed on its own explanatory comment.
+code = "\n".join(
+    line
+    for line in (REPO / ".claude/hooks/post-aegis-compile.sh").read_text().splitlines()
+    if not line.lstrip().startswith("#")
+)
+# `shopt -s <name>` exits non-zero on an unknown option, which `set -e` turns
+# into an abort. Guarding each one keeps a newer option optional rather than
+# required.
+#
+# Both checks below are textual heuristics, not a shell parser. They catch the
+# construct written plainly, which is how it gets reintroduced by accident; they
+# do not survive indirection (`command shopt …`, `eval "shopt …"`, a builtin name
+# assembled from a variable). That is the intended strength — this guards against
+# a careless edit, not against someone working around it.
+unguarded = [
+    line.strip() for line in code.splitlines() if re.match(r"\s*shopt\s", line) and "|| true" not in line
+]
+check("no unguarded shopt", unguarded, [])
+# Builtins bash 3.2 does not have. `declare -A` is included for the same reason
+# even though the hook does not currently use one.
+check(
+    "no bash-4-only builtins",
+    sorted({w for w in ("mapfile", "readarray", "declare -A") if w in code}),
+    [],
+)
+
+print("a successful consultation stamps the gate")
+clear()
+run = compile_hook({"isError": False})
+check("object-shaped response: exit", run.returncode, 0)
+check("object-shaped response: stamp", stamped(), True)
+clear()
+compile_hook([{"type": "text", "text": "{}"}])
+check("array-shaped response (MCP delivery)", stamped(), True)
+clear()
+compile_hook({"isError": False}, target_files=())
+check("empty target_files still stamps", stamped(), True)
+clear()
+# An empty-string entry is what separates the read loop from the `mapfile -t` it
+# replaces: the builtin keeps it as an element, and a blank-line filter would
+# not. It also puts an empty element into the array the near-miss loop expands
+# under `set -u`, which is where bash 3.2 would object if it were going to.
+empty_entry = compile_hook({"isError": False}, target_files=("",))
+check("empty-string target_file: exit", empty_entry.returncode, 0)
+check("empty-string target_file: stderr", empty_entry.stderr.strip(), "")
+check("empty-string target_file: stamp", stamped(), True)
+
+print("a consultation that did not succeed must not stamp — fail closed")
+for label, response in (
+    ("isError true", {"isError": True}),
+    ("is_error true", {"is_error": True}),
+    ("no tool_response", None),
+    ("bare string response", "boom"),
+):
+    clear()
+    compile_hook(response)
+    check(label, stamped(), False)
+
+print("the stamp is per-prompt: a user prompt clears it")
+clear()
+compile_hook({"isError": False})
+hook("user-prompt-gate.sh", {"prompt": "next task"})
+check("cleared on UserPromptSubmit", stamped(), False)
+
+print("dispatch is admitted only with a stamp")
+clear()
+check("no stamp", dispatch(), "BLOCK")
+compile_hook({"isError": False})
+check("with stamp", dispatch(), "PASS")
+
+print("exemptions and the auditable degrade")
+clear()
+for exempt in ("Explore", "code-reviewer", "review-verifier", "spec-verifier", "spec-checker"):
+    check(f"{exempt} without a stamp", dispatch(exempt), "PASS")
+UNAVAILABLE.write_text("aegis MCP tools absent in this session\n")
+check("general-purpose under .aegis-unavailable", dispatch(), "PASS")
+clear()
+
+print("a subagent's own dispatch is not the parent's gate")
+transcript = WORK / "sidechain.jsonl"
+transcript.write_text('{"isSidechain":true}\n')
+check("sidechain dispatch", dispatch(transcript=transcript), "PASS")
+
+print("the near-miss warning fires only on an Aegis/shell glob divergence")
+clear()
+suspicious = compile_hook(
+    {
+        "isError": False,
+        "debug_info": {
+            "near_miss_edges": [
+                {
+                    "reason": "glob_no_match",
+                    "pattern": "src/gateways/*/index.ts",
+                    "target_doc_id": "adr-0016",
+                },
+                {"reason": "command_mismatch", "pattern": "x", "target_doc_id": "adr-0001"},
+            ]
+        },
+    },
+    target_files=("src/gateways/user/index.ts",),
+)
+check("shell matches what Aegis missed: warns", "near_miss_edges warning" in suspicious.stdout, True)
+check("command_mismatch is not reported", "adr-0001" in suspicious.stdout, False)
+clear()
+routine = compile_hook(
+    {
+        "isError": False,
+        "debug_info": {
+            "near_miss_edges": [
+                {"reason": "glob_no_match", "pattern": "docs/adr/*.md", "target_doc_id": "adr-0016"}
+            ]
+        },
+    },
+    target_files=("src/routes/x.tsx",),
+)
+check("shell agrees it does not match: silent", routine.stdout.strip(), "")
+
+print()
+if failures:
+    print(f"FAILED: {len(failures)}")
+    for f in failures:
+        print(f"  - {f}")
+    sys.exit(1)
+print("all checks passed")

--- a/scripts/test-bash-guard.py
+++ b/scripts/test-bash-guard.py
@@ -31,8 +31,12 @@ HOOK = REPO / ".claude/hooks/pre-bash-guard.sh"
 # A unique directory per run, removed at exit. A fixed shared path under the
 # system temp dir would let two concurrent runs clobber each other's fixture, and
 # the `rmtree` that kept it clean would delete whatever else happened to occupy
-# that name. `TemporaryDirectory` gives isolation and cleanup without leaving
-# directories behind.
+# that name.
+# `atexit` runs on a normal exit and on an uncaught exception, but not on SIGKILL,
+# an OOM kill, or a segfault — a hard-killed run leaves its directory behind, and
+# no later run will match the random name to clean it. Sweeping the prefix at
+# startup would restore that self-healing and delete the live directory of a
+# concurrent run, which is the bug this replaced, so it is deliberately not done.
 _STAMPED_TMP = tempfile.TemporaryDirectory(prefix="bash-guard-stamped-")
 atexit.register(_STAMPED_TMP.cleanup)
 STAMPED = pathlib.Path(_STAMPED_TMP.name)

--- a/scripts/test-bash-guard.py
+++ b/scripts/test-bash-guard.py
@@ -15,11 +15,28 @@ Run it after touching pre-bash-guard.sh. Exits non-zero on a mismatch.
 import json
 import os
 import pathlib
+import shutil
 import subprocess
 import sys
+import tempfile
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
 HOOK = REPO / ".claude/hooks/pre-bash-guard.sh"
+
+# A project directory that already holds a review stamp. The guard runs its three
+# decisions in order, so a case built to probe the env or `find` decision with a
+# commit-shaped command still reaches the commit gate — and would then be judged
+# by whether this session happens to have earned a stamp. Pointing such a case at
+# this directory keeps it testing the decision it names.
+# Fixed path, cleared on entry, matching scripts/test-review-gate.py — a fresh
+# mkdtemp per run would accumulate directories nothing deletes.
+STAMPED = pathlib.Path(tempfile.gettempdir()) / "bash-guard-stamped"
+shutil.rmtree(STAMPED, ignore_errors=True)
+# exist_ok because the path is shared: a concurrent or crashed earlier run can
+# leave the directory behind between the rmtree above and this line, and a
+# pre-flight script that dies on that is worse than one that reuses it.
+(STAMPED / ".claude").mkdir(parents=True, exist_ok=True)
+(STAMPED / ".claude/.review-stamp").touch()
 
 # Split so this file's own text is not itself a commit-shaped command.
 LAND = "git " + "com" + "mit"
@@ -27,7 +44,7 @@ LAND = "git " + "com" + "mit"
 failures = []
 
 
-def decide(command):
+def decide(command, project_dir=REPO):
     """Return the hook's decision for a Bash command: 'allow', 'block', or 'ask'."""
     payload = {"tool_name": "Bash", "tool_input": {"command": command}}
     out = subprocess.run(
@@ -35,7 +52,7 @@ def decide(command):
         input=json.dumps(payload),
         capture_output=True,
         text=True,
-        env={**os.environ, "CLAUDE_PROJECT_DIR": str(REPO)},
+        env={**os.environ, "CLAUDE_PROJECT_DIR": str(project_dir)},
     ).stdout.strip()
     if not out:
         return "allow"  # the hook stayed out of the way
@@ -46,8 +63,8 @@ def decide(command):
     return decision or "allow"
 
 
-def check(command, expected, why):
-    actual = decide(command)
+def check(command, expected, why, project_dir=REPO):
+    actual = decide(command, project_dir)
     ok = actual == expected
     if not ok:
         failures.append(f"{why}: {command}")
@@ -105,6 +122,7 @@ check(
     "git add x && " + LAND + " -F - <<'MSG'\nrefuse find . -type f | xargs cat and -delete\nMSG",
     "allow",
     "a commit message describing the dangerous shapes",
+    project_dir=STAMPED,
 )
 check("cat <<'EOF'\nfind / -delete\nEOF", "allow", "heredoc body naming a dangerous find")
 

--- a/scripts/test-bash-guard.py
+++ b/scripts/test-bash-guard.py
@@ -12,10 +12,10 @@ ever executed.
 Run it after touching pre-bash-guard.sh. Exits non-zero on a mismatch.
 """
 
+import atexit
 import json
 import os
 import pathlib
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -28,14 +28,15 @@ HOOK = REPO / ".claude/hooks/pre-bash-guard.sh"
 # commit-shaped command still reaches the commit gate — and would then be judged
 # by whether this session happens to have earned a stamp. Pointing such a case at
 # this directory keeps it testing the decision it names.
-# Fixed path, cleared on entry, matching scripts/test-review-gate.py — a fresh
-# mkdtemp per run would accumulate directories nothing deletes.
-STAMPED = pathlib.Path(tempfile.gettempdir()) / "bash-guard-stamped"
-shutil.rmtree(STAMPED, ignore_errors=True)
-# exist_ok because the path is shared: a concurrent or crashed earlier run can
-# leave the directory behind between the rmtree above and this line, and a
-# pre-flight script that dies on that is worse than one that reuses it.
-(STAMPED / ".claude").mkdir(parents=True, exist_ok=True)
+# A unique directory per run, removed at exit. A fixed shared path under the
+# system temp dir would let two concurrent runs clobber each other's fixture, and
+# the `rmtree` that kept it clean would delete whatever else happened to occupy
+# that name. `TemporaryDirectory` gives isolation and cleanup without leaving
+# directories behind.
+_STAMPED_TMP = tempfile.TemporaryDirectory(prefix="bash-guard-stamped-")
+atexit.register(_STAMPED_TMP.cleanup)
+STAMPED = pathlib.Path(_STAMPED_TMP.name)
+(STAMPED / ".claude").mkdir(parents=True)
 (STAMPED / ".claude/.review-stamp").touch()
 
 # Split so this file's own text is not itself a commit-shaped command.

--- a/scripts/test-review-gate.py
+++ b/scripts/test-review-gate.py
@@ -12,6 +12,7 @@ post-bash-stamp-consume.sh. Exits non-zero on a mismatch, so it works as a
 pre-flight check rather than a report to read.
 """
 
+import atexit
 import json
 import os
 import pathlib
@@ -21,7 +22,17 @@ import sys
 import tempfile
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
-WORK = pathlib.Path(tempfile.gettempdir()) / "review-gate-check"
+# A unique directory per run, removed at exit. A fixed shared path under the
+# system temp dir would let two concurrent runs clobber each other, and the
+# `rmtree` that kept it clean would delete whatever else occupied that name.
+# `atexit` runs on a normal exit and on an uncaught exception, but not on SIGKILL,
+# an OOM kill, or a segfault — a hard-killed run leaves its directory behind, and
+# no later run will match the random name to clean it. Sweeping the prefix at
+# startup would restore that self-healing and delete the live directory of a
+# concurrent run, which is the bug this replaced, so it is deliberately not done.
+_WORK_TMP = tempfile.TemporaryDirectory(prefix="review-gate-check-")
+atexit.register(_WORK_TMP.cleanup)
+WORK = pathlib.Path(_WORK_TMP.name)
 
 # Split so this file's own text cannot look like a commit to the gate that
 # matches `git <anything> commit` — see post-bash-stamp-consume.sh.
@@ -37,7 +48,6 @@ HOOKS = (
     "post-edit-check.sh",
 )
 
-shutil.rmtree(WORK, ignore_errors=True)
 (WORK / ".claude/hooks").mkdir(parents=True)
 for hook_name in HOOKS:
     shutil.copy(REPO / ".claude/hooks" / hook_name, WORK / ".claude/hooks" / hook_name)


### PR DESCRIPTION
## Summary

`.claude/hooks/post-aegis-compile.sh` creates `.claude/.aegis-stamp`, the artifact `pre-agent-aegis-guard.sh` requires before any `Agent` dispatch (ADR-0013). The hook had `shopt -s extglob globstar nullglob` above the `touch`. macOS ships bash 3.2, which has no `globstar`, so `shopt` returned non-zero and `set -e` aborted the hook before the stamp was written — every non-exempt subagent dispatch was blocked from `4ff5e81` onward on such a machine.

It stayed invisible because `pre-agent-aegis-guard.sh` exempts `code-reviewer` / `review-verifier` / `spec-verifier` / `spec-checker`. The review pipeline — the one path where a person would have noticed — kept working. This is ADR-0013's own audit finding 3 (gates degrading silently per machine) recurring in the gate that ADR introduced.

## Changes

- **`fix` — hook made bash-3.2-safe.** Each `shopt -s` is individually guarded, and `mapfile` (also absent in bash 3.2, and positioned after the stamp) is replaced with a read loop that keeps `mapfile -t` parity for empty elements. `globstar` is dropped: it governs pathname expansion, while the near-miss cross-check matches with `[[ str == pattern ]]`, where a `*` already spans `/`. Verified on bash 3.2.57 — the comment claiming otherwise was wrong and is corrected in all four places it appeared.
- **`test` — `scripts/test-aegis-gate.py`.** Drives the real hooks in a throwaway directory, following the convention of `test-review-gate.py` and `test-bash-guard.py`: stamp creation, fail-closed on a failed or absent `tool_response`, per-prompt clearing, dispatch admit/block, the agent-type exemptions, the `.aegis-unavailable` degrade, and the near-miss warning. It also asserts a static invariant — no unguarded `shopt`, no bash-4-only builtin — because the dynamic checks alone would pass on a bash-4 container while a developer's machine stayed broken. The invariant is a textual heuristic against careless reintroduction, and says so.
- **`fix` — `scripts/test-bash-guard.py`** (separate purpose). Its heredoc case asserts `allow` for a commit-shaped command, but the guard evaluates env → find → commit-gate in order, so the case was decided by whether the session happened to hold a `.review-stamp`. It passed when authored and failed in a session without one. `decide()`/`check()` now take a `project_dir`, and that case points at a stamped temp directory.

## Verification

- `python3 scripts/test-aegis-gate.py`, `scripts/test-bash-guard.py`, `scripts/test-review-gate.py` — all exit 0
- `test-bash-guard.py` verified under both ambient stamp states
- Stamp creation confirmed end-to-end against a real `aegis_compile_context` call, not only synthetic payloads
- The static invariant was checked against the original buggy source as a negative control: it flags both constructs
- `bun run typecheck` / `lint` / `format` / `knip` clean
- Reviewed via the ADR-0015 finder → verifier pass: 5 candidates, 5 confirmed, 0 refuted, all addressed

One departure from the verifier's proposed fix: it suggested keeping the inert `shopt -s globstar` line as harmless. It is removed instead, with a comment recording why it is absent — a line that provably does not affect the mechanism invites the same misreading again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Aegis dispatch gate on macOS (bash 3.2) so `.aegis-stamp` is created and non‑exempt `Agent` dispatches are no longer incorrectly blocked. Adds end‑to‑end tests and tighter static checks (with regression tests) to keep all gate hooks bash‑3.2‑safe.

- **Bug Fixes**
  - Made `.claude/hooks/post-aegis-compile.sh` bash‑3.2‑safe:
    - Guard each `shopt -s` with `2>/dev/null || true`; drop `globstar`.
    - Replace `mapfile` with a read loop that preserves empty entries.
    - Use bash `[[ ]]` glob matching for near‑miss checks; update messages.
  - Strengthened static checks in `scripts/test-aegis-gate.py`:
    - Enforces “no unguarded `shopt`; no bash‑4‑only builtins” across `post-aegis-compile.sh`, `user-prompt-gate.sh`, and `pre-agent-aegis-guard.sh`.
    - Guard detector now tokenizes with `shlex`, splits into statements, and requires `|| true` at the end of each `shopt` statement; handles inline `#`/`;#`; fails closed on bad quotes.
    - Adds a regression suite that mirrors bash 3.2 for 15 guard shapes, closing prior fail‑open cases (quoted `|| true`, cross‑statement pairs, multiple `shopt`s).
  - Isolated hook test workdirs:
    - `test-aegis-gate.py`, `test-review-gate.py`, and `test-bash-guard.py` use `TemporaryDirectory` + `atexit`; comments note cleanup limits.
  - Fixed `scripts/test-bash-guard.py`:
    - Adds a `project_dir` parameter; the heredoc case now points at a stamped temp project so results don’t depend on the session’s `.review-stamp`.

<sup>Written for commit 86920a5823167d1a615a0dbf83619f1b8c2789a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imaimai17468/imaimai-front-templete/pull/53?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

