### PR TITLE
feat: Tooltip コンポーネントを shadcn の流儀で追加する

### DIFF
--- a/src/components/ui/tooltip.test.tsx
+++ b/src/components/ui/tooltip.test.tsx
@@ -1,0 +1,99 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./tooltip";
+
+type ProviderOptions = {
+  delayDuration?: number;
+};
+
+const renderTooltip = (provider: ProviderOptions = {}, className?: string) =>
+  render(
+    <TooltipProvider {...provider}>
+      <Tooltip>
+        <TooltipTrigger>保存</TooltipTrigger>
+        <TooltipContent className={className}>下書きを保存する</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+
+const hoverTriggerAndAdvance = (ms: number) => {
+  act(() => {
+    fireEvent.pointerMove(screen.getByRole("button", { name: "保存" }), {
+      pointerType: "mouse",
+    });
+    vi.advanceTimersByTime(ms);
+  });
+};
+
+describe(Tooltip, () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should render the trigger alone when the pointer has not entered it", () => {
+    renderTooltip();
+
+    const trigger = screen.getByRole("button", { name: "保存" });
+
+    expect({
+      slot: trigger.dataset.slot,
+      state: trigger.dataset.state,
+      content: screen.queryByRole("tooltip"),
+    }).toStrictEqual({
+      slot: "tooltip-trigger",
+      state: "closed",
+      content: null,
+    });
+  });
+
+  it("should open the content on the tick the pointer enters when delayDuration is omitted", () => {
+    vi.useFakeTimers();
+    renderTooltip();
+
+    hoverTriggerAndAdvance(0);
+
+    const content = screen.getByRole("tooltip");
+
+    expect({
+      slot: content.dataset.slot,
+      text: content.textContent,
+    }).toStrictEqual({ slot: "tooltip-content", text: "下書きを保存する" });
+  });
+
+  it("should leave the content closed when less than the provider's delayDuration has elapsed", () => {
+    vi.useFakeTimers();
+    renderTooltip({ delayDuration: 700 });
+
+    hoverTriggerAndAdvance(699);
+
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
+  it("should open the content when the provider's delayDuration has elapsed", () => {
+    vi.useFakeTimers();
+    renderTooltip({ delayDuration: 700 });
+
+    hoverTriggerAndAdvance(700);
+
+    expect(screen.getByRole("tooltip").textContent).toBe("下書きを保存する");
+  });
+
+  it("should keep the caller's class when className conflicts with a content class", () => {
+    vi.useFakeTimers();
+    renderTooltip({}, "rounded-none");
+
+    hoverTriggerAndAdvance(0);
+
+    const content = screen.getByRole("tooltip");
+
+    expect({
+      hasCaller: content.classList.contains("rounded-none"),
+      hasDefault: content.classList.contains("rounded-md"),
+    }).toStrictEqual({ hasCaller: true, hasDefault: false });
+  });
+});

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Tooltip as TooltipPrimitive } from "radix-ui";
+import type * as React from "react";
+import { cn } from "@/lib/utils";
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  );
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
+}
+
+function TooltipContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        className={cn(
+          "z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-md bg-foreground px-3 py-1.5 text-xs text-balance text-background fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="relative -top-0.5 z-50 size-2.5 -translate-y-1/2 rotate-45 rounded-xs bg-foreground fill-foreground" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  );
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -10,6 +10,7 @@ import { TanStackRouterDevtoolsPanel } from "@tanstack/react-router-devtools";
 import { Header } from "@/components/shared/header/header";
 import { ThemeProvider } from "@/components/shared/theme-provider/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { getCurrentUserFn } from "@/server/fn/user";
 import "@/styles.css";
 
@@ -31,15 +32,17 @@ const RootComponent = () => {
           enableSystem={false}
           disableTransitionOnChange
         >
-          <div className="flex min-h-dvh flex-col gap-16">
-            <Header user={user} />
-            <div className="flex w-full flex-1 justify-center px-6 md:px-4">
-              <div className="container w-full">
-                <Outlet />
+          <TooltipProvider>
+            <div className="flex min-h-dvh flex-col gap-16">
+              <Header user={user} />
+              <div className="flex w-full flex-1 justify-center px-6 md:px-4">
+                <div className="container w-full">
+                  <Outlet />
+                </div>
               </div>
             </div>
-          </div>
-          <Toaster richColors position="top-center" />
+            <Toaster richColors position="top-center" />
+          </TooltipProvider>
         </ThemeProvider>
         <TanStackDevtools
           plugins={[

--- a/src/styles.css
+++ b/src/styles.css
@@ -35,6 +35,7 @@
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
+  --radius-xs: calc(var(--radius) * 0.4);
   --radius-sm: calc(var(--radius) * 0.6);
   --radius-md: calc(var(--radius) * 0.8);
   --radius-lg: var(--radius);

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,6 +1,16 @@
 import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
-import { afterEach } from "vite-plus/test";
+import { afterEach, vi } from "vite-plus/test";
+
+// jsdom は ResizeObserver を持たないが、Radix の Popper が Arrow の
+// 寸法を測るのに使う。
+class ResizeObserverStub implements ResizeObserver {
+  observe = vi.fn<() => void>();
+  unobserve = vi.fn<() => void>();
+  disconnect = vi.fn<() => void>();
+}
+
+globalThis.ResizeObserver = ResizeObserverStub;
 
 afterEach(() => {
   cleanup();


### PR DESCRIPTION
## 変更

shadcn の new-york-v4 レジストリの `tooltip` 出力を `src/components/ui/tooltip.tsx` に取り込み、import 元を `src/components/ui/badge.tsx` と同じ `radix-ui`（統合パッケージ）と `@/lib/utils` に揃えた。`TooltipProvider` の `delayDuration = 0` 既定と caller の値を使う経路を `src/components/ui/tooltip.test.tsx` で押さえる。`src/routes/__root.tsx` に `TooltipProvider` を置く変更は独立に revert できるので別コミットにした。

## export する部品

`Tooltip` / `TooltipTrigger` / `TooltipContent` / `TooltipProvider` の 4 つを出す。provider を落とせない理由は Radix の実装にある。`createTooltipContext("TooltipProvider")` に既定値がないため、provider の子孫でない `Tooltip` は `` `Tooltip` must be used within `TooltipProvider` `` を投げる。そのうえで `isOpenDelayedRef` は provider が持ち、その配下の `Tooltip` 全部で共有される。

そこで `__root.tsx` の `ThemeProvider` 直下に provider を 1 つ置き、レイアウトと `Toaster` の両方をその内側に入れた。呼び出し側は `Tooltip` を書くだけでよく、隣り合う 2 つの tooltip の間でポインタを動かしたときの skip delay も効く。

採らなかった案は `Tooltip` が内側に `TooltipProvider` を描画する形（shadcn の旧版）で、これだと tooltip ごとに provider が生まれて `isOpenDelayedRef` が分かれるため、隣の tooltip に移っても毎回 delay を待ち直すことになる。

## shadcn 出力から変えた 2 点

1. `TooltipContent` の `sideOffset = 0` を落とした。`@radix-ui/react-popper` の `PopperContent` 自身が `sideOffset = 0` を既定にしているので同じ値の書き直しで、テストの届かない分岐が増えるだけだった。caller が渡す `sideOffset` は `{...props}` がそのまま通す。
2. Arrow の `translate-y-[calc(-50%_-_2px)]` と `rounded-[2px]` を書き換えた。どちらも `tools/oxlint-plugins/style-rules.js` の `no-tailwind-arbitrary` が落とす。前者は `relative -top-0.5 -translate-y-1/2`、後者は `src/styles.css` の `@theme inline` に `--radius-xs: calc(var(--radius) * 0.4)` を足したうえでの `rounded-xs`。

## 取った前提

- Arrow の 2px を `-mt-0.5` で与える案を最初に書いたが、Radix は arrow の wrapper span の高さを `useSize` で読んで offset middleware に渡すため、負の margin だと wrapper が 10px から 8px に縮み、content が trigger に 2px 寄る。Chrome で 3 案を計測し、`position: relative` + `top: -2px` なら wrapper の高さも svg の描画位置も元の式と一致することを確認して差し替えた。
- `rounded-xs` は上流の 2px に対して 4px になる。`.claude/rules/design.md` の Shapes 節が `--radius` から導いた集合の外の値を禁じているため、Tailwind 既定の `--radius-xs`（0.125rem）を使わず、`sm 0.6` の下に `0.4` を足してスケールの算術を続けた。`rounded-xs` は他のどこからも使われていない。
- `TooltipProvider` と `Tooltip` の `data-slot` は DOM に出ない。Radix の Provider と Root はどちらもコンテキストしか描画せず rest props を撒かないため落ちる。同じことが `src/components/ui/dropdown-menu.tsx` の `data-slot="dropdown-menu"` にも当てはまるので、ディレクトリ内の一貫性と次の `shadcn add` との差分を優先して残した。落とすなら dropdown-menu と揃えて別チケットで扱いたい。
- jsdom に `ResizeObserver` がなく Radix の Popper が Arrow の寸法測定に使うため、`src/test-setup.ts` にスタブを置いた。この行を消すと tooltip のテストが 5 件中 3 件 `ReferenceError` で落ちる。
- コンポーネントなので `vitest.config.mts` の coverage include には足していない（AGENTS.md Testing 節）。

## 検証

- `bun run check`、`bun run test`（17 files / 408 tests）、`bun run knip`、`similarity-ts ./src`、`bun run build` を worktree で実行し、いずれも通過。
- `delayDuration = 0` の既定を 700 に変えると「delayDuration is omitted」のテストが落ち、`delayDuration={0}` とハードコードすると「provider's delayDuration」のテストが落ちることを実際に走らせて確認した。
- code-reviewer は 11 候補から 5 件を返した。Arrow の margin、テストヘルパの無意味な条件 spread、コミット分割、`Toaster` を provider の内側へ移す件は反映済み。`data-slot` の件は上に書いた理由で残した。
- ブラウザでの目視は未実施（Tooltip を使う画面がまだない）。Arrow の幾何だけは Chrome で計測した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shadcn-style `Tooltip` component so any route can show tooltips without per-component wiring.

- Exports `Tooltip`, `TooltipTrigger`, `TooltipContent`, and `TooltipProvider` with a default `delayDuration` of 0; tests cover the default and provider-passed values.
- Wraps the layout and `Toaster` in `TooltipProvider` in `__root.tsx`; this change is a separate commit and can be reverted independently.
- Replaces Tailwind arbitrary values that the oxlint style rule forbids; Arrow geometry was measured in Chrome to confirm parity with the original shadcn output.
- Adds `--radius-xs` (0.4 × `--radius`) to `styles.css` instead of Tailwind's default to stay inside the design's radius scale.
- Adds a `ResizeObserver` stub to `test-setup.ts` because jsdom lacks it and Radix Popper needs it for Arrow sizing.

<sup>Written for commit 2394a93c3b2521e53fd9a726c7d1c62a1e7c59a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imaimai17468/imaimai-front-templete/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

