### PR TITLE
fix: gh の本文 flag に git と同じ message scrub を適用する

### DIFF
--- a/.claude/hooks/pre-bash-guard.sh
+++ b/.claude/hooks/pre-bash-guard.sh
@@ -48,32 +48,37 @@ CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""')
 # --- Guard 1: .env protection (applies to parent and sidechains alike) ---
 # Scrub the committed example files, then look for a token that *starts* with
 # `.env` (optionally `.env.local` / `.env.development` / `.env.production`).
-# For git commands only, -m/--message quoted bodies are also scrubbed first:
-# prose about env files in a commit/tag message is not file access. The scrub
+# For `git` and `gh` commands only, the quoted bodies of the inline-text flags
+# selected below are also scrubbed first: prose about env files in a commit
+# message, a pull request body or a review body is not file access. The scrub
 # is deliberately NOT applied to other commands — a quoted message flag can be
 # repurposed as a file argument elsewhere (e.g. `sort -m ".env"`).
-#
-# A `-F -` body arrives as a heredoc, so the same prose reaches this guard by a
-# route the -m scrub does not cover. It is dropped only when the command's last
-# line is the heredoc delimiter: then nothing follows the body, so nothing is
-# hidden. A redirect belongs to the operator line, which is kept either way, and
-# a command chained after the terminator leaves a different last line and blocks
-# the scrub.
 SCRUBBED=$(printf '%s' "$CMD" | sed 's/\.env[.A-Za-z]*\.example//g')
 # NR==1 with an exit: awk would otherwise print the first field of every line,
 # and a multi-line command (a heredoc body) then matched no first word at all.
 FIRST_WORD=$(printf '%s' "$SCRUBBED" | awk 'NR == 1 { print $1; exit }')
-if [ "$FIRST_WORD" = "git" ]; then
+# gh takes inline text through --body, --title and --subject, and reads a file
+# through -F/--body-file and -T/--template (gh 2.86.0). gsub runs over the
+# whole command rather than over the leading gh alone, so the short -b/-t stay
+# out: with `-b` in the pattern the scrub took the operand of a chained
+# `cat -b '.env'`, which the grep below then never saw. The pattern follows the
+# command's first word, so a gh body behind a leading command is left alone.
+case "$FIRST_WORD" in
+  git) TEXT_FLAG_PATTERN='--?m(essage)?' ;;
+  gh) TEXT_FLAG_PATTERN='--(body|title|subject)' ;;
+  *) TEXT_FLAG_PATTERN='' ;;
+esac
+if [ -n "$TEXT_FLAG_PATTERN" ]; then
   # The whole command is one awk record, so a body spanning lines is still one
   # match. sed cannot do this portably here: its `N` loop quits WITHOUT printing
   # when there is no next line on BSD sed, which emptied every single-line
-  # command. The pattern also avoids `\|` and `{1,2}` — BRE alternation is a GNU
+  # command. The patterns also avoid `\|` and `{1,2}` — BRE alternation is a GNU
   # extension and awk intervals are not universal — so `--?m(essage)?` carries
-  # both spellings instead.
+  # both git spellings instead.
   scrub_message_body() { # $1 = the quote character delimiting the body
-    awk -v q="$1" '
+    awk -v q="$1" -v flags="$TEXT_FLAG_PATTERN" '
       BEGIN { RS = "\034" }
-      { gsub("--?m(essage)?[= ]?" q "[^" q "]*" q, "", $0); printf "%s", $0 }
+      { gsub(flags "[= ]?" q "[^" q "]*" q, "", $0); printf "%s", $0 }
     '
   }
   # Single-quoted bodies are always inert (no expansion inside single quotes).
@@ -86,10 +91,11 @@ if [ "$FIRST_WORD" = "git" ]; then
     *'$('*|*'${'*|*'`'*) ;;
     *) SCRUBBED=$(printf '%s' "$SCRUBBED" | scrub_message_body '"') ;;
   esac
-  # A `-F -` body arrives as a heredoc instead. Drop it only when the command's
-  # last line is the delimiter: then nothing follows the body, so nothing is
-  # hidden. A redirect belongs to the operator line, which is kept either way,
-  # and a command chained after the terminator leaves a different last line.
+  # A `-F -` / `--body-file -` body arrives as a heredoc instead, by a route the
+  # flag scrub above does not cover. Drop it only when the command's last line
+  # is the delimiter: then nothing follows the body, so nothing is hidden. A
+  # redirect belongs to the operator line, which is kept either way, and a
+  # command chained after the terminator leaves a different last line.
   SCRUBBED=$(printf '%s' "$SCRUBBED" | awk '
     BEGIN { q = sprintf("%c", 39); op = 0 }
     { last = $0; lines[NR] = $0 }
@@ -111,7 +117,7 @@ if [ "$FIRST_WORD" = "git" ]; then
   ')
 fi
 if printf '%s' "$SCRUBBED" | grep -qE '(^|[[:space:]"'\''`={}:,;&|<>(/-])\.env(\.(local|development|production))?([[:space:]"'\''`{}:,;&|<>)*]|$)'; then
-  deny "PreToolUse(Bash): this command references a protected env file (.env / .env.local / .env.development / .env.production). Reading or writing these is denied regardless of tool. Use .env.local.example for documented placeholders. If this is a false positive (e.g. the literal string in a message), rephrase the command without the filename."
+  deny "PreToolUse(Bash): this command references a protected env file (.env / .env.local / .env.development / .env.production). Reading or writing these is denied regardless of tool. Use .env.local.example for documented placeholders. To write the filename as prose, put it in a quoted body of \`git\` -m/--message or of \`gh\` --body/--title/--subject: a single-quoted body is read as prose, a double-quoted one only when the command contains no \$(, \${ or backtick."
   exit 0
 fi
 

--- a/scripts/test-bash-guard.ts
+++ b/scripts/test-bash-guard.ts
@@ -302,6 +302,100 @@ group("env protection: a git message body is prose, a chained command is not", [
   },
 ]);
 
+// A worker whose ticket touches local env setup has to name the file in a pull
+// request body, a comment and a review reply.
+group("env protection: a gh body is prose, a gh body file is access", [
+  {
+    command:
+      "gh pr create --draft --title t --body 'the .env.local setup step'",
+    expected: "allow",
+    why: "a single-quoted pull request body naming the file",
+  },
+  {
+    command: 'gh pr comment 1 --body "the .env.local setup step"',
+    expected: "allow",
+    why: "a double-quoted comment body naming the file",
+  },
+  {
+    command: "gh pr review 1 --comment --body 'the .env.local setup step'",
+    expected: "allow",
+    why: "a review body naming the file",
+  },
+  {
+    command: "gh issue create --title 'document .env.local' --body x",
+    expected: "allow",
+    why: "a title naming the file",
+  },
+  {
+    command:
+      "gh pr merge 1 --squash --subject 'drop the .env.local step' --body x",
+    expected: "allow",
+    why: "a merge subject naming the file",
+  },
+  {
+    command:
+      "gh pr create --title t --body-file - <<'MSG'\nthe .env.local setup step\nMSG",
+    expected: "allow",
+    why: "a heredoc body naming the file",
+  },
+  {
+    command: "gh pr create --title t --body-file .env.local",
+    expected: "block",
+    why: "--body-file names a file to read",
+  },
+  {
+    command: "gh pr comment 1 -F .env.local",
+    expected: "block",
+    why: "-F names a file to read",
+  },
+  {
+    command: "gh pr create --title t -T .env.local",
+    expected: "block",
+    why: "-T names a template file to read",
+  },
+  {
+    command: 'gh pr comment 1 --body "$(cat .env.local)"',
+    expected: "block",
+    why: "a substitution in the body is not scrubbed",
+  },
+  {
+    command: 'gh pr comment 1 --body "the `.env.local` step"',
+    expected: "block",
+    why: "a backtick in the body is not scrubbed",
+  },
+  {
+    command: "gh pr comment 1 --body 'the .env.local step' && cat .env.local",
+    expected: "block",
+    why: "a real access chained after the body",
+  },
+]);
+
+// The scrub runs over the whole command rather than over the leading gh alone,
+// so a short -b in the pattern also took the operand of a chained `cat -b`,
+// which reads that file.
+group("env protection: the gh scrub covers long flags on a leading gh", [
+  {
+    command: "gh pr comment 1 -b 'the .env.local step'",
+    expected: "block",
+    why: "-b is not scrubbed",
+  },
+  {
+    command: "gh pr create -t 'document .env.local' --body x",
+    expected: "block",
+    why: "-t is not scrubbed",
+  },
+  {
+    command: "gh pr view 1 && cat -b '.env'",
+    expected: "block",
+    why: "a chained cat -b keeps its operand",
+  },
+  {
+    command: "git add x && gh pr create --body 'the .env.local step'",
+    expected: "block",
+    why: "the pattern follows the first word only",
+  },
+]);
+
 console.log("");
 if (failures.length > 0) {
   console.log(`FAILED: ${failures.length}`);


### PR DESCRIPTION
## 何が良くなるか

`.claude/hooks/pre-bash-guard.sh` の Guard 1 は、保護対象の env ファイル名を command 文字列から grep して弾きます。`-m` / `--message` の引用符付き本文は先に落としますが、その scrub が走るのは command の先頭語が `git` のときだけでした。`gh` の本文は grep にそのまま残ります。hook に payload を直接与えて確認しました。

- `gh pr create --draft --title t --body "... .env.local ..."` は `decision: block`
- `gh pr comment 1 --body "... .env.local ..."` は `decision: block`
- 同じ文を `git commit -m` に渡すと allow

local env の設定に触る ticket を持った worker は、そのファイル名を pull request 本文にも comment にも review 返信にも書けませんでした。先頭語ごとに pattern を選ぶ `case` を置き、`gh` には `--body` と `--title` と `--subject` を渡します。scrub 本体と heredoc 落としは `git` 側の既存ロジックをそのまま共有します。

## scrub 対象に選んだ flag

`gh` の長い綴りだけです。file を読むのは `-F` / `--body-file` と `-T` / `--template` で、そちらは対象外なので今までどおり block します（case にしました）。

短縮形の `-b` / `-t` は外しました。scrub の `gsub` は先頭の `gh` ではなく command 全体に掛かるので、`-b` を pattern に入れると `gh pr view 1 && cat -b '.env'` の operand まで一緒に消え、grep がそのファイル名を見なくなります（`cat -b` は行番号を付けてファイルを読みます）。code-reviewer がこの形を作って block から allow に変わることを測り、短縮形を外した版で block に戻ることも測りました。`gh pr create -b '.env.local'` は block のままで、prose を運ぶ綴りは `--body` です。

`gh` の flag を大文字小文字で切り分ける案は取りませんでした。小文字でも file を指すものが実在します（`gh attestation verify -b/--bundle`、`gh secret set -f/--env-file`、`gh api --input`）。長い 3 語を名指しする形なら、この 3 つはどれも対象外です。`gh release create` の `--notes` は release 作業が user の領分なので入れていません。

先頭語の判定は既存のままです。`git add x && gh pr create --body '...'` と `GH_TOKEN=x gh pr create --body '...'` はどちらも scrub されず block します。閉じるには command を `;` `&&` `||` `|` で分けて先頭 segment だけに scrub を掛けることになりますが、本文自身が `&&` を含むと引用の途中で切れます。この hook が他のどこでもやっていない量の shell 解析なので、今回は広げず case で固定しました。

引用符の扱いも既存のままです。単引用の本文は常に scrub し、二重引用の本文は command 全体に `$(`、`${`、backtick が無いときだけ scrub します。backtick を含む本文が block になる case を足しました（この repo の PR 本文はファイル名を code span に入れるので、worker が最初に踏む形です）。

deny の文面には、ファイル名を prose として書ける場所を足しました。今までの「rephrase the command without the filename」は、prose を書きたい worker に行き先を示していませんでした。

## code-reviewer の指摘への対応

- `-[bt]` が連鎖した `cat -b` の operand を消す（major）。指摘どおり短縮形を pattern から外しました。上の測定はその版です。
- `scripts/test-bash-guard.ts` の comment が「gh で file を指す flag は全部大文字」と書いていた（major）。小文字の反例が 3 つあるので、その一文を削り、comment は group が存在する理由だけにしました。flag の事実は hook 側の comment に、`cat -b` の測定と一緒に置きました。
- `--subject` と backtick と `-b` / `-t` に case が無かった（major）。4 件足して 16 件にしました。
- allow 6 件が落ちた状態で test だけが入ること（major）。hook の commit を同じ PR に載せたので、`bun scripts/test-bash-guard.ts` は 62 件すべて `ok` です。
- 先頭語の判定の範囲（minor）。hook の comment に書き、case で固定しました。

## この ticket の外で見つけたもの

grep の直前の文字クラスに `@` が入っていないため、`gh api repos/o/r/issues -F body=@.env.local` はこの PR の前後どちらでも allow です。`-F` の `@file` は実際にそのファイルを読みます。別 ticket として切り出されています。

## 確認

- `bun run check` 通過
- `bun run test` 通過（447 tests）
- `bun scripts/test-bash-guard.ts` が 62 件すべて `ok`
- `cat -b`、`sort -b`、短縮形 `-b` / `-t`、`--bundle`、`--env-file`、`--input`、backtick、先頭語が `git` の各形を、変更後の hook と変更前の hook の両方に通し、差が出るのは意図した allow 3 形だけであることを確認
