### PR TITLE
test: repository の外へ出た root 相対 link の case がどの machine でも走る

### DIFF
--- a/.claude/hooks/check-md-links.test.ts
+++ b/.claude/hooks/check-md-links.test.ts
@@ -435,14 +435,6 @@ describe("check-md-links", () => {
     });
   });
 
-  // Uses a real sibling of the repository rather than creating one, because a test
-  // has no business writing outside the repository it checks.
-  const sibling = fs
-    .readdirSync(path.dirname(REPO))
-    .toSorted()
-    .find((entry) => entry !== path.basename(REPO) && !entry.startsWith("."));
-  const escapeOntoSibling = `/../${sibling ?? ""}`;
-
   describe("a root-relative target may not climb above the repository root", () => {
     // Without the clamp the escaped path was returned, and a same-named file in the
     // parent directory (a nested checkout, a sibling package) reported the link
@@ -452,15 +444,23 @@ describe("check-md-links", () => {
       expect(resolveTarget(DOC, "/../anything.md")).toBeNull();
     });
 
-    // The case that actually bites: the escaped path EXISTS.
-    it.runIf(sibling !== undefined)(
-      "should report dead when the escape lands on a real sibling of the repository",
-      () => {
-        expect(deadTargets(`[x](${escapeOntoSibling})\n`)).toStrictEqual([
-          escapeOntoSibling,
-        ]);
-      }
-    );
+    // The escaped path EXISTS here, which is what a false negative needs. `/..`
+    // addresses the directory the checkout sits in. The entry beside the repository
+    // this case used to look for was absent on a checkout whose parent held nothing
+    // else, and the case skipped in silence. `escapedTargetExists` asserts that the
+    // escaped path is on disk, because resolveTarget clamps by string comparison
+    // before anything stats it, so the `dead` half alone cannot tell an escape onto
+    // a real path from an escape onto nothing.
+    it("should report dead when the escape lands on a path that exists", () => {
+      const verdict = {
+        dead: deadTargets("[x](/..)\n"),
+        escapedTargetExists: targetExists(path.resolve(REPO, "..")),
+      };
+      expect(verdict).toStrictEqual({
+        dead: ["/.."],
+        escapedTargetExists: true,
+      });
+    });
   });
 
   // On a case-insensitive filesystem (APFS by default) a bare existence test answers


### PR DESCRIPTION
## 直したこと

`check-md-links.test.ts` の「escape 先が実在する」case は `it.runIf(sibling !== undefined)` で守られていた。sibling は repository root の親 directory を `readdirSync` して dotfile でない最初の entry を取るので、case が走るかどうかは checkout の隣に何が置かれているかで決まっていた。他の worktree を片付けた直後のこの checkout では親に何も残らず、`bun run test` は `461 passed | 1 skipped` を出した。skip されたのは、`resolveTarget` の clamp を外すと dead link を live と報告する false negative を pin する唯一の case である。

link を `/..` に変えた。`resolveTarget` は root 相対 target を `path.resolve(REPO, ..)` で解くので、escape 先は checkout が置かれている directory になる。`REPO` は `import.meta.dirname` から作るため、module を import できた場所にはその親がある。assert は `dead`（`deadTargets("[x](/..)\n")`、他の case と同じ pipeline を通る）と `escapedTargetExists`（`targetExists(path.resolve(REPO, ".."))`）を一つの object で `toStrictEqual` する。後者を入れたのは、`resolveTarget` が disk を読む前に文字列比較で null を返すため、`dead` だけでは「実在する path への escape」と「何も無い先への escape」を区別できないからである。

`check-md-links.ts` は変えていない。

## 測ったこと

- 変更前: `bun run test` → `461 passed | 1 skipped`（skip はこの case）
- 変更後: `bun run test` → `462 passed`、skipped の行は出ない。file 単体は `75 passed`
- clamp（`check-md-links.ts` の `if (target !== REPO && !target.startsWith(REPO + path.sep))`）を消して走らせると、この case は `dead: []` で落ちる。つまり assert は clamp を掴んでいる
- `bun run check` pass、`bun run knip` exit 0（`knip.json` の `oxlint-plugin-react-doctor` hint は変更前からある）

## 採らなかった選択肢

- **`resolveTarget` に root parameter を足す（`root = REPO`）**: 一度実装して revert した。test は自分の temp directory の中に stand-in root と その上の file を作れるようになるが、production の呼び手は `scanFile` 一つだけで root を渡さないため、parameter の唯一の consumer が test になる。さらに `reachedViaSymlink`、`gitListed`、`mdFiles`、report の `path.relative` は module level の `REPO` を読み続けるので、root を渡した呼び手は clamp と symlink 判定と report label で別々の root を見ることになる。harness の docstring が言う「ship しない code path を test する harness」に自分から寄る形だった。
- **repository の外に fixture を書く**: 消した comment が断っていた通り、gate の test が checkout の外に書き込む理由がない。並行実行や権限の問題も抱える。
- **module を temp directory に copy して import し、`import.meta.dirname` 経由で root を変える**: 走るのは copy であって ship する file ではなく、仕組みも重い。
- **既存 fixture の `WORK/sub` を stand-in root、`WORK/real.md` をその上の file として使う**: production を触らずに済み、cleanup も既存の `afterAll` に乗る。採らなかったのは、`resolveTarget` に root を渡す口が必要で、それは上の選択肢と同じ parameter を production に足すことになるからである。

## 判断が要る finding

`code-reviewer` は「premise field を別の `it` に分ける」案を preference として挙げ、correction ではないと述べた。分けなかったのは、AGENTS.md の「One test, one expect」と「A structural result is asserted as one whole object」の両方を一つの object で満たせるからである。分けたほうが失敗時に clamp と premise を読み分けやすいという主張は成り立つので、分けたい場合は言ってほしい。

## 前提として置いたこと

- `/..` が addressed する path は directory であって `.md` file ではない。この checker は directory を live な target として扱う（`[x](./sub)` の case が pin している）ので、clamp を外すと live と報告される点は file の場合と同じである。消した version も parent の最初の entry を取るだけで、file とは限らなかった。
- `escapedTargetExists` は disk を読むので、ancestor directory が読めない machine では false になって test が落ちる。落ちる先が silent な skip ではなく failure である点が、この ticket が閉じた穴である。同じ条件では既存の `[x](/README.md)` の case も落ちる。


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the test for root-relative links escaping the repository root run on any machine. Previously it looked for a sibling directory next to the repo, so it silently skipped when none existed. Now it uses `/..` to address the checkout's parent, which always exists, and asserts both that the link is dead and that the escaped target actually exists. No production code changes.

<sup>Written for commit c7f40689bc84287f98f9a2b80f9ba73c833dde93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imaimai17468/imaimai-front-templete/pull/130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

