### PR TITLE
feat: Alert コンポーネントを shadcn の流儀で追加する

### DIFF
--- a/src/components/ui/alert.test.tsx
+++ b/src/components/ui/alert.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import { Alert, AlertDescription, AlertTitle } from "./alert";
+
+describe(Alert, () => {
+  it("should render an alert-role div with the default variant colors when variant is omitted", () => {
+    render(<Alert>Backup finished</Alert>);
+
+    const alert = screen.getByRole("alert");
+
+    expect({
+      tagName: alert.tagName,
+      slot: alert.dataset.slot,
+      hasDefault: alert.classList.contains("text-card-foreground"),
+      hasDestructive: alert.classList.contains("text-destructive"),
+    }).toStrictEqual({
+      tagName: "DIV",
+      slot: "alert",
+      hasDefault: true,
+      hasDestructive: false,
+    });
+  });
+
+  it("should render the destructive colors when variant is destructive", () => {
+    render(<Alert variant="destructive">Backup failed</Alert>);
+
+    const alert = screen.getByRole("alert");
+
+    expect({
+      slot: alert.dataset.slot,
+      hasDefault: alert.classList.contains("text-card-foreground"),
+      hasDestructive: alert.classList.contains("text-destructive"),
+    }).toStrictEqual({
+      slot: "alert",
+      hasDefault: false,
+      hasDestructive: true,
+    });
+  });
+
+  it("should keep the caller's class when className conflicts with a base class", () => {
+    render(<Alert className="rounded-none">Backup queued</Alert>);
+
+    const alert = screen.getByRole("alert");
+
+    expect({
+      hasCaller: alert.classList.contains("rounded-none"),
+      hasBase: alert.classList.contains("rounded-lg"),
+    }).toStrictEqual({ hasCaller: true, hasBase: false });
+  });
+});
+
+describe(AlertTitle, () => {
+  it("should render a div with the alert-title slot when className is omitted", () => {
+    render(<AlertTitle>Update available</AlertTitle>);
+
+    const title = screen.getByText("Update available");
+
+    expect({
+      tagName: title.tagName,
+      slot: title.dataset.slot,
+    }).toStrictEqual({ tagName: "DIV", slot: "alert-title" });
+  });
+
+  it("should keep the caller's class when className conflicts with a base class", () => {
+    render(<AlertTitle className="font-bold">Update available</AlertTitle>);
+
+    const title = screen.getByText("Update available");
+
+    expect({
+      hasCaller: title.classList.contains("font-bold"),
+      hasBase: title.classList.contains("font-medium"),
+    }).toStrictEqual({ hasCaller: true, hasBase: false });
+  });
+});
+
+describe(AlertDescription, () => {
+  it("should render a div with the alert-description slot when className is omitted", () => {
+    render(<AlertDescription>Version 2 is ready</AlertDescription>);
+
+    const description = screen.getByText("Version 2 is ready");
+
+    expect({
+      tagName: description.tagName,
+      slot: description.dataset.slot,
+    }).toStrictEqual({ tagName: "DIV", slot: "alert-description" });
+  });
+
+  it("should keep the caller's class when className conflicts with a base class", () => {
+    render(
+      <AlertDescription className="text-base">
+        Version 2 is ready
+      </AlertDescription>
+    );
+
+    const description = screen.getByText("Version 2 is ready");
+
+    expect({
+      hasCaller: description.classList.contains("text-base"),
+      hasBase: description.classList.contains("text-sm"),
+    }).toStrictEqual({ hasCaller: true, hasBase: false });
+  });
+});

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,65 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import type * as React from "react";
+import { cn } from "@/lib/utils";
+
+const alertVariants = cva(
+  "relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 rounded-lg border px-4 py-3 text-sm has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-[>svg]:gap-x-3 [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 [&>svg]:text-current",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "col-start-2 grid justify-items-start gap-1 text-sm text-muted-foreground [&_p]:leading-relaxed",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Alert, AlertDescription, AlertTitle };


### PR DESCRIPTION
## 変更

`src/components/ui/alert.tsx` を shadcn の new-york-v4 レジストリ（`https://ui.shadcn.com/r/styles/new-york-v4/alert.json`）の出力から取り込み、import 元を `src/components/ui/badge.tsx` と同じ `@/lib/utils` の `cn` に書き換えた。variant の default / destructive の分岐と、`Alert` / `AlertTitle` / `AlertDescription` それぞれの `className` マージを `src/components/ui/alert.test.tsx` で押さえる。

## 取った前提

- レジストリは `import { cn } from "cn"` を出力し、npm パッケージ `cn` を依存に挙げる。既存の `src/lib/utils.ts` が同じ関数を持つため、この依存は入れず import 先を差し替えた。追加した npm パッケージはない。
- Alert は Radix の primitive を使わないため、`radix-ui` からは何も import していない。
- cva の variant 文字列とクラス文字列は上流の alert をそのまま使い、スタイルは変えていない。
- 上流の alert は `alertVariants` を export しないので、こちらも export していない。badge.tsx が `badgeVariants` を export しているのは上流の badge がそうしているからで、方針は「上流の export リストに合わせる」に置いた。`knip.json` は `src/components/ui/**` を entry に挙げるため、どちらを選んでも knip は通る。
- 上流の alert は badge と違って `data-variant` 属性を出さない。そのため variant の分岐はクラス名（`text-card-foreground` / `text-destructive`）で検証している。属性を足せばテストは読みやすくなるが、上流の出力から離れるので取らなかった。
- コンポーネントなので `vitest.config.mts` の coverage include には足していない（AGENTS.md Testing 節）。

## 検証

- `bun run check`、`bun run test`（17 files / 410 tests）、`bun run knip`、`bun run doctor --no-score`、`bun run check:pins`、`similarity-ts ./src --fail-on-duplicates` を worktree で実行し、いずれも通過。
- code-reviewer は 7 候補を挙げ、5 件が実コードで反証、1 件が判断待ちとして返され、確定した指摘は 1 件。最初のテスト名 `should render a div with the alert role when variant is omitted` が、実際には default variant の色まで assert しているのに名前が role と要素しか語っていなかった。`should render an alert-role div with the default variant colors when variant is omitted` に直し、初回コミットに含めた。
- レビュアーは `src/components/ui/badge.test.tsx:6` の `should render a span when asChild is omitted` にも同じずれがあると指摘した。このチケットの範囲外なので触っていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the shadcn-style `Alert`, `AlertTitle`, and `AlertDescription` components to `src/components/ui/alert.tsx` with default and destructive variants.

- Imports `cn` from `@/lib/utils` instead of adding the `cn` npm package the upstream registry lists as a dependency.
- Adds no new dependencies; no Radix primitives are used.
- Tests cover variant class branches and caller `className` merging for all three components.

<sup>Written for commit f5fb760db5fd56cd8bb05cfdd3aae8ffd0836576. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imaimai17468/imaimai-front-templete/pull/115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

