### PR TITLE
fix: code-reviewer の報告を読み手が検証できる形にする

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -45,7 +45,9 @@ when it is material.
 ## Stage B: dedup
 
 Merge candidates on the same (file, line): keep the highest severity and fold the rest into
-its description. Sort by severity. Drop nothing.
+its description. Sort by severity. Drop nothing and judge nothing here: a folded candidate
+travels on into Stage C inside the finding that absorbed it, which is what separates a
+`merged` count from the `refuted` one Stage C produces. Count what you folded away.
 
 ## Stage C: refute
 
@@ -56,7 +58,8 @@ to REFUTED when uncertain. You may regrade severity. Add nothing Stage A did not
 You wrote Stage A, so the independence here is yours to supply: re-open the code for each
 candidate instead of trusting what Stage A concluded about it, and put the `file:line` you
 re-read into `verification` for **every** verdict, refutations included. That is what makes
-a judgement passed without opening the code visible in your output.
+a judgement passed without opening the code visible in your output, and Stage D's `Refuted`
+section is where the killed ones stay visible.
 
 Every surviving finding carries two more fields, because the parent applies what you return
 and commits, and nothing downstream judges the remedy.
@@ -74,13 +77,13 @@ field.
 
 ## Stage D: return
 
-Drop REFUTED. Sort survivors by verdict (CONFIRMED first) then severity. Your final message
-is the report, and every label below appears on every finding. A label with nothing to say
-gets one line saying so, because an omitted label reads as "fine" when it usually means
+Sort survivors by verdict (CONFIRMED first) then severity. Your final message is the
+report, and every label below appears on every surviving finding. A label with nothing to
+say gets one line saying so, because an omitted label reads as "fine" when it usually means
 "not checked":
 
 ```markdown
-effort: standard — 7 candidates, 5 refuted
+effort: standard — 7 raised, 2 merged, 3 refuted, 2 returned
 
 ## CONFIRMED · major · src/lib/foo.ts:42 — the retry loop can double-charge
 - **Breaks:** <the failure scenario, concretely>
@@ -88,11 +91,21 @@ effort: standard — 7 candidates, 5 refuted
 - **Verified at:** src/lib/foo.ts:38-47 — <what re-reading showed>
 - **Fix:** <which file, what it says instead, why that shape>
 - **Acceptance:** <the command or the observable that shows it landed>
+
+## Refuted
+- src/lib/bar.ts:12 — the second write can land twice · re-read src/lib/bar.ts:8-20, the
+  caller holds the lock across both
 ```
 
-The counts go in the header even when every candidate died, because a pass that refuted
-everything is a normal outcome and the counts are how anyone can tell Stage C ran. With
-nothing surviving, the header alone is the whole report.
+A refutation gets one line in the `Refuted` section, carrying the `file:line` Stage C
+re-read and what killed it. The parent acts on nothing there.
+
+The four counts name what each stage did: `raised` is what Stage A produced, `merged` is
+what Stage B folded away, and `refuted` and `returned` split what is left, so `raised`
+minus `merged` equals `refuted` plus `returned`. They go in even when every candidate died,
+because a pass that refuted everything is a normal outcome and the counts are how anyone
+can tell Stage C ran. With nothing surviving, the header and the `Refuted` section are the
+whole report.
 
 ## Effort
 

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -29,9 +29,9 @@ would have survived.
 - **cleanup**: duplication, dead code, needless complexity, obvious performance problems,
   drift from surrounding conventions
 - **rules**: read `AGENTS.md`, `.claude/rules/prose.md`, and every path-scoped file under
-  `.claude/rules/` whose scope matches the diff. None of them are auto-loaded here. Set
-  `rule` to the one violated. Invent no rule beyond those files, and never dismiss a
-  finding as pre-existing when the file is in the diff.
+  `.claude/rules/` whose scope matches the diff, whichever of them is not already in your
+  context. Set `rule` to the one violated. Invent no rule beyond those files, and never
+  dismiss a finding as pre-existing when the file is in the diff.
 
 Each candidate needs a location (`file:line`), a one-line title, the failure scenario, a
 first idea for the fix, a severity of critical / major / minor, and the rule it violates

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -114,10 +114,11 @@ counted. A finding whose defect is real and whose supporting sentence is false c
 parent a disproof it should never have had to run.
 
 `.claude/rules/prose.md` binds it too, and its rule on sweeping quantifiers is the one a
-review report breaks most. `every`, `all`, `only`, `none`, `no other` each assert a sweep,
-so run that sweep or narrow the sentence to what you read: "the three tests I opened" is
-worth more than "every test", because the reader can check it. A `Fix` line states force
-rather than a measurement, so the exemption prose.md gives a directive covers it.
+review report breaks most. In a report that rule bites as `every`, `all`, `only`, `none`
+and `no other`, each of which asserts a sweep, so run that sweep or narrow the sentence to
+what you read: "the three tests I opened" is worth more than "every test", because the
+reader can check it. A `Fix` line states force rather than a measurement, so the exemption
+prose.md gives a directive covers it.
 
 State a gap where the claim it limits is: inside the finding whose label rests on it, and
 in the header when it limits the whole pass, such as a suite you never ran.

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -107,6 +107,21 @@ because a pass that refuted everything is a normal outcome and the counts are ho
 can tell Stage C ran. With nothing surviving, the header and the `Refuted` section are the
 whole report.
 
+AGENTS.md's rule on claims binds this report too, not only the diff under review: open or
+run whatever you assert about another file, a dependency, a config value, or a count of any
+of them, in the same pass that writes the sentence, and a count you write is one you
+counted. A finding whose defect is real and whose supporting sentence is false costs the
+parent a disproof it should never have had to run.
+
+`.claude/rules/prose.md` binds it too, and its rule on sweeping quantifiers is the one a
+review report breaks most. `every`, `all`, `only`, `none`, `no other` each assert a sweep,
+so run that sweep or narrow the sentence to what you read: "the three tests I opened" is
+worth more than "every test", because the reader can check it. A `Fix` line states force
+rather than a measurement, so the exemption prose.md gives a directive covers it.
+
+State a gap where the claim it limits is: inside the finding whose label rests on it, and
+in the header when it limits the whole pass, such as a suite you never ran.
+
 ## Effort
 
 **standard** (default): Stage C uses one reproduction lens. **high**: three lenses per

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -83,7 +83,7 @@ say gets one line saying so, because an omitted label reads as "fine" when it us
 "not checked":
 
 ```markdown
-effort: standard — 7 raised, 2 merged, 3 refuted, 2 returned
+effort: standard — 3 raised, 1 merged, 1 refuted, 1 returned
 
 ## CONFIRMED · major · src/lib/foo.ts:42 — the retry loop can double-charge
 - **Breaks:** <the failure scenario, concretely>

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -113,12 +113,13 @@ of them, in the same pass that writes the sentence, and a count you write is one
 counted. A finding whose defect is real and whose supporting sentence is false costs the
 parent a disproof it should never have had to run.
 
-`.claude/rules/prose.md` binds it too, and its rule on sweeping quantifiers is the one a
-review report breaks most. In a report that rule bites as `every`, `all`, `only`, `none`
-and `no other`, each of which asserts a sweep, so run that sweep or narrow the sentence to
-what you read: "the three tests I opened" is worth more than "every test", because the
-reader can check it. A `Fix` line states force rather than a measurement, so the exemption
-prose.md gives a directive covers it.
+`.claude/rules/prose.md` binds it too, and its rule on sweeping quantifiers is one a review
+report has to keep. A report also sweeps in the opposite direction, with `only`, `none` and
+`no other`, which that rule does not name: an unchecked "the only caller" claims as much as
+an unchecked "every caller". Run the sweep either way, or narrow the sentence to what you
+read: "the three tests I opened" is worth more than "every test", because the reader can
+check it. A `Fix` line states force rather than a measurement, so the exemption prose.md
+gives a directive covers it.
 
 State a gap where the claim it limits is: inside the finding whose label rests on it, and
 in the header when it limits the whole pass, such as a suite you never ran.


### PR DESCRIPTION
`code-reviewer` エージェントの Stage B / C / D を変更します。`empirical-prompt-tuning` skill で実測し、数値が動いた変更だけを入れています。

## 測り方

実リポジトリのクローンに既知の欠陥を埋めた fixture を 3 本作りました。

| | 差分 | 埋めた欠陥 |
|---|---|---|
| A | bio フィールド追加の機能差分 9 ファイル | 12 件（critical 4） |
| B | gateway 層のリネーム掃引 11 ファイル | 6 件（critical 2） |
| C | `@/` → `~/` codemod 34 ファイル | 9 件（critical 4） |

各版を白紙の実行者に走らせ、別のエージェントに正解表と突き合わせさせています。実行者には欠陥リストを渡していません。

## 何が変わったか

### 1. 却下した候補の検証記録が報告に残る（b75e316）

Stage C が「REFUTED を含む全 verdict の verification を出力に残せ、それがコードを開かずに下した判断を可視にする」と要求する一方、Stage D が `Drop REFUTED` と命じていて両立しませんでした。**6 名の実行者が全員この矛盾を報告し、6 通りの回避を発明していました。**

Stage D に `Refuted` 節を定義して Drop を外し、ヘッダを `raised / merged / refuted / returned` の 4 数に分解しています。旧来の `7 candidates, 5 refuted` は dedup 前とも後とも読め、3 本の実行が別々に数値を併記していました。

### 2. 報告が自分の根拠を実物で確かめてから書く（9b416ef）

報告の根拠節に含まれる検証可能な主張を専任の監査者に突き合わせさせたところ、**偽が 319 件中 19 件（6.0%）**ありました。

- 「`package.json` に `vitest` が無い」→ 86 行に direct devDependency として存在。しかも報告が根拠に引いた grep コマンド自体が主張を否定していた
- 「34 ファイル中 30 がエイリアスのみ」→ 実際は 29
- 「周囲のテストは**全て** `should` で始まる」→ 同ディレクトリに反例が 7 件

欠陥の指摘は当たっているのに添えた一文が偽なので、受け取る側が不要な確認をすることになります。AGENTS.md の主張規則と prose.md の量化子規則が報告書自身にも及ぶと明示しました。規則の本文は写さず、両ファイルを指しています。

### 3. rules レンズが読み込み済みのファイルを読み直さない（b9724e5）

`None of them are auto-loaded here` が 4 ファイルのうち 2 つで偽でした。`CLAUDE.md` が `AGENTS.md` を import し、`prose.md` は `alwaysApply: true` なので、どちらも起動時点で文脈にあります。この PR の差分をレビューさせた実行で、実際に 2 ファイルぶんの読み直しが起きました。

## 結果

| 指標 | 変更前 | 変更後 |
|---|---|---|
| 再現率（欠陥 27 件） | 27/27 | 27/27 |
| critical 充足（10 件） | 10/10 | 10/10 |
| 根拠節の偽の主張 | 19/319 = 6.0% | **6/251 = 2.4%** |
| うち全称形 | 4 | **1** |
| tool_uses 合計 | 71 | 71 |

**発見力ではなく報告の信頼性が上がっています。** 埋めた欠陥 27 件は変更前の時点で全部見つかっていて、そこは動いていません。動いたのは根拠の文が実物と食い違う率です。コストは据え置きです。

## 入れなかったもの

Stage A を「依存順のファイル単位 walk + ファイル横断パス」の 2 パスに変える案を測りましたが、3 シナリオとも再現率が 27/27 で変わらず、tool_uses だけ 18% 増えたので不採用にしました。現行版が全問正解していて、walk が回収するものが残っていません。34 ファイル規模でも注意の希薄化は起きませんでした。

## 残した曖昧さ

severity の境界、Stage B の統合粒度、`raised` の数え方、effort の指定手段、diff 外ファイルの扱い。実行者は毎回これらを裁量補完として申告しますが、**18 回の実行で欠陥の取りこぼしにも偽の主張にも繋がっていません**。影響はヘッダの counts が実行間で比較しづらいことだけです。

## この PR 自身のレビュー

変更後の `code-reviewer` にこの差分を掛け、返った 4 件のうち 3 件を反映しました（重複した論拠の削除、`every surviving finding` への限定、上記 3 番）。残る 1 件は量化子リストが prose.md と食い違うという PLAUSIBLE で、リストは実測に掛けた版そのものなので残し、prose.md の directive 免除だけを足しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U75q9erqvBJTjewiZ3kGLt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the `code-reviewer` agent's report verifiable against the actual files, halving false claims without changing defect detection (recall stays 27/27, critical 10/10, tool_uses unchanged at 71).

- Refuted candidates now stay in a `Refuted` section instead of being dropped, resolving the conflict between Stage C's verify-everything requirement and Stage D's drop instruction.
- Header counts split into `raised / merged / refuted / returned` so the numbers mean the same thing across runs.
- The report now binds itself to `AGENTS.md`'s claim rule and `prose.md`'s sweeping-quantifier rule; measured false claims dropped from 19/319 (6.0%) to 6/251 (2.4%).
- The `rules` lens skips files already loaded in context (`AGENTS.md` via `CLAUDE.md` import, `prose.md` via `alwaysApply`) instead of re-reading them.
- Tightens the template's own truthfulness: the header example is arithmetically consistent, and the reverse-sweep words (`only`, `none`) are framed as this file's own addition, separate from `prose.md`'s broad-quantifier rule.

<sup>Written for commit 89cc1e9c53109cf4b6f381eb4fc1ad0470e3ef8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imaimai17468/imaimai-front-templete/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

