### PR TITLE
feat: ローディング中のプレースホルダに Skeleton を使えるようにする

### DIFF
--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,14 @@
+import type * as React from "react";
+import { cn } from "@/lib/utils";
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };


### PR DESCRIPTION
## 変更

`src/components/ui/skeleton.tsx` を追加する。shadcn/ui new-york の Skeleton で、`card.tsx` と同じく `cn` を `@/lib/utils` から import し、`data-slot="skeleton"` を付ける。

## 取った前提

- 生成は `bunx shadcn@latest add skeleton --yes` で行った。CLI は registry の依存 `cn` を npm パッケージ `cn@0.1.1` として `package.json` に追加し、`import { cn } from "cn"` を書いたので、その 2 ファイルの変更を戻し、import を `@/lib/utils` に直した。
- 背景トークンは registry の `bg-accent` を `bg-muted` に変えた。`.claude/rules/design.md` の Accent Color がアプリ UI では accent を操作要素に限ると定めており、既存の非操作面（`avatar.tsx` のフォールバック、`code-block.tsx`）はどちらも `bg-muted` を使っている。`src/styles.css` では現在 `--muted` と `--accent` が同じ値なので、見た目は今のところ変わらない。registry との差分が残る点は承知のうえで、トークンの意味を優先した。
- テストは置かない。Skeleton には分岐も state もなく、`src/components/ui/` の既存 8 コンポーネントにもテストはない。`src/components/ui/**` は knip の entry なので、未使用の export でも knip は通る。

## 確認

- `bun run check`、`bun run test`（14 files / 379 tests）、`bun run knip`、`similarity-ts src` を worktree で実行し、いずれも通過。
- pre-commit（react-doctor / format / lint）と pre-push（actionlint / cf-typegen-check / check / similarity / toolchain-pins）も通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `Skeleton` component for loading placeholders, based on shadcn/ui's new-york Skeleton. The background uses `bg-muted` instead of the registry's `bg-accent` to keep accent reserved for interactive elements, matching existing non-interactive components. No tests are included since the component has no branching or state, consistent with the other `src/components/ui/` components.

<sup>Written for commit 05c37d976b23e49f84e6b6890589fa1139fd4b12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imaimai17468/imaimai-front-templete/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

