### PR TITLE
fix: Cursor セッションでレビュースタンプの拒否が無音にならない

### DIFF
--- a/.claude/hooks/post-agent-review-stamp.sh
+++ b/.claude/hooks/post-agent-review-stamp.sh
@@ -74,6 +74,11 @@ esac
 # completed | error | aborted. An errored or aborted agent has verified
 # nothing, so only "completed" may stamp; a payload without the field (every
 # Claude Code payload) skips this check rather than failing it.
+#
+# No followup_message here, unlike the blank-report refusal below: Cursor
+# documents the field as consumed only when status is "completed"
+# (https://cursor.com/docs/hooks#subagentstop), so on this branch it would be
+# dead weight — and the parent already sees the failed dispatch itself.
 STATUS=$(printf '%s' "$INPUT" | jq -r '.status // ""' 2>/dev/null || true)
 if [ -n "$STATUS" ] && [ "$STATUS" != "completed" ]; then
   jq -n --arg st "$STATUS" '{
@@ -146,9 +151,30 @@ REPORTED=$(printf '%s' "$INPUT" | jq -r '
 [ -n "$REPORTED" ] || REPORTED=absent
 
 if [ "$REPORTED" = "blank" ]; then
-  jq -n '{
-    systemMessage: "⛔ Review stamp NOT written: the code-reviewer stopped without a final message, so it produced no findings report — a crashed or interrupted review looks exactly like this. Re-run the review on the current tree."
-  }'
+  MSG="⛔ Review stamp NOT written: the code-reviewer stopped without a final message, so it produced no findings report — a crashed or interrupted review looks exactly like this. Re-run the review on the current tree."
+  # In a Cursor session this refusal used to be invisible: systemMessage is
+  # Claude Code's channel and Cursor ignores it (see post-bash-stamp-consume.sh),
+  # so the first sign was `git commit` being refused later with no stated cause —
+  # which on 2026-08-07 ended with an agent asking the user to create the marker
+  # by hand. followup_message is the one documented subagentStop output Cursor
+  # consumes (https://cursor.com/docs/hooks#subagentstop), so the refusal rides
+  # it on the Cursor dialect. Emitted only when loop_count == 0: Claude-registered
+  # hooks run in Cursor with NO followup cap (loop_limit defaults to null for
+  # third-party hooks per the docs), so an unconditional followup could loop a
+  # failing review forever. Scoped to the camelCase event name because what
+  # Claude Code does with an unknown followup_message field has not been
+  # observed here. scripts/test-review-gate.py pins the emission; whether Cursor
+  # actually consumes it from this hook has not been observed yet — no real
+  # blank refusal has occurred in a Cursor session since this was added.
+  LOOP_COUNT=$(printf '%s' "$INPUT" | jq -r '.loop_count // 0' 2>/dev/null || echo 0)
+  if [ "$EVENT" = "subagentStop" ] && [ "$LOOP_COUNT" = "0" ]; then
+    jq -n --arg msg "$MSG" '{
+      systemMessage: $msg,
+      followup_message: ($msg + " Do NOT create the stamp file by hand and do NOT ask the user to — a manual marker forges the commit gate. Re-dispatch the code-reviewer agent (/review-diff) instead.")
+    }'
+  else
+    jq -n --arg msg "$MSG" '{systemMessage: $msg}'
+  fi
   exit 0
 fi
 

--- a/.claude/hooks/pre-bash-guard.sh
+++ b/.claude/hooks/pre-bash-guard.sh
@@ -234,7 +234,7 @@ fi
 ROOT="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
 
 if [ ! -f "$ROOT/.claude/.review-stamp" ]; then
-  deny "PreToolUse(Bash): the review gate has not been stamped. Dispatch the code-reviewer agent, then the review-verifier agent (or run /review-diff), on the uncommitted diff before committing. Fixing what the verifier confirms does not require another review (ADR-0019) — the stamp survives those edits, so commit once the findings are addressed."
+  deny "PreToolUse(Bash): the review gate has not been stamped. Dispatch the code-reviewer agent (or run /review-diff) on the uncommitted diff before committing — its completion writes the stamp (ADR-0029). Never create the stamp by hand and never ask the user to; a manual marker forges the gate. Fixing what the review confirms does not require another review (ADR-0019) — the stamp survives those edits, so commit once the findings are addressed."
   exit 0
 fi
 

--- a/scripts/test-review-gate.py
+++ b/scripts/test-review-gate.py
@@ -444,6 +444,82 @@ for label, msg, want_stamp in (
     # stamp would inherit the previous case's stamp and pass for the wrong reason.
     clear_stamp()
 
+
+def cursor_stop(status="completed", summary=OMIT, loop_count=0):
+    """Fire the stamp hook with a Cursor-shaped subagentStop payload.
+
+    Shape taken from two payloads captured live on 2026-08-07 in a Cursor cloud
+    agent session running this repository's real hooks: camelCase
+    `hook_event_name`, `subagent_type`, `status` (completed | error | aborted),
+    `loop_count`, and — when the harness supplies the agent's report — `summary`.
+    Neither carried `last_assistant_message`; an earlier desktop capture the
+    same day carried neither report field at all, which is the `summary=OMIT`
+    case below.
+    """
+    payload = {
+        "hook_event_name": "subagentStop",
+        "subagent_type": "code-reviewer",
+        "status": status,
+        "loop_count": loop_count,
+    }
+    if summary is not OMIT:
+        payload["summary"] = summary
+    return raw_hook("post-agent-review-stamp.sh", payload)
+
+
+# The refusals above are visible in Claude Code through systemMessage, which
+# Cursor ignores — a blank-report refusal there used to be silent until the
+# commit gate fired later with no stated cause (2026-08-07, ending with an agent
+# asking the user to hand-create the marker). The hook now rides the refusal on
+# followup_message, the one documented subagentStop output Cursor consumes, and
+# only on the first loop (Claude-registered hooks run in Cursor with no followup
+# cap). These cases pin the emission side; whether Cursor consumes it from this
+# hook is not testable here.
+print("the Cursor dialect stamps and refuses like the Claude one")
+for label, kwargs, want_stamp, want_followup in (
+    ("a completed stop with a summary stamps",
+     dict(summary="findings: none surviving"), True, False),
+    ("an aborted stop does not stamp",
+     dict(status="aborted", summary="partial text"), False, False),
+    ("an errored stop does not stamp",
+     dict(status="error", summary="partial text"), False, False),
+    ("a blank summary does not stamp, and the refusal rides a followup",
+     dict(summary=""), False, True),
+    ("a null summary does not stamp, and the refusal rides a followup",
+     dict(summary=None), False, True),
+    ("no followup after the first loop",
+     dict(summary="", loop_count=1), False, False),
+):
+    edit("fileA.ts", f"export const a = {len(label)};\n")
+    dispatch("code-reviewer")
+    out = cursor_stop(**kwargs)
+    check(label, stamped(), want_stamp)
+    check(
+        f"...followup {'present' if want_followup else 'absent'}",
+        "followup_message" in out,
+        want_followup,
+    )
+    clear_stamp()
+
+# The desktop capture that carried neither report field: nothing to judge, so it
+# stamps and says the check was skipped — same contract as the Claude OMIT case.
+edit("fileA.ts", "export const a = 901;\n")
+dispatch("code-reviewer")
+out = cursor_stop()
+check("neither report field stamps, with a warning", stamped(), True)
+check("...and says the check was skipped", "could not be checked" in out, True)
+clear_stamp()
+
+# The followup stays scoped to the camelCase dialect: what Claude Code does with
+# an unknown followup_message field has not been observed, so its payloads must
+# keep producing exactly the pre-change output.
+edit("fileA.ts", "export const a = 902;\n")
+dispatch("code-reviewer")
+out = stop(message="")
+check("a Claude-dialect blank refusal carries no followup",
+      "followup_message" in out, False)
+clear_stamp()
+
 # Restore the invariant the following sections run on — a stamp earned by a clean
 # pass. The loop above deliberately ends with none, and the next section asserts that
 # editing a reviewed file still passes the gate, which needs one.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 問題

Cursor セッションでレビュー完了後にスタンプが書かれないことがあり、コミットがブロックされた際にエージェントがユーザーへマーカーの手動作成を依頼する事態が起きた。

原因は2つ:

1. スタンプ拒否(レビューエージェントが空レポートで停止した場合など)の通知が `systemMessage` のみで、Cursor はこのチャネルを無視するため、拒否が無音で起きていた
2. コミットゲートの deny 文面が ADR-0029 で削除済みの `review-verifier` エージェントの派遣を指示しており、従えないエージェントが手動作成の依頼に流れた

## 変更

- `post-agent-review-stamp.sh`: 空レポート拒否時、Cursor 方言のペイロードに限り `followup_message`(subagentStop で Cursor が消費する唯一の文書化された出力)にも拒否理由と再レビュー指示を載せる。third-party フックは followup 回数無制限のため `loop_count == 0` の初回のみ発出。Claude Code 方言の出力は全分岐でバイト同一(レビューで実測確認)
- `pre-bash-guard.sh`: deny 文面から `review-verifier` を除去し、スタンプの手動作成禁止を明記
- `scripts/test-review-gate.py`: 2026-08-07 に本リポジトリで捕捉した Cursor 実ペイロード形状(`status` / `summary` / `loop_count`)の回帰ケースを追加

## 検証

- `test-review-gate.py` / `test-bash-guard.py` / `test-aegis-gate.py` 全通過
- スタンプのライフサイクル(派遣時クリア → 完了時スタンプ → クリーンツリーで消費)を Cursor Cloud Agent 上でフォアグラウンド・バックグラウンド両方の実派遣で確認
- shell/python 用の linter は本プロジェクトに構成されていないため、検証はテストスイートによる

なお、レビュー後の正当な Aegis 相談がスタンプを消す件(`pre-aegis-compile-guard.sh` の設計)は別の判断事項として未着手。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fdde5-8aa1-77d7-9f61-ff21466572cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fdde5-8aa1-77d7-9f61-ff21466572cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes silent review-stamp refusals in Cursor sessions and removes misleading commit-gate guidance. Cursor now surfaces blank-report refusals as a follow-up message, and the guard no longer suggests a non-existent `review-verifier` or manual stamps.

- **Bug Fixes**
  - post-agent-review-stamp.sh: On blank report, emit `followup_message` for Cursor `subagentStop` only when `loop_count == 0`; keep Claude Code output byte-identical.
  - pre-bash-guard.sh: Remove `review-verifier`; explicitly forbid manual stamp creation; direct to the code-reviewer or `/review-diff`.
  - scripts/test-review-gate.py: Add regression tests for Cursor payload shape (`status`/`summary`/`loop_count`) and follow-up emission; verify stamp lifecycle.

<sup>Written for commit d1e033d112a02c1f867c7fd87dbcf0c4ffd9b868. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imaimai17468/imaimai-front-templete/pull/69?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

