### PR TITLE
oxlint の type-aware ルール拡充と検出違反の解消

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -43,8 +43,38 @@
     "@typescript-eslint/ban-ts-comment": "error",
     "@typescript-eslint/no-non-null-assertion": "error",
     "@typescript-eslint/switch-exhaustiveness-check": "error",
-    "@typescript-eslint/no-misused-promises": "warn",
+    "@typescript-eslint/no-misused-promises": "error",
     "@typescript-eslint/consistent-type-imports": "error",
+    "@typescript-eslint/consistent-type-exports": "error",
+    "@typescript-eslint/no-unsafe-assignment": "error",
+    "@typescript-eslint/no-unsafe-argument": "error",
+    "@typescript-eslint/no-unsafe-call": "error",
+    "@typescript-eslint/no-unsafe-member-access": "error",
+    "@typescript-eslint/no-unsafe-return": "error",
+    "@typescript-eslint/use-unknown-in-catch-callback-variable": "error",
+    "@typescript-eslint/no-deprecated": "error",
+    "@typescript-eslint/no-confusing-void-expression": "error",
+    "@typescript-eslint/no-mixed-enums": "error",
+    "@typescript-eslint/only-throw-error": [
+      "error",
+      {
+        "allow": [
+          {
+            "from": "package",
+            "package": "@tanstack/router-core",
+            "name": "Redirect"
+          }
+        ]
+      }
+    ],
+    "@typescript-eslint/prefer-promise-reject-errors": "error",
+    "@typescript-eslint/prefer-nullish-coalescing": "error",
+    "@typescript-eslint/promise-function-async": "error",
+    "@typescript-eslint/require-await": "error",
+    "@typescript-eslint/restrict-plus-operands": "error",
+    "@typescript-eslint/return-await": "error",
+    "@typescript-eslint/strict-boolean-expressions": "error",
+    "@typescript-eslint/strict-void-return": "error",
     "unicorn/throw-new-error": "error",
     "oxc/no-accumulating-spread": "error",
     "import/no-unassigned-import": "off",

--- a/src/components/features/profile-page/profile-form/ProfileForm.tsx
+++ b/src/components/features/profile-page/profile-form/ProfileForm.tsx
@@ -40,7 +40,7 @@ export const ProfileForm = ({ user }: ProfileFormProps) => {
   // Object URL(外部リソース)の解放を表示中の previewUrl に同期する。
   // 差し替え時は古い URL の cleanup が走り、アンマウント時も解放される。
   useEffect(() => {
-    if (!previewUrl) {
+    if (previewUrl === null) {
       return undefined;
     }
     return () => {
@@ -51,7 +51,7 @@ export const ProfileForm = ({ user }: ProfileFormProps) => {
   const form = useForm<FormData>({
     resolver: zodResolver(UpdateUserSchema),
     defaultValues: {
-      name: user.name || "",
+      name: user.name ?? "",
     },
   });
 
@@ -83,13 +83,13 @@ export const ProfileForm = ({ user }: ProfileFormProps) => {
     setPreviewUrl(nextPreviewUrl);
   };
 
-  const onSubmit = async (data: FormData) => {
+  const onSubmit = (data: FormData) => {
     startTransition(async () => {
       if (pendingFile) {
         const avatarData = new globalThis.FormData();
         avatarData.append("avatar", pendingFile);
         const avatarResult = await uploadAvatarFn({ data: avatarData });
-        if ("error" in avatarResult && avatarResult.error) {
+        if ("error" in avatarResult && avatarResult.error !== undefined) {
           toast.error(avatarResult.error);
           return;
         }
@@ -100,7 +100,7 @@ export const ProfileForm = ({ user }: ProfileFormProps) => {
       formData.append("name", data.name);
 
       const result = await updateProfileFn({ data: formData });
-      if ("error" in result && result.error) {
+      if ("error" in result && result.error !== undefined) {
         toast.error(result.error);
       } else {
         toast.success("Profile updated successfully");
@@ -108,8 +108,9 @@ export const ProfileForm = ({ user }: ProfileFormProps) => {
     });
   };
 
-  const displayName = user.name || "User";
-  const avatarUrl = previewUrl || user.avatarUrl;
+  const displayName =
+    user.name === null || user.name === "" ? "User" : user.name;
+  const avatarUrl = previewUrl ?? user.avatarUrl;
 
   return (
     <Form {...form}>
@@ -120,7 +121,7 @@ export const ProfileForm = ({ user }: ProfileFormProps) => {
         <div className="flex items-center gap-6">
           <div className="relative">
             <Avatar className="size-24">
-              <AvatarImage src={avatarUrl || undefined} alt={displayName} />
+              <AvatarImage src={avatarUrl ?? undefined} alt={displayName} />
               <AvatarFallback className="text-2xl">
                 {displayName.charAt(0).toUpperCase()}
               </AvatarFallback>

--- a/src/components/shared/header/user-menu/UserMenu.tsx
+++ b/src/components/shared/header/user-menu/UserMenu.tsx
@@ -19,7 +19,7 @@ type UserMenuProps = {
 
 export const UserMenu = ({ user }: UserMenuProps) => {
   const avatarUrl = user.avatarUrl;
-  const name = user.name || "User";
+  const name = user.name === null || user.name === "" ? "User" : user.name;
   const email = user.email;
 
   return (
@@ -30,7 +30,7 @@ export const UserMenu = ({ user }: UserMenuProps) => {
           className="cursor-pointer rounded-full focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
         >
           <Avatar className="size-8">
-            <AvatarImage src={avatarUrl || undefined} alt={name} />
+            <AvatarImage src={avatarUrl ?? undefined} alt={name} />
             <AvatarFallback>{name.charAt(0).toUpperCase()}</AvatarFallback>
           </Avatar>
         </button>

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -139,7 +139,7 @@ function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
   const { error, formMessageId } = useFormField();
   const body = error ? (error.message ?? "") : props.children;
 
-  if (!body) {
+  if (body == null || body === "") {
     return null;
   }
 

--- a/src/gateways/user/index.ts
+++ b/src/gateways/user/index.ts
@@ -63,7 +63,7 @@ export const updateUserAvatar = async (
   file: File
 ): Promise<{ success: boolean; error?: string; avatarUrl?: string }> => {
   const fileExt = avatarExtensionForMime(file.type);
-  if (!fileExt) {
+  if (fileExt === null) {
     return { success: false, error: "Unsupported image type" };
   }
   const key = `${userId}/avatar.${fileExt}`;

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -2,7 +2,7 @@ import { getRequest } from "@tanstack/react-start/server";
 import { getAuth } from "./auth";
 
 export const getSession = async () => {
-  return await getAuth().api.getSession({ headers: getRequest().headers });
+  return getAuth().api.getSession({ headers: getRequest().headers });
 };
 
 /** @public セッションから User を取り出すヘルパー。テンプレ用途で公開、派生実装で使う想定。 */

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -8,3 +8,9 @@ export const getRouter = () => {
     scrollRestoration: true,
   });
 };
+
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: ReturnType<typeof getRouter>;
+  }
+}

--- a/src/routes/api/auth.$.ts
+++ b/src/routes/api/auth.$.ts
@@ -4,8 +4,8 @@ import { getAuth } from "@/lib/auth/auth";
 export const Route = createFileRoute("/api/auth/$")({
   server: {
     handlers: {
-      GET: ({ request }) => getAuth().handler(request),
-      POST: ({ request }) => getAuth().handler(request),
+      GET: async ({ request }) => getAuth().handler(request),
+      POST: async ({ request }) => getAuth().handler(request),
     },
   },
 });

--- a/src/routes/api/avatars.ts
+++ b/src/routes/api/avatars.ts
@@ -14,7 +14,7 @@ export const Route = createFileRoute("/api/avatars")({
 
         const url = new URL(request.url);
         const key = url.searchParams.get("key");
-        if (!key || !isOwnAvatarKey(key, session.user.id)) {
+        if (key === null || !isOwnAvatarKey(key, session.user.id)) {
           return Response.json({ error: "Invalid key" }, { status: 400 });
         }
 

--- a/src/server/fn/profile.ts
+++ b/src/server/fn/profile.ts
@@ -11,7 +11,7 @@ import {
 } from "@/lib/storage/avatar-validation";
 
 export const updateProfileFn = createServerFn({ method: "POST" })
-  .inputValidator((data: unknown) => {
+  .validator((data: unknown) => {
     if (!(data instanceof FormData)) {
       throw new Error("Expected FormData");
     }
@@ -26,7 +26,7 @@ export const updateProfileFn = createServerFn({ method: "POST" })
   });
 
 export const uploadAvatarFn = createServerFn({ method: "POST" })
-  .inputValidator((data: unknown) => {
+  .validator((data: unknown) => {
     if (!(data instanceof FormData)) {
       throw new Error("Expected FormData");
     }

--- a/src/server/fn/user.ts
+++ b/src/server/fn/user.ts
@@ -3,6 +3,6 @@ import { fetchCurrentUser } from "@/gateways/user";
 
 export const getCurrentUserFn = createServerFn({ method: "GET" }).handler(
   async () => {
-    return await fetchCurrentUser();
+    return fetchCurrentUser();
   }
 );

--- a/src/ssr.tsx
+++ b/src/ssr.tsx
@@ -6,7 +6,7 @@ import {
 const handler = createStartHandler(defaultStreamHandler);
 
 export default {
-  fetch(request: Request) {
+  async fetch(request: Request) {
     return handler(request);
   },
 } satisfies ExportedHandler<CloudflareEnv>;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request

## なぜこの変更をするのか

型情報がないと検出できないバグ(握りつぶされた any、廃止 API の使用、Promise の取り扱いミス、nullable の暗黙の真偽値評価)を lint で機械的に塞ぐため、oxlint の type-aware ルールを拡充する。導入前に全候補ルールをコードベースへ実測し、違反ゼロのもの・実バグを検出したものだけを error で採用した。

## 変更内容

- `.oxlintrc.json` に型情報ベースのルールを追加(no-unsafe-* 系、no-deprecated、strict-boolean-expressions、prefer-nullish-coalescing、return-await ほか)。`only-throw-error` は TanStack Router の `throw redirect()` イディオムを allow 設定で除外
- ルールが検出した実問題の修正:
  - TanStack Router の型登録(`Register` 宣言)が欠落しており `useLoaderData()` が any になっていたのを解消
  - 廃止 API `inputValidator` を `validator` へ移行
  - try-catch 外の `return await` 除去、Promise を返すハンドラへの async 明示、nullable 文字列条件の明示化(挙動差なし)
- oxlint で nursery 扱いのルール(no-unnecessary-condition / prefer-optional-chain)は安定を待って見送り

## 確認ページ

なし(挙動に影響する変更はルーターの型復元のみで、表示・動作は従来どおり)

## その他コメント

- 検証: `tsc --noEmit`、`oxlint --type-aware`、`oxfmt --check`、`vitest --run`(135件)すべてパス
- コミット前レビュー(code-reviewer)で、name が空文字のときにアバターフォールバックが消える指摘を受け、明示比較で従来挙動を維持する形に修正済み
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fdf6b-00ca-7357-91af-88fd4306a905?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fdf6b-00ca-7357-91af-88fd4306a905&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand `oxlint` type-aware rules and fix all violations across the app. This blocks unsafe any/deprecated API/async pitfalls and restores correct `@tanstack/react-router` types for `useLoaderData()`.

- **Refactors**
  - Enable `oxlint --type-aware` rules (unsafe-any, deprecated APIs, async misuse, strict boolean checks) via `@typescript-eslint` set to error.
  - Allow `Redirect` from `@tanstack/router-core` in `only-throw-error`.
  - Skip nursery rules for now (`no-unnecessary-condition`, `prefer-optional-chain`).

- **Bug Fixes**
  - Register router types to propagate `@tanstack/react-router` types; `useLoaderData()` is no longer `any`.
  - Replace deprecated `.inputValidator` with `.validator` in `@tanstack/react-start`.
  - Remove unnecessary `return await`, add `async` where required, and make handlers explicitly `async`.
  - Make null/empty checks explicit and use `??` defaults (preserve "User" fallback and avatar src behavior).

<sup>Written for commit 9e1e58070b9c964b58a584d5a26e90495ad3a481. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imaimai17468/imaimai-front-templete/pull/73?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

