### PR TITLE
feat: テストを壊した turn を Stop gate が止める

### DIFF
--- a/.claude/hooks/stop-gate.sh
+++ b/.claude/hooks/stop-gate.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 # Stop combined gate:
-# 1. Quality gate — typecheck / lint / format (blocking)
-#    — knip and similarity are not here: their verdict is a property of the whole
-#      tree rather than of this turn's diff, so CI runs knip and lefthook's
-#      pre-push runs similarity-ts
+# 1. Quality gate — typecheck / lint / format, then the test suite (blocking)
+#    — knip and similarity are not here: their verdict is a property of more
+#      than this turn's diff, so CI runs knip and lefthook's pre-push runs
+#      similarity-ts
 #    — runs only when code-relevant files changed (docs-only turns skip it)
 #    — respects stop_hook_active: if this Stop was already blocked once, a
-#      still-failing gate downgrades to a warning instead of blocking again,
-#      so a pre-existing failure the agent cannot fix does not loop forever
+#      failing gate downgrades to a warning instead of blocking again, so a
+#      pre-existing failure the agent cannot fix does not loop forever. The
+#      steps below fail fast, so the second Stop can carry a failure the first
+#      one never reported
 # 2. Markdown link check — blocking; dead relative links are decidable by opening
 #    the path, so they belong here rather than in a reviewer's judgment
 
@@ -50,6 +52,14 @@ emit_block() { # $1 = summary, $2 = reason body (stdin-free)
   exit 0
 }
 
+# `local out` is separate from the assignment because `local out=$(...)` would
+# report local's own exit status and lose the one `bun run` returned.
+run_or_block() { # $1 = the `bun run` script to run
+  local out
+  out=$(bun run "$1" 2>&1) ||
+    emit_block "bun run $1 failed. Fix before ending the turn." "$out"
+}
+
 # Skip when there are no changes
 if [ -z "$(git status --porcelain)" ]; then
   exit 0
@@ -65,16 +75,13 @@ ALL_FILES=$(printf '%s\n%s' "$CHANGED" "$UNTRACKED" | sort -u)
 
 # ==== 1. Quality gate (only when code-relevant files changed) ====
 
-CODE_CHANGED=$(printf '%s\n' "$ALL_FILES" | grep -cE '\.(ts|tsx|js|jsx|mjs|cjs|json|css)$' || true)
+CODE_CHANGED=$(printf '%s\n' "$ALL_FILES" | grep -cE '\.(ts|mts|cts|tsx|js|jsx|mjs|cjs|json|css)$' || true)
 
 if [ "$CODE_CHANGED" -gt 0 ]; then
-  # Layer 1: format, lint and type check in one pass. `bun run check` is
-  # `vp check`, which runs all three over one file walk.
-  OUT=$(bun run check 2>&1)
-  RC=$?
-  if [ $RC -ne 0 ]; then
-    emit_block "bun run check failed. Fix before ending the turn." "$OUT"
-  fi
+  # `bun run check` is `vp check`, which formats, lints and type-checks over one
+  # file walk. `bun run test` is `vp test --run --coverage`.
+  run_or_block check
+  run_or_block test
 fi
 
 # ==== 2. Markdown link check ====
@@ -103,7 +110,7 @@ LINK_NOTE="md links: clean"
 [ "$LINKS_AVAILABLE" = "false" ] && LINK_NOTE="md links: SKIPPED (bun not installed)"
 
 if [ "$CODE_CHANGED" -gt 0 ]; then
-  jq -n --arg links "$LINK_NOTE" '{"systemMessage":("✅ Stop gate: typecheck / lint / format pass (" + $links + ")")}'
+  jq -n --arg links "$LINK_NOTE" '{"systemMessage":("✅ Stop gate: typecheck / lint / format and the test suite pass (" + $links + ")")}'
 else
   jq -n --arg links "$LINK_NOTE" '{"systemMessage":("✅ Stop gate: no code-relevant changes (quality gate skipped, " + $links + ")")}'
 fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -58,8 +58,8 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/stop-gate.sh",
-            "timeout": 120,
-            "statusMessage": "Stop gate: typecheck / lint / format + markdown links..."
+            "timeout": 240,
+            "statusMessage": "Stop gate: typecheck / lint / format + tests + markdown links..."
           }
         ]
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ Your training data goes stale. Outdated guidance is worse than no guidance.
 
 **Generated types stay generated:** after any `wrangler.toml` change, run `bun run cf-typegen`. That command writes `worker-configuration.d.ts`, so never hand-edit it.
 
-**Verification before completion:** Never report done without running `bun run check` and `bun run test`, fixing every error. `check` is `vp check`, which formats, lints and type-checks in one pass. A change touching no code skips both. `knip` and `similarity-ts` judge the whole tree rather than your diff, and CI and the pre-push hook run them.
+**Verification before completion:** `knip` and `similarity-ts` judge more than your diff, so the Stop gate runs neither: CI runs `knip` on every pull request, and lefthook's pre-push runs `similarity-ts` over `src/` where that binary is on PATH, skipping the step where it is not. Neither is filtered by which files your change touched, and what either finds is yours to fix.
 
 **Never escape the type system to move on:** no `as` (except `as const`), `any`, `@ts-ignore`/`@ts-expect-error`/`@ts-nocheck`, non-null `!`, or lint-disable comments to silence an error. Fix the type (narrowing, guards, schema validation, `satisfies`). Where you genuinely cannot, dispatch a subagent with the right skill. Where that still fails, leave the PR in Draft with a comment naming the type that will not resolve and report it, and never silently cast or suppress.
 
@@ -100,7 +100,7 @@ Tests are written against the implementation, and test-first is not required. Wh
 - **One test, one `expect`, arranged as Arrange / Act / Assert.** A table-driven case is one test per row and obeys the same rule.
 - **A structural result is asserted as one whole object.** Build what the unit produced, whether that is a set of fields or a response's status and headers, and compare it with `toStrictEqual` in a single `expect`. It fails with the whole shape, where field-by-field expects stop at the first mismatch and hide the rest.
 
-Reaching a component's branches from a test depends on how the component was shaped, and `.claude/rules/react.md` (Testable Behavior Extraction) governs that. Run `bun run test` yourself, because nothing else runs the suite before CI.
+Reaching a component's branches from a test depends on how the component was shaped, and `.claude/rules/react.md` (Testable Behavior Extraction) governs that.
 
 ## Commits & Pull Requests
 


### PR DESCRIPTION
## 何が良くなるか

テストを壊した turn がそのまま終わり、CI が後で見つけていました。`.claude/settings.json` が `Stop` に登録している `.claude/hooks/stop-gate.sh` は `bun run check` と markdown link check だけを走らせ、suite を走らせる hook も lefthook の stage もありませんでした。

その gate に `bun run test` を `bun run check` の隣へ足します。新しい仕組みは足さず、既存の経路に乗せました。docs だけの turn を飛ばす changed-file 判定、`stop_hook_active`（Cursor では `loop_count`）による二度目の warning 降格、`emit_block` を `bun run check` と共有します。

`bun run check` と同じ `OUT=$(...)` / `RC=$?` / `if` を 2 つ並べる形になったので、`emit_block` の隣に `run_or_block` を切り出し、両方をその呼び出しにしました。`local out` を代入と分けているのは、`local out=$(...)` が `local` 自身の exit status を返し、`bun run` が返した側を失うからです（`local out=$(printf boom; exit 1)` の直後の `$?` は 0、分けた場合は 1 になることを probe script で確認しました）。

## 測定

macOS、この worktree、並列 worker が数本動いている状態で計測しました。

| 対象 | 初回（install 直後の worktree） | warm |
| --- | --- | --- |
| `bun run check` | 48.1s | 7.3s |
| `bun run test` | 41.1s | 4.0s |
| `bun .claude/hooks/check-md-links.ts` | 0.25s | 0.25s |
| gate 全体（Stop payload を渡して直接起動） | 未計測（上の合計 89.5s） | 12.9s / 15.9s / 16.4s / 23.7s |

gate 全体の初回は計測していません。表の初回列の合計が 89.5s です。`node_modules/.vite` を消してから起動しても 15.9s のままだったので、初回の 40〜50s は vite の cache ではありません。残る候補は install 直後の worktree の cold な page cache と worker どうしの競合ですが、そこまで切り分けていません。

`Stop` hook の `timeout` は 120 から 240 にしました。cold 合計 89.5s は 120 に対して 30s しか残しません。240 なら cold 合計の 2.7 倍で、`bun run check` だけだった頃の 120 / 48.1 = 2.5 倍とほぼ同じ余裕になります。warm の gate の最大 23.7s に対しては 10 倍です。warm の幅が 12.9s から 23.7s まで開くのは並列 worker の競合で、gate は worker が turn を終えるたびに走るので、この競合が起きている状態が想定すべき状態です。

## 挙動の変更: coverage threshold

`bun run test` は `vp test --run --coverage` なので、`vitest.config.mts` の `coverage.include` に載っているモジュールが per-file 100% branch を割ると gate が turn を止めます。二方向で測りました。

- `src/lib/utils.ts`（include 済み）に test の無い `n > 0 ? "a" : "b"` を足す → exit 1、`ERROR: Coverage for branches (0%) does not meet global threshold (100%) for src/lib/utils.ts`
- 同じ関数を include に無い新規ファイル `src/lib/scratch-probe-aebd.ts` に置く → exit 0

これが止まったとき worker がすることは、その branch に届く test を書くことです。`coverage.include` からモジュールを外すことと `--coverage` を外すことは、どちらもこの gate を無効化します。

新規の純粋モジュールを include に載せないままだと何も測られない点は、AGENTS.md の Testing が既に書いています。

この threshold の話は script の comment には書いていません。`.claude/hooks/stop-gate.sh` から `vitest.config.mts` の key 名を指す comment は、その key が改名された瞬間に黙って嘘になります（AGENTS.md の「A comment's subject never lives outside what it ships with」）。comment には `bun run test` が `vp test --run --coverage` であることだけを残しました。

## `CODE_CHANGED` が `.mts` を拾う

`CODE_CHANGED` の pattern は `\.(ts|tsx|js|jsx|mjs|cjs|json|css)$` で、`.mts` に一致しませんでした。tracked な `.mts` は `vitest.config.mts` の 1 本だけで、それはこの PR が gate に載せた per-file threshold を決めているファイルであり、AGENTS.md の Testing が「新しい純関数モジュールを足したらここにも足す」と編集を指示しているファイルでもあります。その 1 ファイルだけを触った turn は gate を丸ごと飛ばしていました。pattern に `mts|cts` を足しました（`mjs|cjs` が既に対になっているのに合わせています）。

`.toml`、`.yml`、`.yaml`、`.sh`、`.sql` は今も pattern の外です。tracked なものは `bunfig.toml`、`lefthook.yml`、`mise.toml`、`wrangler.toml`、`.github/dependabot.yml`、`.github/workflows/ci.yaml`、`.claude/hooks/` の 3 本の `.sh`、`scripts/cloud-agent-install.sh`、migration 1 本です。これらだけを触った turn は Stop gate を飛ばし、`lefthook.yml` の pre-push の `bun run check` が拾います。どの拡張子を gate が持つかはこの ticket の外なので広げていません。

## gate が実際に止まることの確認

最初は `src/lib/utils.test.ts` の assertion を 1 つ反転させました（`expect(cn("px-2", "px-4")).toBe("px-2")`）。

- 変更後の gate は `"decision": "block"` と `bun run test failed. Fix before ending the turn.` を返し、`reason` に失敗した test が入りました
- 同じ tree に対して origin/main の gate は `✅ Stop gate: typecheck / lint / format pass (md links: clean)` を返しました。この ticket が直す欠陥そのものです
- assertion を戻すと `✅ Stop gate: typecheck / lint / format and the test suite pass (md links: clean)` を返しました

`run_or_block` を切り出した後、失敗する test 1 本だけの probe file を置いて両方向をもう一度通しました。`emit_block` の `exit 0` が `run_or_block` の内側から script を終わらせることは、gate の出力が block の JSON で終わり、その後に成功行が続かないことで確認しました（`printf boom; exit 1` を返す probe script でも、`||` から呼んだ関数の `exit 0` が script 全体を終わらせることを確認しています）。probe file の最初の版が lint に引っかかったので、`run_or_block check` の側が block することも同じ経路で確認できました。

`stop_hook_active: true` の payload を同じ probe file に対して渡すと、gate は `decision` を付けず `⚠️ Stop gate STILL failing (not re-blocking — stop_hook_active): bun run test failed.` を返しました。新しい layer が降格の経路も継いでいます。

probe file と反転させた assertion はどちらも commit に入っていません。片付けた後の `git status --porcelain` は `.claude/hooks/stop-gate.sh`、`.claude/settings.json`、`AGENTS.md` の 3 行だけです。

## AGENTS.md の 2 箇所

**Verification before completion**（Code Practices）から `bun run check` と `bun run test` の指示を落とし、hook が走らせないものだけを書きました。

> **Verification before completion:** `knip` and `similarity-ts` judge more than your diff, so the Stop gate runs neither: CI runs `knip` on every pull request, and lefthook's pre-push runs `similarity-ts` over `src/` where that binary is on PATH, skipping the step where it is not. Neither is filtered by which files your change touched, and what either finds is yours to fix.

`check` は `vp check` である、という一文もここから消しました。README.md:15、`.github/workflows/ci.yaml`:111、`.claude/hooks/stop-gate.sh` が同じことを書いているので、AGENTS.md が 4 つ目の写しでした。

`similarity-ts` の側は 2 回書き直しています。「the whole tree」は `lefthook.yml` の `similarity-ts ./src --fail-on-duplicates` に対して広すぎ（`tools/`、`scripts/`、`.claude/hooks/*.ts` は scan の外）、「on every push」は同じ command の `skip: - run: "! command -v similarity-ts"` に対して無条件すぎました。`.claude/hooks/stop-gate.sh` の header comment も同じ「whole tree」を書いていたので揃えました。

**「A change touching no code skips both」を書き換えた理由を、決めてもらう必要があります。** ticket はこの一文を残すよう指示していました。元の段落での「both」は `bun run check` と `bun run test` で、`CODE_CHANGED` 判定がまさにそれを実装しています。段落から check と test が消えた後、「both」は直前の 2 語である knip と similarity-ts を指し、その 2 つについてこの文は偽になります。`.github/workflows/ci.yaml` に `paths` filter は無く、knip の step に `if` も無いので、CI は docs だけの PR でも `bun run knip` を走らせます。`lefthook.yml` の pre-push の `similarity` command にも glob はありません。偽の一文を残すより、真の側（どちらも変更したファイルで絞られない）を書きました。check と test について「code を触らない変更は飛ばす」という事実は、いま `.claude/hooks/stop-gate.sh` の `CODE_CHANGED` が持っています。

Testing の最後の一文「Run `bun run test` yourself, because nothing else runs the suite before CI.」は削除し、その前の一文で節を終えました。理由の側がこの PR で偽になります。gate の内容はどちらの節にも書き足していません。`.claude/hooks/` がそれを持ち、走らない gate の扱いは Degraded Environments が持っています。

## 判断と前提

`bun run test` をそのまま呼び、`vp test --run`（coverage 無し）にはしませんでした。coverage が止める turn はこの ticket の意図で、既存の経路に乗せる指示もありました。

`bun run check` を先、suite を後にしました。型エラーがあるときの suite の出力は読む価値が下がります。この順序に依存する主張は script の comment に書いていません。

`timeout` は 240 で、より小さい値にはしませんでした。最悪ケースは install 直後の worktree の最初の turn で、しかも worker が数本動いている状態です。

セッションが `bun run check` と `bun run test` を自分で走らせる指示は `.claude/skills/ticket-work/SKILL.md` の step 6 と AGENTS.md の Commits & Pull Requests に残っているので、AGENTS.md からその指示が消えてもセッションは指示を失いません。

## 決めてほしい指摘: 2 つ同時に壊れた turn は warning で終わる

`code-reviewer` が挙げ、変更を入れませんでした。

`run_or_block check` が失敗すると `emit_block` の `exit 0` で script が終わるので、`run_or_block test` は走りません。agent が check を直して二度目に止まると、その Stop は `stop_hook_active` を立てて来るので、test の失敗は block ではなく warning になります。turn は suite が赤いまま終わります。この PR の前は 2 段目が markdown link check だったので、壊れやすい step が 2 つ同じ「一度だけ block できる」枠を分け合う形は、この PR が作りました。

reviewer が求めた変更は、`run_or_block` が `emit_block` を自分で呼ぶ代わりに失敗を溜め、両方走らせた後で 1 回だけ `emit_block` を呼ぶ形です。1 つの Stop が両方の失敗を報告できます。代わりに typecheck が壊れている turn も suite の時間（warm 4.0s、初回 41.1s）を払います。

入れなかった理由は、fail-fast をやめるのが `bun run check` 側の既存の挙動の変更で、この ticket の範囲を超えるからです。降格したときの文面は「if this failure is pre-existing or unfixable, report it to the user explicitly; do not treat it as passed.」なので、agent は赤いまま黙って終わることを許されてはいません。header comment には fail-fast であることと、二度目の Stop が一度も報告されていない失敗を運べることを書きました。溜める形に変えるかは決めてください。

## 見送った指摘

`simplify` の efficiency reviewer が 2 つ挙げ、どちらも見送りました。

`bun run check` と `bun run test` を並行に走らせる（warm で `max(7.3, 4.0)` = 7.3s、初回で `max(48.1, 41.1)` = 48.1s まで縮む）。見送った理由は 2 つあります。失敗の報告が変わり、最初の失敗で止めて 1 つの出力を返すという現在の挙動を捨てることになります。それに AGENTS.md の Commits & Pull Requests が worker 1 本を 4 GB（うち `bun run check` が 1.4 GB）で見積もっているところへ、gate が check と vitest を同時に抱える形になります。並行化を選ぶなら独立した ticket が要ります。

`bun run test -- --coverage.reporter=text` にして `coverage/` への 15 ファイル 432KB の書き込みを省く。gitignore 済みのディレクトリへの turn ごと 432KB より、gate の command が AGENTS.md と CI と ticket-work が名前で呼ぶ `bun run test` と一致していることを取りました。

## 範囲外で直していないもの

README.md:26 は `similarity-ts` を「Stop gate の重複検出」と書き、README.md:34 は Stop gate が欠落を「スキップした」と明示すると書いています。`.claude/hooks/stop-gate.sh` は similarity-ts を走らせません（header comment が、CI が knip を、lefthook の pre-push が similarity-ts を走らせると書いています）。欠落を報告するのは `.claude/hooks/session-start-env-check.sh` で、走らせるのは lefthook の pre-push です。この 2 行はこの PR の前から偽で、この ticket の範囲外なので触っていません。

`.claude/skills/ticket-work/SKILL.md` の step 6 は `bun run check` と `bun run test` を自分で走らせるよう言い続けます。偽ではなく、turn の終わりを待たずに直すための指示として機能します。gate と重なる点をどう扱うかは範囲外です。

shellcheck がこの環境の PATH に無いので、shell の変更は静的に lint していません。代わりに gate を何度も起動し、pass、`run_or_block check` の block、`run_or_block test` の block、`stop_hook_active` の降格を通しました。

## 確認

- `bun run check` 通過
- `bun run test` 通過（19 files / 462 tests、branches 100%）
- `bun .claude/hooks/check-md-links.ts` 通過（21 files）


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Stop gate run `bun run test` after `bun run check`, so a turn that breaks a test or drops per-file branch coverage below 100% is blocked at turn end instead of being found by CI later.

**Behavior changes**

- `run_or_block` now wraps both `bun run check` and `bun run test`, sharing the existing `CODE_CHANGED`, `stop_hook_active`, and `emit_block` paths.
- `CODE_CHANGED` matches `.mts`/`.cts`; `vitest.config.mts` alone previously skipped the gate entirely.
- Stop hook timeout raised from 120s to 240s; cold-start runs measure ~89.5s total.
- `AGENTS.md` now describes only what the gate does not run (`knip`, `similarity-ts`).

**Decision needed**

- When both check and test fail, only the check failure blocks; the second Stop carries the test failure as a warning because `stop_hook_active` is set. The alternative is collecting both failures and using the single block for both.

<sup>Written for commit 3dfdeef6da37feaec5b33c865bef825f5104b2c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imaimai17468/imaimai-front-templete/pull/140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

