### PR TITLE
fix: 型アサーションを lint が error にする

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -79,6 +79,13 @@ export default defineConfig({
       "vitest/no-hooks": "off",
       "@typescript-eslint/ban-ts-comment": "error",
       "@typescript-eslint/no-non-null-assertion": "error",
+      // Without the option the rule rewrites `<T>x` into `x as T` and lets
+      // `as` through. `never` reports both forms and leaves `as const` and
+      // `satisfies` alone.
+      "@typescript-eslint/consistent-type-assertions": [
+        "error",
+        { assertionStyle: "never" },
+      ],
       "@typescript-eslint/switch-exhaustiveness-check": "error",
       "@typescript-eslint/no-misused-promises": "error",
       "@typescript-eslint/consistent-type-imports": "error",


### PR DESCRIPTION
AGENTS.md の Code Practices は `as`（`as const` を除く）、`any`、`@ts-ignore` 系、非 null `!`、lint-disable コメントを禁じている。`vite.config.ts` の `rules` は `any`、`@ts-comment` 系、非 null `!` を error にしていたが、`as` を止める設定は入っていなかった。

## 入れた設定

```ts
"@typescript-eslint/consistent-type-assertions": [
  "error",
  { assertionStyle: "never" },
],
```

`@typescript-eslint/ban-ts-comment` と `@typescript-eslint/no-non-null-assertion` の直後に置いた。この 2 つが AGENTS.md の同じ一文から来る規則で、`overrides` のどのブロックもこの rule を off にしていない。

`core` は同じ rule を `typescript/consistent-type-assertions: "error"` として既に入れている（`node_modules/ultracite/config/oxlint/core/index.mjs:359`）。oxlint は 2 つの綴りを同じ rule id に正規化するので、この entry は options を上書きするだけで rule が二重に走ることはない。probe に対して出た診断は 1 件で、rule 名は `typescript(consistent-type-assertions)`、options は `never` 側だった。`switch-exhaustiveness-check`、`no-misused-promises`、`consistent-type-imports`、`consistent-type-exports` がこの file で既に同じ形を取っている。

lint 時間は増えない。`consistent-type-assertions` は type-aware rule ではないので `oxlint-tsgolint` の pass を呼ばない。

## oxlint 1.79.0 で確認したこと

`node_modules/oxlint/package.json` の version は 1.79.0（`package.json:72` の pin と `vite-plus` 0.3.0 の `oxlint` 依存が同じ値）。scratch の probe を素の oxlint に食わせた結果:

| 設定 | `"x" as string` | `<string>"y"` | `{ x: 1 } as const` | `"z" satisfies string` |
| --- | --- | --- | --- | --- |
| `"error"`（core が入れていた値） | 報告しない | 報告する（`as` へ書き換えろという help 付き） | 報告しない | 報告しない |
| `["error", { assertionStyle: "never" }]` | 報告する | 報告する | 報告しない | 報告しない |

つまり設定前の rule は `<T>x` を `x as T` へ誘導していて、`as` そのものは素通りしていた。

`vp lint` 経由でも発火することを、`src/` と `scripts/` にそれぞれ probe file を置いて確認した（どちらも `typescript(consistent-type-assertions)` を出した）。probe file は削除済みで、この PR の diff は `vite.config.ts` の 7 行だけ。

## 違反件数: 0 件

設定を入れてから `bun run lint` が報告した `consistent-type-assertions` は 0 件で、修正した file はない。ツリー全体の `\bas [A-Za-z_{(<]` の grep が拾ったのはコメントと `import { X as Y }` だけだった。

`src/routeTree.gen.ts` は `as any` を 6 箇所持つが lint に引っかからない。1 行目が `/* eslint-disable */` で、oxlint はこれを file 全体の disable として扱う。header の 3 行を落とした copy を同じ config に食わせると `typescript(no-explicit-any)` が出るので、この header が黙らせている。file は `.gitignore:23` にも載っている。`tsr generate` の出力なので手で直す対象ではなく、この穴は今回の rule より前から `no-explicit-any` と `ban-ts-comment`（3 行目が `// @ts-nocheck`）に対して開いていた。

## safety-comment rule について（判断を渡す）

`ultracite/oxlint/anti-slop` が入れている `anti-slop/require-safety-comment-for-type-assertion` は、近くに `SAFETY:` コメントを持つ assertion を許す rule で、AGENTS.md の「`as` は禁止」と食い違っていた。`assertionStyle: "never"` はこの食い違いを AGENTS.md 側に決めた。

**混乱するメッセージは出る。** probe で確認した挙動:

- `SAFETY:` コメントなしの assertion → `consistent-type-assertions` と `require-safety-comment-for-type-assertion` の 2 件が同じ位置に出る。後者は「`SAFETY:` を書け」と指示するが、書いても前者が残るので、そのメッセージに従った作者は 2 回目の lint でまた落ちる。
- `SAFETY:` コメント付きの assertion → `consistent-type-assertions` だけが出る。

**dead weight になった。** `require-safety-comment-for-type-assertion` の report 集合は `consistent-type-assertions` の真部分集合になった。plugin の実装（`ultracite/config/oxlint/anti-slop/plugin.mjs`）が `TSAsExpression` と `TSTypeAssertion` しか visit しないので、assertion がない code で単独に発火することはない。

**選べる 3 つ。** `code-reviewer` もこの点を挙げ、判断は PR の author が持つと返した。

1. `anti-slop/require-safety-comment-for-type-assertion` だけを `"off"` にする。二重報告が消えるが、同じ理由で subset になった rule が他に 3 つ残る。`anti-slop/no-chained-type-assertions` と `anti-slop/no-widen-then-assert` は plugin の実装で `TSAsExpression` と `TSTypeAssertion` だけを visit していて、`typescript/no-unsafe-type-assertion` も probe で 2 回とも `consistent-type-assertions` と同じ行に出た。
2. 4 つとも有効なまま残す。二重報告と、上に書いた誤誘導するメッセージを受け入れる。
3. 4 つとも `"off"` にする。assertion 1 つに error が 1 件になるが、`assertionStyle` を将来緩めたときに assertion 固有のメッセージが戻らない。

**2 を選んだ。** 1 は config の行を増やしながら残り 3 つで同じ二重報告を残すので、一般的な条件（assertion を全面禁止したので assertion 系 rule がまとめて subsume された）のうち 1 件だけを直すことになる。3 は assertion 系 rule 4 つを刈る判断で、この ticket の範囲より広い。どちらを取るかを決めるのはこの PR の読み手なので、4 つとも有効なまま残して判断を渡す。

## 残っている穴

`// oxlint-disable-next-line typescript/consistent-type-assertions` を書いた probe file は `bun run lint` が 1 件も報告しなかった。file 冒頭の `/* eslint-disable */` も同じく効く（`src/routeTree.gen.ts` がその実例）。どちらも oxlint が rule 名を問わず解釈する directive なので、この穴は今回の rule で新しく開いたものではない。AGENTS.md の「lint-disable コメントで error を黙らせない」は gate ではなく規則として残っている。

## 前提

- ticket に書かれていない範囲、つまり `AGENTS.md`、`.claude/hooks/`、`.claude/skills/`、`vitest.config.mts`、`tsconfig.json` は触っていない。
- knip が出す `oxlint-plugin-react-doctor / knip.json / Remove from ignoreDependencies` は、この branch を rebase した先の `origin/main`（57c2bbb）でも同じ 1 行が出る（`git stash` して確認した）ので、この PR の変更ではない。exit code は 0。

## Gate

`bun run check` / `bun run test`（19 files, 462 tests, branch 100%）/ `bun run knip` / `bun run doctor --no-score` / `bun run check:pins` がすべて通っている。
