### PR TITLE
feat: Separator コンポーネントを shadcn の流儀で追加する

### DIFF
--- a/src/components/ui/separator.test.tsx
+++ b/src/components/ui/separator.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import { Separator } from "./separator";
+
+describe(Separator, () => {
+  it("should render a decorative horizontal rule when orientation and decorative are omitted", () => {
+    render(<Separator data-testid="separator" />);
+
+    const separator = screen.getByTestId("separator");
+
+    expect({
+      slot: separator.dataset.slot,
+      orientation: separator.dataset.orientation,
+      role: separator.getAttribute("role"),
+    }).toStrictEqual({
+      slot: "separator",
+      orientation: "horizontal",
+      role: "none",
+    });
+  });
+
+  it("should expose the separator role when decorative is false", () => {
+    render(<Separator data-testid="separator" decorative={false} />);
+
+    const separator = screen.getByTestId("separator");
+
+    expect({
+      role: separator.getAttribute("role"),
+      ariaOrientation: separator.getAttribute("aria-orientation"),
+    }).toStrictEqual({ role: "separator", ariaOrientation: null });
+  });
+
+  it("should announce a vertical orientation when orientation is vertical", () => {
+    render(
+      <Separator
+        data-testid="separator"
+        decorative={false}
+        orientation="vertical"
+      />
+    );
+
+    const separator = screen.getByTestId("separator");
+
+    expect({
+      orientation: separator.dataset.orientation,
+      ariaOrientation: separator.getAttribute("aria-orientation"),
+    }).toStrictEqual({ orientation: "vertical", ariaOrientation: "vertical" });
+  });
+
+  it("should drop only the conflicting base class when className overrides one of them", () => {
+    render(<Separator className="bg-transparent" data-testid="separator" />);
+
+    const separator = screen.getByTestId("separator");
+
+    expect({
+      hasCaller: separator.classList.contains("bg-transparent"),
+      hasConflictingBase: separator.classList.contains("bg-border"),
+      hasUnrelatedBase: separator.classList.contains("shrink-0"),
+    }).toStrictEqual({
+      hasCaller: true,
+      hasConflictingBase: false,
+      hasUnrelatedBase: true,
+    });
+  });
+});

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { Separator as SeparatorPrimitive } from "radix-ui";
+import type * as React from "react";
+import { cn } from "@/lib/utils";
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      data-slot="separator"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Separator };


### PR DESCRIPTION
## 変更

`src/components/ui/separator.tsx` と `src/components/ui/separator.test.tsx` を追加した。

shadcn レジストリ `new-york-v4` の `separator` 出力をそのまま起点にして、`cn` の import 元だけを `@/lib/utils` に差し替えた。この出力は Radix の primitive を統合パッケージ `radix-ui` から import する形になっていて、`avatar.tsx` や `label.tsx` や `badge.tsx` の現在の書き方と一致する。`radix-ui` / `clsx` / `tailwind-merge` はすでに依存にあるので、npm パッケージは追加していない。

## テスト

`separator.tsx` が足した分岐は `orientation = "horizontal"` と `decorative = true` の 2 つの既定値だけで、4 本のテストが既定値を使う経路と明示的に渡す経路の両方を通る。

class 文字列が効いているかも 1 本で押さえた。`separator.tsx` の class 文字列を `""` に置き換えて `bunx vitest run src/components/ui/separator.test.tsx` を走らせると `should drop only the conflicting base class when className overrides one of them` が落ち、戻すと 4 本とも通ることを確認した。

decorative な separator は Radix が `role="none"` を付けるので `getByRole` から引けない。そこで 4 本とも `data-testid` で引いている。この属性は `separator.tsx` には書かれておらず、`{...props}` のスプレッド経由で DOM に届くだけなので、テスト専用の prop を component 側に足してはいない。

## 検証

`bun run check`、`bun run test`（17 files / 407 tests）、`bun run knip`、`similarity-ts` がいずれも通る。

## 前提

ルートやページへの組み込みはこのチケットの外にした。Badge を足したコミット 25adacf も 2 ファイルだけを足していて、それに合わせている。

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the shadcn-style Separator component and its tests. It's taken from the `new-york-v4` registry output with only the `cn` import changed to `@/lib/utils`, and it uses the `radix-ui` package already in dependencies, so no npm packages are added.

**Behavior**
- Defaults to `orientation="horizontal"` and `decorative=true`, merging `className` over base classes via `cn`.
- Four tests cover default paths, explicit overrides, and class merging.
- `bun run check`, `bun run test` (17 files / 407 tests), `bun run knip`, and `similarity-ts` all pass.
- Page integration is out of scope, matching the earlier Badge addition.

<sup>Written for commit 6ea991d2cb91a5e6faee8fa4bd67a74a7b219f19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imaimai17468/imaimai-front-templete/pull/116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

