### PR TITLE
feat: Badge コンポーネントを shadcn の流儀で追加する

### DIFF
--- a/src/components/ui/badge.test.tsx
+++ b/src/components/ui/badge.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import { Badge } from "./badge";
+
+describe(Badge, () => {
+  it("should render a span when asChild is omitted", () => {
+    render(<Badge>New</Badge>);
+
+    const badge = screen.getByText("New");
+
+    expect({
+      tagName: badge.tagName,
+      slot: badge.dataset.slot,
+      variant: badge.dataset.variant,
+    }).toStrictEqual({ tagName: "SPAN", slot: "badge", variant: "default" });
+  });
+
+  it("should render the child element when asChild is true", () => {
+    render(
+      <Badge asChild variant="outline">
+        <a href="/releases">Releases</a>
+      </Badge>
+    );
+
+    const badge = screen.getByRole("link", { name: "Releases" });
+
+    expect({
+      tagName: badge.tagName,
+      slot: badge.dataset.slot,
+      variant: badge.dataset.variant,
+    }).toStrictEqual({ tagName: "A", slot: "badge", variant: "outline" });
+  });
+
+  it("should keep the caller's class when className conflicts with a variant class", () => {
+    render(<Badge className="rounded-md">Tag</Badge>);
+
+    const badge = screen.getByText("Tag");
+
+    expect({
+      hasCaller: badge.classList.contains("rounded-md"),
+      hasVariant: badge.classList.contains("rounded-full"),
+    }).toStrictEqual({ hasCaller: true, hasVariant: false });
+  });
+});

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,47 @@
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+import type * as React from "react";
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        secondary:
+          "bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        destructive:
+          "bg-destructive text-white focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40 [a&]:hover:bg-destructive/90",
+        outline:
+          "border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        ghost: "[a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 [a&]:hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+function Badge({
+  className,
+  variant = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : "span";
+
+  return (
+    <Comp
+      data-slot="badge"
+      data-variant={variant}
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+export { Badge, badgeVariants };


### PR DESCRIPTION
## 変更

`src/components/ui/badge.tsx` を `bunx shadcn@latest add badge` で生成し、`src/components/ui/button.tsx` と同じ import 元（`Slot` は `@radix-ui/react-slot`、`cn` は `@/lib/utils`）に書き換えた。`asChild` の分岐と `className` のマージ順を `src/components/ui/badge.test.tsx` で押さえる。

## 取った前提

- CLI は `import { cn } from "cn"` と `import { Slot } from "radix-ui"` を出力し、npm パッケージ `cn` と `radix-ui` を package.json に追加した。既存の `@radix-ui/react-slot` と `src/lib/utils.ts` で同じものが賄えるため、この 2 依存は入れず、import 先を button.tsx に揃えた。
- cva の variant 文字列は shadcn 上流の badge をそのまま使い、スタイルは変えていない。
- コンポーネントなので `vitest.config.mts` の coverage include には足していない（AGENTS.md Testing 節）。

## 検証

- `bun run check`、`bun run test`（15 files / 382 tests）、`bun run knip`、`similarity-ts ./src --fail-on-duplicates` を worktree で実行し、いずれも通過。
- code-reviewer は 6 候補を挙げ、いずれも実コードで反証され、返された指摘は 0 件。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `Badge` component following shadcn conventions, reusing the existing `@radix-ui/react-slot` and `@/lib/utils` imports.

- Uses upstream cva variants for the badge styles.
- Tests cover `asChild` rendering and `className` merge order.

<sup>Written for commit 70f8a128edb5349101cdc2445d435cc57a316b36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imaimai17468/imaimai-front-templete/pull/110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

