### PR TITLE
docs: motion-craft の値の食い違いを一つに決め、他節が述べている重複を落とす

### DIFF
--- a/.claude/skills/motion-craft/SKILL.md
+++ b/.claude/skills/motion-craft/SKILL.md
@@ -5,14 +5,9 @@ description: Unified animation and motion skill — Apple-style fluid interface 
 
 # Motion Craft
 
-Everything you need to design, build, and review web animation — in one place.
-Three concerns, one skill: **design philosophy** (how motion should feel),
-**implementation reference** (exact values and techniques), and **review
-standards** (how to audit animation code). Plus a vocabulary glossary for
-naming effects precisely.
-
-Read this before writing any animation code. Re-check the review standards
-before calling the work done.
+Read Part 1 when deciding how a motion should feel, Part 2 when writing the
+value, Part 3 before calling animation work done, and Part 4 when the user
+describes an effect without naming it.
 
 ---
 

--- a/.claude/skills/motion-craft/SKILL.md
+++ b/.claude/skills/motion-craft/SKILL.md
@@ -587,12 +587,7 @@ Cite `file:line`. Pull exact values from Part 2 rather than approximating.
 
 Turn a vague description of a motion effect into the precise term, so you know
 what to ask for. When the user describes an effect loosely, return the matching
-term(s):
-
-```
-**Stagger** — Animate several items one after another with a small delay
-between each, creating a cascade.
-```
+term(s) in the bold-term-then-definition form the sections below use.
 
 If several terms could fit, list the best match first, then 1-2 alternates with
 a one-line note on how they differ.

--- a/.claude/skills/motion-craft/SKILL.md
+++ b/.claude/skills/motion-craft/SKILL.md
@@ -299,8 +299,6 @@ and abrupt brightness jumps.
 
 | Need | Technique | Concrete value |
 | --- | --- | --- |
-| Default UI spring | Critically damped, no overshoot | `damping 1.0`, `response 0.3-0.4` |
-| Momentum / flick spring | Under-damped, slight bounce | `damping ~0.8`, `response 0.3-0.4` |
 | Gesture -> spring velocity | Hand off release velocity | `gestureVelocity / (target - current)` if normalized |
 | Flick landing point | Project momentum | `current + (v/1000)*d/(1-d)`, `d ~ 0.998` |
 | Interrupt cleanly | Start from presentation (live) value | read the on-screen transform |
@@ -392,11 +390,6 @@ Feel natural because they simulate physics; no fixed duration.
 Keep bounce subtle (0.1-0.3); reserve for drag-to-dismiss and playful
 interactions. Springs maintain velocity when interrupted (keyframes restart
 from zero).
-
-| Need | Config |
-| --- | --- |
-| Default UI spring | `damping 1.0`, `response 0.3-0.4` |
-| Momentum / flick spring | `damping ~0.8`, `response 0.3-0.4` |
 
 ## Interruptibility
 

--- a/.claude/skills/motion-craft/SKILL.md
+++ b/.claude/skills/motion-craft/SKILL.md
@@ -152,6 +152,9 @@ const target = nearestSnapPoint(projectedEndpoint);
 animateSpringTo(target, { velocity: releaseVelocity });
 ```
 
+At release, the **sign of the velocity** decides between reverse and commit,
+not the position the gesture reached.
+
 ## 7. Spatial consistency
 
 > "If something disappears one way, we expect it to emerge from where it came."
@@ -160,7 +163,8 @@ animateSpringTo(target, { velocity: releaseVelocity });
   must dismiss to the right.
 - **Anchor interactions to their source.** A menu or popover should originate
   from the element that triggered it — set `transform-origin` to the trigger.
-- **Mirror the easing on reversible transitions.**
+- **Mirror the easing on reversible transitions** with the inverse
+  cubic-bezier.
 
 ## 8. Hint in the direction of the gesture
 
@@ -294,23 +298,6 @@ and abrupt brightness jumps.
 - **Test with real people in real context**, and review motion with fresh
   eyes — play it in slow motion / frame-by-frame to catch what's invisible at
   full speed.
-
-## Quick Reference
-
-| Need | Technique | Concrete value |
-| --- | --- | --- |
-| Gesture -> spring velocity | Hand off release velocity | `gestureVelocity / (target - current)` if normalized |
-| Flick landing point | Project momentum | `current + (v/1000)*d/(1-d)`, `d ~ 0.998` |
-| Interrupt cleanly | Start from presentation (live) value | read the on-screen transform |
-| Avoid reversal "brick wall" | Carry velocity through re-target | spring that blends velocity |
-| Reversible transition | Mirror the easing curve | inverse cubic-bezier |
-| Decide reverse vs. commit | Use velocity **sign**, not position | at release |
-| 1:1 drag | Pointer Events + capture | respect the grab offset |
-| Feedback | On pointer-down, continuous | never only at the end |
-| Boundary | Rubber-band, don't hard-stop | progressive resistance |
-| Translucent chrome | `backdrop-filter` layer | content scrolls under |
-| Type tracking | Size-specific, never fixed | tighten large text (`-0.02em`), body near `0` |
-| Reduced motion | Cross-fade, not slide/spring | `@media (prefers-reduced-motion)` |
 
 ---
 

--- a/.claude/skills/motion-craft/SKILL.md
+++ b/.claude/skills/motion-craft/SKILL.md
@@ -551,18 +551,15 @@ Each of these is a finding on sight, and no standard above decides it:
 
 When proposing fixes, prefer earlier moves over later ones:
 
-1. **Delete the animation** (high-frequency / no purpose / keyboard-triggered).
-2. **Reduce it** — shorter duration, smaller transform, fewer properties.
-3. **Fix the easing** — swap `ease-in` -> `ease-out`/custom curve.
-4. **Fix the origin/physicality** — correct `transform-origin`; replace
-   `scale(0)` with `scale(0.95)` + opacity.
-5. **Make it interruptible** — keyframes -> transitions/springs for gestures.
-6. **Move it to the GPU** — layout props -> `transform`/`opacity`.
-7. **Asymmetric timing** — slow the deliberate phase, snap the response.
-8. **Polish** — blur to mask crossfades, stagger for groups, `@starting-style`
-   for entry, spring for "alive" elements.
-9. **Accessibility & cohesion** — add reduced-motion + hover gating; tune to
-   match personality.
+1. **Delete the animation.**
+2. **Reduce it.**
+3. **Fix the easing.**
+4. **Fix the origin and physicality.**
+5. **Make it interruptible.**
+6. **Move it to the GPU.**
+7. **Make the timing asymmetric.**
+8. **Polish it.**
+9. **Fix the accessibility gating and the cohesion.**
 
 ## Review Output Format
 

--- a/.claude/skills/motion-craft/SKILL.md
+++ b/.claude/skills/motion-craft/SKILL.md
@@ -438,11 +438,7 @@ Slow where the user is deciding, fast where the system responds.
 
 - **Momentum dismissal**: compute velocity (`Math.abs(distance)/elapsedMs`);
   dismiss if `> ~0.11`. A flick should be enough.
-- **Damping at boundaries**: dragging past a natural edge moves less the
-  further you go.
-- **Pointer capture** once dragging starts.
 - **Multi-touch protection**: ignore extra touch points after drag begins.
-- **Friction over hard stops** — allow over-drag with rising resistance.
 
 ## Masking imperfect crossfades
 

--- a/.claude/skills/motion-craft/SKILL.md
+++ b/.claude/skills/motion-craft/SKILL.md
@@ -375,8 +375,7 @@ Feel natural because they simulate physics; no fixed duration.
 ```
 
 Keep bounce subtle (0.1-0.3); reserve for drag-to-dismiss and playful
-interactions. Springs maintain velocity when interrupted (keyframes restart
-from zero).
+interactions. Springs maintain velocity when interrupted.
 
 ## Interruptibility
 

--- a/.claude/skills/motion-craft/SKILL.md
+++ b/.claude/skills/motion-craft/SKILL.md
@@ -52,13 +52,6 @@ The moment lag appears, the feeling of directness "falls off a cliff."
   For a drag, slider, or drawer, update the UI 1:1 with the pointer the whole
   way through.
 
-```css
-.button:active {
-  transform: scale(0.97);
-  transition: transform 100ms ease-out;
-}
-```
-
 ## 2. Direct manipulation — 1:1 tracking
 
 > "Touch and content should move together."

--- a/.claude/skills/motion-craft/SKILL.md
+++ b/.claude/skills/motion-craft/SKILL.md
@@ -730,12 +730,7 @@ a one-line note on how they differ.
 
 ## Principles
 
-- **Purposeful animation** — Motion serves a function, not just decoration.
 - **Anticipation** — Small wind-up in the opposite direction before a move.
 - **Follow-through** — Parts keep moving and settle after the main motion stops.
 - **Squash & stretch** — Deforming to convey weight, speed, and flexibility.
 - **Perceived performance** — The right animation makes an interface feel faster.
-- **Frequency of use** — The more often it's seen, the shorter and subtler it should be.
-- **Spatial consistency** — Animate so elements keep identity and position across states.
-- **Hardware acceleration** — Animating transform and opacity lets the GPU keep motion smooth.
-- **Reduced motion** — Respecting the user's `prefers-reduced-motion` setting.

--- a/.claude/skills/motion-craft/SKILL.md
+++ b/.claude/skills/motion-craft/SKILL.md
@@ -363,7 +363,8 @@ Find curves at [easing.dev](https://easing.dev/) or
 | Modals, drawers | 200-500ms |
 | Marketing / explanatory | Can be longer |
 
-**Rule: UI animations stay under 300ms.**
+**Rule: stay inside the element's row above. A longer duration needs a stated
+reason.**
 
 ## Physicality
 
@@ -531,8 +532,8 @@ Every animation in the diff is measured against these. A violation is a finding.
 3. **Responsive easing.** Entering/exiting elements use `ease-out` or a strong
    custom curve. `ease-in` on UI is a block. Built-in CSS easings are too weak.
 
-4. **Sub-300ms UI.** UI animations stay under 300ms; anything slower needs
-   justification.
+4. **Duration within range.** A duration past its element's row in Part 2's
+   duration table needs justification.
 
 5. **Origin & physical correctness.** Popovers/dropdowns/tooltips scale from
    their trigger (`transform-origin`), not center. Never `scale(0)` — start
@@ -564,7 +565,8 @@ Flag these on sight:
 - `scale(0)` or pure-fade entrances with no initial transform
 - `ease-in` on any UI interaction; weak built-in easing on deliberate animation
 - Animation on a keyboard shortcut or 100+/day action
-- UI duration > 300ms with no stated reason
+- A duration past its element's row in Part 2's duration table, with no stated
+  reason
 - `transform-origin: center` on a trigger-anchored popover/dropdown/tooltip
 - Keyframes on toasts, toggles, or anything added/triggered rapidly
 - Animating layout properties (`width`/`height`/`margin`/`padding`/`top`/`left`)

--- a/.claude/skills/motion-craft/SKILL.md
+++ b/.claude/skills/motion-craft/SKILL.md
@@ -539,22 +539,12 @@ Every animation in the diff is measured against these. A violation is a finding.
 
 ## Aggressive Escalation Triggers
 
-Flag these on sight:
+Each of these is a finding on sight, and no standard above decides it:
 
 - `transition: all`
-- `scale(0)` or pure-fade entrances with no initial transform
-- `ease-in` on any UI interaction; weak built-in easing on deliberate animation
-- Animation on a keyboard shortcut or 100+/day action
-- A duration past its element's row in Part 2's duration table, with no stated
-  reason
-- `transform-origin: center` on a trigger-anchored popover/dropdown/tooltip
-- Keyframes on toasts, toggles, or anything added/triggered rapidly
-- Animating layout properties (`width`/`height`/`margin`/`padding`/`top`/`left`)
+- A pure-fade entrance with no initial transform
 - Motion `x`/`y`/`scale` props on motion that runs while the page is busy
 - Updating a CSS variable on a parent to drive a child transform
-- Missing `prefers-reduced-motion` handling on movement
-- Ungated `:hover` motion
-- Symmetric enter/exit timing on a press-and-release
 - Everything-at-once entrance where a 30-80ms stagger belongs
 
 ## Remedial Preference Hierarchy

--- a/.claude/skills/motion-craft/SKILL.md
+++ b/.claude/skills/motion-craft/SKILL.md
@@ -464,16 +464,10 @@ Stagger is decorative — never block interaction while it plays.
 ## Accessibility (implementation)
 
 ```css
-@media (prefers-reduced-motion: reduce) {
-  .element { animation: fade 0.2s ease; }
-}
 @media (hover: hover) and (pointer: fine) {
   .element:hover { transform: scale(1.05); }
 }
 ```
-
-Reduced motion means fewer and gentler animations, not zero — keep transitions
-that aid comprehension, remove movement/position changes.
 
 ## Debugging
 


### PR DESCRIPTION
`motion-craft` の SKILL.md 内で、同じ規則を二つの値で述べていた 3 箇所を一つの値に決め、他の節が同じ規則をすでに述べていた 9 箇所を落とした。変更は `.claude/skills/motion-craft/SKILL.md` だけ。

## 矛盾の決着

**ボタン押下のフィードバック時間。** Part 1 §1 のコードブロックが `transition: transform 100ms ease-out`、Part 2 の Physicality が `160ms`、Part 2 の duration テーブルが `100-160ms` を書いていた。

Part 2 の `160ms` を残し、Part 1 のコードブロックを消した。Part 2 は実装リファレンスで、Part 3 の Review Output Format が「正確な値は Part 2 から引き、近似しない」と指示している参照先であり、Part 1 が持っていなかった `0.95-0.98` の範囲も持っている。Part 1 §1 の 3 つの箇条書きが「押した瞬間にフィードバックを出す」という規則自体を述べているので、消したのは値の重複だけ。

**300ms の上限。** Part 3 の標準 4 が「UI は 300ms 未満、それより遅いものは正当化が必要」、Part 2 の duration テーブルが modal と drawer に `200-500ms`。Part 3 だけを読んだレビュアーが Part 2 の認める 400ms の drawer を止める。

テーブルを残した。要素ごとの範囲を持つのはテーブルだけで、Part 3 は正確な値を Part 2 から引くよう既に指示している。300ms を書いていた 3 箇所（Part 2 の Rule 行、Part 3 の標準 4、escalation trigger）を「要素の行の範囲を超えたら理由が必要」に置き換えた。trigger 行はその後 cut 5 で消えている。

**spring の bounce の条件。** Quick Reference の default 行が `damping 1.0` / `response 0.3-0.4`、momentum 行が `damping ~0.8` を、Part 1 §4 が付けている条件なしで並べていた。§4 は bounce を「ジェスチャ自身が勢いを持っていたとき（flick、throw、drag release）だけ」に限り、move には `0.4`、drawer には `0.3` を与えている。

条件と要素ごとの値を持つ §4 を残し、Quick Reference と Part 2 springs テーブルの spring 2 行を消した。Part 2 の springs 節は残る「bounce は 0.1-0.3 に抑え、drag-to-dismiss と遊びのある操作に限る」で条件を保っている。

## 落とした重複

いずれも先に生存側が規則を完全に述べていることを確認した。

- **Quick Reference テーブル**（14 行）。13 行は同じファイルの上の節の要約で、残る 1 行「reverse と commit は位置ではなく velocity の符号で決める」だけが他に住所を持たなかった。この規則を §6 Momentum projection に移した。Reversible transition 行の第 3 列 `inverse cubic-bezier` は §7 が持っていなかったので、§7 の該当箇条書きに入れた。
- **Aggressive Escalation Triggers**（14 → 5）。9 個は上の番号付き標準が決めていた（ease-in は 3、keyboard / 高頻度は 2、duration は 4、transform-origin と `scale(0)` は 5、toast の keyframes は 6、layout プロパティは 7、reduced-motion と ungated hover は 8、対称タイミングは 9）。標準の前置きが「diff の全アニメーションを標準で測り、違反は finding」と述べている。stagger の一件は Part 2 が 30-80ms の間隔を書くだけで finding かを述べていなかったので、節の前置きを「どれも finding であり、上の標準はこれを決めていない」に変えて判定を与えた。
- **Remedial Preference Hierarchy**。順序は他のどこにも書かれていない規則なので 9 つの太字を動作として残し、各項目の処方（duration を短く、ease-in を ease-out へ、transform-origin の修正、keyframes を transition へ、layout を transform へ）を落とした。これは標準 1-10 が 2 画面上で書いている。
- **用語集の Principles 5 項目**（purposeful animation、frequency of use、spatial consistency、hardware acceleration、reduced motion）。Part 1 §7 §11 §14、frequency テーブル、標準 1・2・7・8 が規則として書いていることを弱い形で言い直していた。残る 4 項目（anticipation、follow-through、squash & stretch、perceived performance）は他が名前を与えていない効果を指す。
- **Part 2 の reduced-motion ブロック**。§14 は media feature を 3 つ扱い `transform: none !important` まで書いているので、弱い版を消した。§14 が持たない `@media (hover: hover) and (pointer: fine)` のゲートは残した。
- **境界の抵抗と pointer capture**。Gestures & drag の「Damping at boundaries」と「Friction over hard stops」が同じ規則を 1 リスト内で 2 度書き、§9 が `rubberband()` 付きで 3 度目を書いていた。「Pointer capture once dragging starts」は §2 の繰り返しで、§2 は理由まで書いている。momentum dismissal と multi-touch protection を残した。
- **小さな重複 2 件**。springs 節の括弧書き `(keyframes restart from zero)` は 10 行下の Interruptibility 節の主題。springs 設定テーブルは spring 2 行だけだったので、上の矛盾 3 の commit で消えた（cut 10 の後半はそこで済んでいる）。
- **冒頭の 2 段落**。文書自身の構成を報告し frontmatter の description を言い直していた。どの Part をいつ開くかに絞った。
- **Part 4 の Stagger 例示ブロック**。下の用語集が同じ項目を持っている。項目を残し、例示は各節が使っている「太字の用語＋定義」の形を指すだけにした。

飛ばした cut はない。

## 数字

- em dash：157 → 140。うち 104 は用語集の `**用語** — 定義` という定義リストの区切り、14 は見出しの区切り、1 は frontmatter。走る文の中は 23 → 21 で、4321 words に対し 1000 words あたり 4.9 と `.claude/rules/prose.md` の 5 を下回る（変更前は 4833 words に対し 4.8）。Remedial Preference Hierarchy が落とした 8 本は定義リスト側に数えられている。
- 語数：4833 → 4321（512 words 減）。行数：779 → 715。

## 確認

`bun .claude/hooks/check-md-links.ts` が通る（20 files, dead link なし）。pre-push の actionlint / cf-typegen-check / check / similarity / toolchain-pins も通っている。コード変更がないので `bun run test` は実行していない。


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves three value contradictions in the `motion-craft` SKILL.md and removes nine spots that restated rules already covered elsewhere. Only `.claude/skills/motion-craft/SKILL.md` changes: net -89 lines / -512 words, no code impact.

**Contradictions resolved**
- Button-press feedback: keep Part 2's `160ms`; the Part 1 code block only repeated that value.
- 300ms cap: keep Part 2's per-element duration table; rewrite the three "sub-300ms" statements to "stay within the element's row, longer needs a stated reason."
- Spring bounce: keep Part 1 §4's conditional values; remove the spring rows from Quick Reference and Part 2's springs table.

**Duplicates removed**
- Delete the 14-row Quick Reference table; move the velocity-sign rule into §6 and inverse cubic-bezier into §7.
- Trim escalation triggers from 14 to 5; keep only violations the numbered standards don't already decide, and give the stagger item an explicit finding status.
- Slash Remedial Preference Hierarchy to just the 9-item ordering; each item's prescription already lives in standards 1-10.
- Drop the glossary Principles, reduced-motion, boundary-friction, pointer-capture, intro, and Stagger items that weakened or restated rules given elsewhere.

<sup>Written for commit f4112050a1cea5174762bd63a7c804db5deb97cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imaimai17468/imaimai-front-templete/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

