### PR TITLE
test: Badge のテストが base クラスの消失とテスト名の不一致を捉えるようにする

### DIFF
--- a/src/components/ui/badge.test.tsx
+++ b/src/components/ui/badge.test.tsx
@@ -32,18 +32,27 @@ describe(Badge, () => {
   });
 
   it("should drop only the conflicting base class when className overrides one of them", () => {
-    render(<Badge className="rounded-md">Tag</Badge>);
+    render(
+      <>
+        <Badge>Plain</Badge>
+        <Badge className="rounded-md">Tag</Badge>
+      </>
+    );
 
-    const badge = screen.getByText("Tag");
+    const plain = screen.getByText("Plain");
+    const overridden = screen.getByText("Tag");
 
     expect({
-      hasCaller: badge.classList.contains("rounded-md"),
-      hasConflictingBase: badge.classList.contains("rounded-full"),
-      hasUnrelatedBase: badge.classList.contains("inline-flex"),
+      plainHasConflictingBase: plain.classList.contains("rounded-full"),
+      overriddenHasCaller: overridden.classList.contains("rounded-md"),
+      overriddenHasConflictingBase:
+        overridden.classList.contains("rounded-full"),
+      overriddenHasUnrelatedBase: overridden.classList.contains("inline-flex"),
     }).toStrictEqual({
-      hasCaller: true,
-      hasConflictingBase: false,
-      hasUnrelatedBase: true,
+      plainHasConflictingBase: true,
+      overriddenHasCaller: true,
+      overriddenHasConflictingBase: false,
+      overriddenHasUnrelatedBase: true,
     });
   });
 });

--- a/src/components/ui/badge.test.tsx
+++ b/src/components/ui/badge.test.tsx
@@ -31,14 +31,19 @@ describe(Badge, () => {
     }).toStrictEqual({ tagName: "A", slot: "badge", variant: "outline" });
   });
 
-  it("should keep the caller's class when className conflicts with a variant class", () => {
+  it("should drop only the conflicting base class when className overrides one of them", () => {
     render(<Badge className="rounded-md">Tag</Badge>);
 
     const badge = screen.getByText("Tag");
 
     expect({
       hasCaller: badge.classList.contains("rounded-md"),
-      hasVariant: badge.classList.contains("rounded-full"),
-    }).toStrictEqual({ hasCaller: true, hasVariant: false });
+      hasConflictingBase: badge.classList.contains("rounded-full"),
+      hasUnrelatedBase: badge.classList.contains("inline-flex"),
+    }).toStrictEqual({
+      hasCaller: true,
+      hasConflictingBase: false,
+      hasUnrelatedBase: true,
+    });
   });
 });

--- a/src/components/ui/badge.test.tsx
+++ b/src/components/ui/badge.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vite-plus/test";
 import { Badge } from "./badge";
 
 describe(Badge, () => {
-  it("should render a span when asChild is omitted", () => {
+  it("should render a span with the default variant when asChild and variant are omitted", () => {
     render(<Badge>New</Badge>);
 
     const badge = screen.getByText("New");
@@ -15,7 +15,7 @@ describe(Badge, () => {
     }).toStrictEqual({ tagName: "SPAN", slot: "badge", variant: "default" });
   });
 
-  it("should render the child element when asChild is true", () => {
+  it("should render the child element with the given variant when asChild is true", () => {
     render(
       <Badge asChild variant="outline">
         <a href="/releases">Releases</a>


### PR DESCRIPTION
## 変更

`src/components/ui/badge.test.tsx` の className マージテストは caller の `rounded-md` が付くことと `rounded-full` が消えることしか見ていなかった。`badge.tsx` の cva の base クラス文字列を丸ごと空にしても 3 件とも通る状態で、今週 2 人の worker がこの穴を踏んだ。`src/components/ui/separator.test.tsx:50-64` と同じ形にして、競合しない base クラス `inline-flex` が残ることを同じ expect に加えた。

レビュー指摘を受けて、className を渡さない `<Badge>` も同じテストで render し、そこに `rounded-full` が付くことも assert した。これで base から `rounded-full` だけを消した場合も落ちる。

先頭 2 件のテスト名は span を返すこと・子要素を返すことだけを述べていたが、本体は `data-variant` も assert していた。名前に variant を入れて本体と一致させた（2 件目も同じずれだったので揃えた）。

`badge.tsx` は変更していない。

## mutation の確認

`badge.tsx` を壊した状態で `bun run test src/components/ui/badge.test.tsx` を実行した。実行後はいずれも元に戻し、作業ツリーに `badge.tsx` の差分が残っていないことを確認している。

| 壊し方 | 変更前のテスト | このブランチのテスト |
| --- | --- | --- |
| cva の base クラス文字列を `""` にする | 3 passed | 1 failed（`overriddenHasUnrelatedBase` が false） |
| base から `rounded-full` だけ削る | 3 passed | 1 failed（`plainHasConflictingBase` が false） |

`bun run check` と `bun run test`（19 files / 419 tests）は通っている。

## 他の ui テストとの差

`separator.test.tsx:50-64` は className を渡した 1 要素だけを見る 3 フィールドの形で、このブランチの badge は 4 フィールドになった。`alert.test.tsx:40-49` と `tooltip.test.tsx:86-98` は caller のクラスの有無と base クラスの不在だけを見る 2 フィールドで、同じ穴が残っている。この 3 ファイルを揃えるのは別チケットにした。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
