### PR TITLE
fix: 並列 worker がいる間も main checkout の test gate が通る

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite-plus";
+import { defaultExclude, defineConfig } from "vite-plus";
 
 export default defineConfig({
   resolve: {
@@ -16,6 +16,7 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     isolate: false,
+    exclude: [...defaultExclude, ".claude/worktrees/**"],
     setupFiles: ["./src/test-setup.ts"],
     // include が対象の全リスト。新しい純関数モジュールを
     // テスト付きで追加したらここにも足す。


### PR DESCRIPTION
## 直した defect

`vitest.config.mts` に `test.include` も `test.exclude` もなく、test discovery が `.claude/worktrees/<agent>/` の中まで降りていた。AGENTS.md が書いているとおり、そこには並列 ticket の checkout が並ぶ。worktree はそれぞれ別の install を持つので、拾われた test file の複製は module 解決に失敗する。gate は worker が走っている間だけ赤くなり、worktree が 1 つもないときだけ緑だった。

## file 数（実測）

main checkout（worktree 3 つ）で修正前に `bun run test` を走らせると `Test Files 57 failed | 19 passed (76)` と `Tests 462 passed` を出した。修正後の同じ checkout は `Test Files 19 passed (19)` と `Tests 462 passed` で、`.claude/worktrees/` から来る失敗は 0 件。この worktree の中では `Test Files 19 passed (19)` / `Tests 462 passed` / branches 100%。

main checkout の修正後の数字は、`bun run test` と同じ `vp test --run --coverage` を `--exclude` で同じ list を渡して実行したもの。この session は isolated worktree なので shared checkout の file を書き換えていない。修正前の 76 file は同じ checkout で `bun run test` をそのまま走らせて記録した。worker が増えるにつれ同じ command が 133 file まで伸びるのも観測している。

## 直し方

```ts
exclude: [...defaultExclude, ".claude/worktrees/**"],
```

- vitest 4.1.11 の `test.exclude` は default を継承せず上書きする（array key は deepMerge で代入になる）。この spread を外すと discovery は 276 file を拾い、うち 257 file は `node_modules` が同梱する test file だった。
- `defaultExclude` の中身は `["**/node_modules/**", "**/.git/**"]` で、`dist` は入っていない。`vite-plus` 0.3.0 が `vitest/config` から型付きで再 export している。
- glob は `relative(config.dir || config.root, moduleId)` に対して照合されるので、root 起点の `.claude/worktrees/**` で足りる。worktree を root にして走らせた場合はこの path に一致しないため、同じ 19 file が見つかる。
- `.claude/**` をまとめて除外する案は落とした。`.claude/hooks/check-md-links.test.ts` は 19 file のうちの 1 つで、まとめて除外すると黙って走らなくなる。
- 正の `test.include` に切り替える案も落とした。tracked な test file は `src`(14) / `tools`(3) / `scripts`(1) / `.claude`(1) の 4 root に散っているので `.claude/hooks/**` を書く必要があり、`.claude/worktrees/**` と同じ親の下で区別する問題は残る。失敗の向きも悪くなる。除外の失敗は「余分に走って落ちる」で、allowlist の失敗は「新しい root の test が黙って走らない」。

## coverage.include は変えていない

読んで決めた。`coverage.include` の entry はすべて root 起点で先頭が literal segment（`src` / `scripts` / `tools`）なので、tinyglobby の partial matcher が第 1 階層で枝を刈り、`.claude/worktrees/<agent>/src/entities/...` には一致しない。worktree が 5 つある main checkout で coverage 付きで走らせたところ、coverage map は 8 file、`.claude/worktrees` 配下は 0 file だった。対称性で足すと、`coverage.include` は自分では歩かない場所を除外する list を持つことになる。

## user の判断に回す 1 件（reviewer の CONFIRMED 指摘）

`tsconfig.json` の `include` は `["**/*.ts", "**/*.tsx", ".claude/hooks/**/*.ts", "src/routeTree.gen.ts"]` で、`**/*.ts` は `.mts` に一致しない。`bunx tsc -p tsconfig.json --listFiles --noEmit` の出力に `vitest.config.mts` は現れない。つまり今回足した `defaultExclude` の import specifier は `bun run check` の型検査を通っていない。specifier を書き間違えても check は通り、`bun run test` の config load で落ちる。

reviewer が求めた変更は `tsconfig.json` の `include` に `"vitest.config.mts"` を 1 行足すこと。入れなかった理由は 2 つ。この gap は今回の diff より前から、この file の全 key について存在している。もう 1 つは、この ticket の scope が `vitest.config.mts` 1 file で、tsconfig の program に config file を入れると whole-tree の型検査対象が変わるので、別 ticket で影響を測るほうが安全だという判断。受け入れる場合の観測点は `bunx tsc -p tsconfig.json --listFiles --noEmit | grep -c "vitest.config.mts"` が 1 を出すこと（今は 0）。

## 見送った cleanup 1 件

`dist/**` `.wrangler/**` `coverage/**` `.tanstack/**` を同じ array に足すと、readdir が 89 回から 52 回に減る（19 file という結果は変わらない）。差は数 ms で、finding を出した reviewer 自身も fix ではなく小さな勝ちだと書いている。生成物 directory の手入れ list を 1 つ増やすことになるので入れなかった。`.wrangler/state` は local 開発で育つので、体感に出るなら別 ticket で足せる。

## 前提として置いた assumption

- `.claude/worktrees/` 以外に別 install の checkout が置かれることはない前提で glob を 1 本にした。`.gitignore:60` と AGENTS.md がこの path を worktree の置き場として書いている。
- Japanese の comment（`include が対象の全リスト`）は指示どおり触っていない。`exclude` は `isolate` の直後に置いて、この comment の隣に来ないようにした。comment は今も `coverage:` の直上にある。
- test は足していない。この diff は branch も module も追加せず、変えたのは vitest 自身の discovery なので、AGENTS.md の Testing 節が求める「足した branch を落とす test」に対応する対象がない。

## gate

`bun run check` clean、`bun run test` は 19 file / 462 test / branches 100%。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the main checkout test gate so it stays green while parallel workers have worktrees checked out. Vitest was picking up duplicated test files under `.claude/worktrees/`, and because each worktree has its own install, those copies failed module resolution; the gate only passed when no worktrees existed.

Adds `exclude: [...defaultExclude, ".claude/worktrees/**"]` to `vitest.config.mts`. Since `test.exclude` replaces the default in `vitest` 4, `defaultExclude` from `vite-plus` is spread in first.

**Notes**
- Running from inside a worktree still finds the same 19 test files because the glob is matched relative to the config root.
- `.claude/**` is not excluded because `.claude/hooks/check-md-links.test.ts` is one of those 19 files.
- `coverage.include` is unchanged; its patterns already stop at the first path segment, so worktree files aren't covered.
- `tsconfig.json` still doesn't include `vitest.config.mts`, so the new `defaultExclude` import isn't type-checked by `bun run check`; that gap predates this diff and is left for a separate ticket.

<sup>Written for commit d8839491e4962b1e1810b80f3bb142a7c8a63a22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imaimai17468/imaimai-front-templete/pull/135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

