### PR TITLE
chore: oxlint の全カテゴリを error にする

### DIFF
--- a/.claude/hooks/check-md-links.ts
+++ b/.claude/hooks/check-md-links.ts
@@ -101,8 +101,7 @@ export const stripCode = (text: string): string => {
         return blankCodeSpans(line, 0);
       }
       if (
-        marker !== undefined &&
-        marker.startsWith(fence.char) &&
+        marker?.startsWith(fence.char) === true &&
         marker.length >= fence.length
       ) {
         fence = null;
@@ -317,7 +316,7 @@ export const targetExists = (target: string): boolean => {
     .filter((part) => part !== "");
   return parts.every((part, depth) => {
     const entries = listdir(path.join(root, ...parts.slice(0, depth)));
-    return entries !== null && entries.has(part);
+    return entries?.has(part) === true;
   });
 };
 

--- a/src/components/features/profile-page/profile-form/profile-form.tsx
+++ b/src/components/features/profile-page/profile-form/profile-form.tsx
@@ -101,7 +101,7 @@ export const ProfileForm = ({ user }: ProfileFormProps) => {
         const avatarData = new globalThis.FormData();
         avatarData.append("avatar", pendingFile);
         const avatarResult = await uploadAvatarFn({ data: avatarData });
-        if ("error" in avatarResult && avatarResult.error !== undefined) {
+        if ("error" in avatarResult) {
           toast.error(avatarResult.error);
           return;
         }
@@ -112,7 +112,7 @@ export const ProfileForm = ({ user }: ProfileFormProps) => {
       formData.append("name", data.name);
 
       const result = await updateProfileFn({ data: formData });
-      if ("error" in result && result.error !== undefined) {
+      if ("error" in result) {
         toast.error(result.error);
       } else {
         toast.success("Profile updated successfully");

--- a/tools/oxlint-plugins/arch-rules.js
+++ b/tools/oxlint-plugins/arch-rules.js
@@ -11,7 +11,7 @@ const noSizeProps = {
   create(context) {
     return {
       JSXAttribute(node) {
-        const propName = node.name && node.name.name;
+        const propName = node.name?.name;
         if (propName !== "width" && propName !== "height") {
           return;
         }
@@ -85,9 +85,7 @@ const oneComponentPerFile = {
         if (decl.type === "VariableDeclaration") {
           for (const declarator of decl.declarations) {
             const name =
-              declarator.id && declarator.id.type === "Identifier"
-                ? declarator.id.name
-                : null;
+              declarator.id?.type === "Identifier" ? declarator.id.name : null;
             if (!name || !isComponentName(name)) {
               continue;
             }
@@ -120,8 +118,7 @@ const testNamingFormat = {
           calleeName = callee.name;
         } else if (
           callee.type === "MemberExpression" &&
-          callee.object &&
-          callee.object.type === "Identifier" &&
+          callee.object?.type === "Identifier" &&
           (callee.object.name === "it" || callee.object.name === "test")
         ) {
           if (callee.property && SKIP_METHODS.has(callee.property.name)) {
@@ -162,11 +159,7 @@ const isExpectCall = (node) => {
   if (callee.type === "Identifier" && callee.name === "expect") {
     return true;
   }
-  if (
-    callee.type === "MemberExpression" &&
-    callee.object &&
-    callee.object.name === "expect"
-  ) {
+  if (callee.type === "MemberExpression" && callee.object?.name === "expect") {
     return true;
   }
   return false;
@@ -181,8 +174,7 @@ const isEachCall = (node) => {
     callee.type === "MemberExpression" &&
     callee.object &&
     (callee.object.name === "it" || callee.object.name === "test") &&
-    callee.property &&
-    callee.property.name === "each"
+    callee.property?.name === "each"
   ) {
     return true;
   }
@@ -199,14 +191,11 @@ const singleExpect = {
           return;
         }
         const { callee } = node;
-        let calleeName =
-          callee && callee.type === "Identifier" ? callee.name : null;
+        let calleeName = callee?.type === "Identifier" ? callee.name : null;
         if (
           calleeName === null &&
-          callee &&
-          callee.type === "MemberExpression" &&
-          callee.object &&
-          callee.object.type === "Identifier" &&
+          callee?.type === "MemberExpression" &&
+          callee.object?.type === "Identifier" &&
           (callee.object.name === "it" || callee.object.name === "test")
         ) {
           if (callee.property && SKIP_METHODS.has(callee.property.name)) {
@@ -235,14 +224,11 @@ const singleExpect = {
           return;
         }
         const { callee } = node;
-        let calleeName =
-          callee && callee.type === "Identifier" ? callee.name : null;
+        let calleeName = callee?.type === "Identifier" ? callee.name : null;
         if (
           calleeName === null &&
-          callee &&
-          callee.type === "MemberExpression" &&
-          callee.object &&
-          callee.object.type === "Identifier" &&
+          callee?.type === "MemberExpression" &&
+          callee.object?.type === "Identifier" &&
           (callee.object.name === "it" || callee.object.name === "test")
         ) {
           if (callee.property && SKIP_METHODS.has(callee.property.name)) {
@@ -341,9 +327,7 @@ const componentFileNaming = {
         if (decl.type === "VariableDeclaration") {
           for (const declarator of decl.declarations) {
             const name =
-              declarator.id && declarator.id.type === "Identifier"
-                ? declarator.id.name
-                : null;
+              declarator.id?.type === "Identifier" ? declarator.id.name : null;
             if (!name || !isComponentName(name)) {
               continue;
             }

--- a/tools/oxlint-plugins/arch-rules.test.ts
+++ b/tools/oxlint-plugins/arch-rules.test.ts
@@ -172,7 +172,7 @@ describe("one-component-per-file", () => {
     };
 
     // Act
-    visitors.ExportNamedDeclaration?.(node);
+    visitors.ExportNamedDeclaration(node);
 
     // Assert
     expect(context.report).not.toHaveBeenCalled();
@@ -190,8 +190,8 @@ describe("one-component-per-file", () => {
     };
 
     // Act
-    visitors.ExportNamedDeclaration?.(firstNode);
-    visitors.ExportNamedDeclaration?.(secondNode);
+    visitors.ExportNamedDeclaration(firstNode);
+    visitors.ExportNamedDeclaration(secondNode);
 
     // Assert
     expect(context.report).toHaveBeenCalledOnce();
@@ -214,7 +214,7 @@ describe("one-component-per-file", () => {
     };
 
     // Act
-    visitors.ExportNamedDeclaration?.(node);
+    visitors.ExportNamedDeclaration(node);
 
     // Assert
     expect(context.report).not.toHaveBeenCalled();
@@ -248,8 +248,8 @@ describe("one-component-per-file", () => {
     };
 
     // Act
-    visitors.ExportNamedDeclaration?.(firstNode);
-    visitors.ExportNamedDeclaration?.(secondNode);
+    visitors.ExportNamedDeclaration(firstNode);
+    visitors.ExportNamedDeclaration(secondNode);
 
     // Assert
     expect(context.report).toHaveBeenCalledOnce();
@@ -264,7 +264,7 @@ describe("one-component-per-file", () => {
     };
 
     // Act
-    visitors.ExportNamedDeclaration?.(node);
+    visitors.ExportNamedDeclaration(node);
 
     // Assert
     expect(context.report).not.toHaveBeenCalled();
@@ -287,7 +287,7 @@ describe("one-component-per-file", () => {
     };
 
     // Act
-    visitors.ExportNamedDeclaration?.(node);
+    visitors.ExportNamedDeclaration(node);
 
     // Assert
     expect(context.report).not.toHaveBeenCalled();
@@ -1221,8 +1221,8 @@ describe("one-component-per-file (defensive branches)", () => {
     };
 
     // Act
-    visitors.ExportNamedDeclaration?.(named);
-    visitors.ExportDefaultDeclaration?.(defaultExport);
+    visitors.ExportNamedDeclaration(named);
+    visitors.ExportDefaultDeclaration(defaultExport);
 
     // Assert
     expect(context.report).toHaveBeenCalledOnce();
@@ -1237,7 +1237,7 @@ describe("one-component-per-file (defensive branches)", () => {
     };
 
     // Act
-    visitors.ExportNamedDeclaration?.(node);
+    visitors.ExportNamedDeclaration(node);
 
     // Assert
     expect(context.report).not.toHaveBeenCalled();
@@ -1249,7 +1249,7 @@ describe("one-component-per-file (defensive branches)", () => {
     const visitors = rule.create(context);
 
     // Act
-    visitors.ExportNamedDeclaration?.({ declaration: null });
+    visitors.ExportNamedDeclaration({ declaration: null });
 
     // Assert
     expect(context.report).not.toHaveBeenCalled();
@@ -1261,7 +1261,7 @@ describe("one-component-per-file (defensive branches)", () => {
     const visitors = rule.create(context);
 
     // Act
-    visitors.ExportNamedDeclaration?.({
+    visitors.ExportNamedDeclaration({
       declaration: { id: { name: "Card" }, type: "ClassDeclaration" },
     });
 
@@ -1275,7 +1275,7 @@ describe("one-component-per-file (defensive branches)", () => {
     const visitors = rule.create(context);
 
     // Act
-    visitors.ExportNamedDeclaration?.({
+    visitors.ExportNamedDeclaration({
       declaration: { id: null, type: "FunctionDeclaration" },
     });
 
@@ -1295,7 +1295,7 @@ describe("one-component-per-file (defensive branches)", () => {
     };
 
     // Act
-    visitors.ExportNamedDeclaration?.(node);
+    visitors.ExportNamedDeclaration(node);
 
     // Assert
     expect(context.report).not.toHaveBeenCalled();
@@ -1315,7 +1315,7 @@ describe("one-component-per-file (defensive branches)", () => {
     };
 
     // Act
-    visitors.ExportNamedDeclaration?.(node);
+    visitors.ExportNamedDeclaration(node);
 
     // Assert
     expect(context.report).not.toHaveBeenCalled();
@@ -1338,7 +1338,7 @@ describe("one-component-per-file (defensive branches)", () => {
     };
 
     // Act
-    visitors.ExportNamedDeclaration?.(node);
+    visitors.ExportNamedDeclaration(node);
 
     // Assert
     expect(context.report).not.toHaveBeenCalled();
@@ -1350,7 +1350,7 @@ describe("one-component-per-file (defensive branches)", () => {
     const visitors = rule.create(context);
 
     // Act
-    visitors.ExportDefaultDeclaration?.({ declaration: null });
+    visitors.ExportDefaultDeclaration({ declaration: null });
 
     // Assert
     expect(context.report).not.toHaveBeenCalled();
@@ -1362,7 +1362,7 @@ describe("one-component-per-file (defensive branches)", () => {
     const visitors = rule.create(context);
 
     // Act
-    visitors.ExportDefaultDeclaration?.({
+    visitors.ExportDefaultDeclaration({
       declaration: { type: "ArrowFunctionExpression" },
     });
 
@@ -1376,7 +1376,7 @@ describe("one-component-per-file (defensive branches)", () => {
     const visitors = rule.create(context);
 
     // Act
-    visitors.ExportDefaultDeclaration?.({
+    visitors.ExportDefaultDeclaration({
       declaration: { id: null, type: "FunctionExpression" },
     });
 
@@ -1390,7 +1390,7 @@ describe("one-component-per-file (defensive branches)", () => {
     const visitors = rule.create(context);
 
     // Act
-    visitors.ExportDefaultDeclaration?.({
+    visitors.ExportDefaultDeclaration({
       declaration: { id: { name: "helper" }, type: "FunctionDeclaration" },
     });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -135,13 +135,14 @@ export default defineConfig({
     ],
     overrides: [
       {
-        // A config object's key order carries meaning that alphabetical order
-        // destroys: `plugins` runs in array order, and the blocks here read as
-        // lint, then fmt, then what Vite itself needs. These files are linted
-        // and type-checked, so only the ordering rule is dropped.
+        // `sort-keys` is dropped because a config object's key order carries
+        // meaning that alphabetical order destroys: `plugins` runs in array
+        // order, and the blocks here read as lint, then fmt, then what Vite
+        // itself needs. `vitest/require-hook` is dropped because it reports
+        // these files' top-level statements even though a config holds no
+        // tests. Every other rule still applies, and these files are linted
+        // and type-checked like any other.
         files: ["*.config.{js,ts,mjs,mts}"],
-        // vitest/require-hook reports this file's top-level statements even
-        // though a config holds no tests.
         rules: { "sort-keys": "off", "vitest/require-hook": "off" },
       },
       {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,7 +42,11 @@ export default defineConfig({
     categories: {
       correctness: "error",
       suspicious: "error",
+      pedantic: "error",
       perf: "error",
+      style: "error",
+      restriction: "error",
+      nursery: "error",
     },
     rules: {
       complexity: "error",
@@ -65,6 +69,10 @@ export default defineConfig({
       "react/jsx-pascal-case": "error",
       eqeqeq: ["error", "always", { null: "ignore" }],
       "no-console": "warn",
+      // `style` enables this alongside vitest/require-hook, which asks for the
+      // opposite: setup at the top level trips require-hook, setup inside a
+      // hook trips this. Dropping this one leaves require-hook coherent.
+      "vitest/no-hooks": "off",
       "@typescript-eslint/ban-ts-comment": "error",
       "@typescript-eslint/no-non-null-assertion": "error",
       "@typescript-eslint/switch-exhaustiveness-check": "error",
@@ -132,7 +140,9 @@ export default defineConfig({
         // lint, then fmt, then what Vite itself needs. These files are linted
         // and type-checked, so only the ordering rule is dropped.
         files: ["*.config.{js,ts,mjs,mts}"],
-        rules: { "sort-keys": "off" },
+        // vitest/require-hook reports this file's top-level statements even
+        // though a config holds no tests.
+        rules: { "sort-keys": "off", "vitest/require-hook": "off" },
       },
       {
         // The script drives a hook and parses its JSON stdout, so `unknown` is
@@ -148,6 +158,21 @@ export default defineConfig({
           "anti-slop/no-unsafe-dictionary-type": "off",
           "no-console": "off",
           "unicorn/no-array-for-each": "off",
+          // vitest/require-hook reports these scripts' top-level statements.
+          // They run their own assertions under bun and vitest never loads
+          // them, so there is no hook for the work to move into.
+          "vitest/require-hook": "off",
+        },
+      },
+      {
+        // Vitest loads this through setupFiles, where the afterEach registers
+        // once for every test file. Wrapping it in a describe would scope the
+        // cleanup to that block, and dropping the import would leave afterEach
+        // undefined, because vitest.config.mts does not enable globals.
+        files: ["src/test-setup.ts"],
+        rules: {
+          "vitest/no-importing-vitest-globals": "off",
+          "vitest/require-top-level-describe": "off",
         },
       },
       {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,9 @@ import { defineConfig } from "vite-plus";
 import reactDoctor from "./oxlint.react-doctor.ts";
 import { wranglerTypes } from "./tools/vite-plugins/wrangler-types-plugin";
 
+const CONFIG_FILES = "*.config.{js,ts,mjs,mts}";
+const FILES_VITEST_NEVER_LOADS = [CONFIG_FILES, "scripts/**"];
+
 export default defineConfig({
   lint: {
     options: { typeAware: true, typeCheck: true },
@@ -135,15 +138,15 @@ export default defineConfig({
     ],
     overrides: [
       {
-        // `sort-keys` is dropped because a config object's key order carries
-        // meaning that alphabetical order destroys: `plugins` runs in array
-        // order, and the blocks here read as lint, then fmt, then what Vite
-        // itself needs. `vitest/require-hook` is dropped because it reports
-        // these files' top-level statements even though a config holds no
-        // tests. Every other rule still applies, and these files are linted
-        // and type-checked like any other.
-        files: ["*.config.{js,ts,mjs,mts}"],
-        rules: { "sort-keys": "off", "vitest/require-hook": "off" },
+        // A config object's key order carries meaning that alphabetical order
+        // destroys: `plugins` runs in array order, and the blocks here read as
+        // lint, then fmt, then what Vite itself needs.
+        files: [CONFIG_FILES],
+        rules: { "sort-keys": "off" },
+      },
+      {
+        files: FILES_VITEST_NEVER_LOADS,
+        rules: { "vitest/require-hook": "off" },
       },
       {
         // The script drives a hook and parses its JSON stdout, so `unknown` is
@@ -159,19 +162,13 @@ export default defineConfig({
           "anti-slop/no-unsafe-dictionary-type": "off",
           "no-console": "off",
           "unicorn/no-array-for-each": "off",
-          // vitest/require-hook reports these scripts' top-level statements.
-          // They run their own assertions under bun and vitest never loads
-          // them, so there is no hook for the work to move into.
-          "vitest/require-hook": "off",
         },
       },
       {
-        // Vitest loads this through setupFiles, where the afterEach registers
-        // once for every test file. Wrapping it in a describe would scope the
-        // cleanup to that block, and dropping the import would leave afterEach
-        // undefined, because vitest.config.mts does not enable globals.
         files: ["src/test-setup.ts"],
         rules: {
+          // vitest.config.mts sets no `globals`, so this import is what
+          // defines afterEach here.
           "vitest/no-importing-vitest-globals": "off",
           "vitest/require-top-level-describe": "off",
         },


### PR DESCRIPTION
## 変更

oxlint のカテゴリ7つすべてを `error` にした。これまでは `correctness` / `suspicious` / `perf` の3つだけだった。

| カテゴリ | 追加前 | 追加で出た指摘 |
|---|---|---|
| `pedantic` | 未設定 | 0件 |
| `restriction` | 未設定 | 0件 |
| `style` | 未設定 | 17件（全て vitest プラグインの誤爆） |
| `nursery` | 未設定 | 37件（このPRで修正） |

## off にした4ルール

直すと後退するものだけを落とした。

| ルール | 範囲 | 理由 |
|---|---|---|
| `vitest/no-hooks` | 全体 | `vitest/require-hook` と要求が正反対で両立しない。トップレベルに置けば require-hook が、フックに入れれば no-hooks が鳴る |
| `vitest/require-hook` | `*.config.*` / `scripts/**` | テストを持たないファイルのトップレベル文に鳴る。移す先のフックが存在しない |
| `vitest/require-top-level-describe` | `src/test-setup.ts` | describe で囲むと cleanup がそのブロックに閉じる |
| `vitest/no-importing-vitest-globals` | `src/test-setup.ts` | `vitest.config.mts` が globals を有効にしていないので、import を消すと `afterEach` が未定義になる |

## 修正した37件

```
tools/oxlint-plugins/arch-rules.js        12件  a && a.b を a?.b へ
tools/oxlint-plugins/arch-rules.test.ts   21件  型上 non-nullish な ?.( を落とす
.claude/hooks/check-md-links.ts            2件  同上
src/components/.../profile-form.tsx        2件  "error" in x && x.error !== undefined の後半
```

`profile-form.tsx` だけ実行時の挙動が変わり得るので裏を取った。`error` は `error?: string` 宣言だが、`src/gateways/user/index.ts` の全 return で `error` には文字列リテラルしか入らず、`{ error: undefined }` を作る経路が無い。`"error" in x` だけで同じ判定になる。

## 確認

- `bun run check` 終了コード 0
- `bun run test` 379件通過、分岐カバレッジ 100%（`&&` が `?.` になった分、分岐数は319から302へ減った）
- `bun .claude/hooks/check-md-links.ts` を実リポジトリに対して実行、終了コード 0
- `bun run scripts/test-bash-guard.ts` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
oxlint の全7カテゴリを `error` に上げ、`style` と `nursery` で出た指摘を型を縮める形で潰した。

**修正内容**
- `arch-rules.js` / `arch-rules.test.ts` / `check-md-links.ts` で型上 non-nullish な `?.` と常に真になる条件を落とした。
- `profile-form.tsx` は `"error" in x && x.error !== undefined` の後半を削除。`error` には文字列リテラルしか入らず `{ error: undefined }` の経路が無い。
- `vite.config.ts` の override を理由ごとに分割し、対象群を定数に切り出した。コメントは直下の1ルールだけを説明する。

**off にした4ルール**
- `vitest/no-hooks` は `vitest/require-hook` と要求が正反対で両立しないため全体で off
- `vitest/require-hook` はテストを持たない `*.config.*` と `scripts/**` で off
- `src/test-setup.ts` では `require-top-level-describe` と `no-importing-vitest-globals` を off。`describe` で囲むと cleanup がブロックに閉じ、globals が有効でないため import も消せない

<sup>Written for commit de99d0a46a8dd91dbc323228829c607319a27fc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imaimai17468/imaimai-front-templete/pull/92?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

