### PR TITLE
fix: 効いていない lint 抑制コメントを削除する

### DIFF
--- a/src/server/cloudflare.ts
+++ b/src/server/cloudflare.ts
@@ -1,9 +1,7 @@
-// biome-disable
 // `cloudflare:workers` is provided by the Workers runtime (and by
 // @cloudflare/vite-plugin during dev). When running outside a Worker (vitest),
 // imports of this module should be avoided — D1 / R2 bindings have no meaning
 // in that environment.
-// eslint-disable-next-line import/no-unresolved
 import { env as runtimeEnv } from "cloudflare:workers";
 
 export const getCloudflareEnv = (): CloudflareEnv => runtimeEnv;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request

## なぜこの変更をするのか

コード内コメントの規約(コメントは直下のコードの説明のみ・lint-disable コメント禁止)に対する監査で、`src/server/cloudflare.ts` 先頭の 2 行が違反として見つかったため。このプロジェクトの linter は oxlint で、Biome も ESLint も依存に存在せず、どちらのコメントも何も抑制していない。

## 変更内容

- `src/server/cloudflare.ts` から `// biome-disable` と `// eslint-disable-next-line import/no-unresolved` の 2 行を削除
- 間にある vitest 環境に関する説明コメントは正当なため維持

## 確認ページ

なし(コメントのみの変更で動作に影響なし)

## その他コメント

削除後に typecheck / lint / format / test(135 件)がすべて通過することを確認済み。コミット前レビュー(code-reviewer)も findings ゼロ。knip はこの環境で vite.config.ts の読み込みに失敗するため未実行。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fdec9-3281-7473-9bcd-2216df72b2db?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fdec9-3281-7473-9bcd-2216df72b2db&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `// biome-disable` and `// eslint-disable-next-line import/no-unresolved` from the top of src/server/cloudflare.ts to comply with our comment policy. No behavior change.

<sup>Written for commit 29f9eb47b58754f3a828ab65cb449c165cbad6f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imaimai17468/imaimai-front-templete/pull/71?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

