### PR TITLE
fix: clean-worktrees の keep 理由が GitHub との前後関係を取り違えなくなる

### DIFF
--- a/scripts/orchestrate-decisions.test.ts
+++ b/scripts/orchestrate-decisions.test.ts
@@ -440,6 +440,17 @@ describe(ancestryKeepReason, () => {
     expect(reason).toBe("commits main does not hold");
   });
 
+  it("should name the commit when the repository does not have the holder's", () => {
+    const reason = ancestryKeepReason(
+      { commit: "4b486bc", kind: "absent" },
+      "the pull request"
+    );
+
+    expect(reason).toBe(
+      "the pull request is at commit 4b486bc, which this repository does not have"
+    );
+  });
+
   it("should name the failure when the ancestry check could not run", () => {
     const reason = ancestryKeepReason(
       { kind: "failed", reason: "fatal: not a git repository" },
@@ -510,6 +521,20 @@ describe(worktreeVerdict, () => {
     expect(verdict).toStrictEqual({
       kind: "keep",
       reason: "commits the pull request does not hold",
+    });
+  });
+
+  it("should keep the worktree when the pull request's commit is not in this repository", () => {
+    const verdict = worktreeVerdict({
+      kind: "pull-request",
+      pullRequest: pullRequest("MERGED", "UNKNOWN"),
+      pullRequestAncestry: { commit: "4b486bc", kind: "absent" },
+    });
+
+    expect(verdict).toStrictEqual({
+      kind: "keep",
+      reason:
+        "the pull request is at commit 4b486bc, which this repository does not have",
     });
   });
 

--- a/scripts/orchestrate-decisions.test.ts
+++ b/scripts/orchestrate-decisions.test.ts
@@ -428,34 +428,35 @@ describe(localVerdict, () => {
 });
 
 describe(ancestryKeepReason, () => {
-  it("should return undefined when main holds the branch commits", () => {
-    const reason = ancestryKeepReason({ kind: "ancestor" });
+  it("should return undefined when the holder holds the branch commits", () => {
+    const reason = ancestryKeepReason({ kind: "ancestor" }, "main");
 
     expect(reason).toBeUndefined();
   });
 
-  it("should name the commits when the branch holds one main does not", () => {
-    const reason = ancestryKeepReason({ kind: "not-ancestor" });
+  it("should name the holder when the branch holds a commit the holder does not", () => {
+    const reason = ancestryKeepReason({ kind: "not-ancestor" }, "main");
 
     expect(reason).toBe("commits main does not hold");
   });
 
   it("should name the failure when the ancestry check could not run", () => {
-    const reason = ancestryKeepReason({
-      kind: "failed",
-      reason: "fatal: not a git repository",
-    });
+    const reason = ancestryKeepReason(
+      { kind: "failed", reason: "fatal: not a git repository" },
+      "main"
+    );
 
-    expect(reason).toBe("failed: fatal: not a git repository");
+    expect(reason).toBe(
+      "git could not compare with main: fatal: not a git repository"
+    );
   });
 });
 
 describe(worktreeVerdict, () => {
-  it("should remove the worktree when its branch has no pull request and main holds its HEAD", () => {
+  it("should remove the worktree when its branch has no pull request and main holds its commits", () => {
     const verdict = worktreeVerdict({
-      ancestry: { kind: "ancestor" },
-      headSha: HEAD_SHA,
-      pullRequest: NO_PULL_REQUEST,
+      kind: "no-pull-request",
+      mainAncestry: { kind: "ancestor" },
     });
 
     expect(verdict).toStrictEqual({ kind: "remove" });
@@ -463,9 +464,8 @@ describe(worktreeVerdict, () => {
 
   it("should keep the worktree when its branch has no pull request and holds a commit main does not", () => {
     const verdict = worktreeVerdict({
-      ancestry: { kind: "not-ancestor" },
-      headSha: HEAD_SHA,
-      pullRequest: NO_PULL_REQUEST,
+      kind: "no-pull-request",
+      mainAncestry: { kind: "not-ancestor" },
     });
 
     expect(verdict).toStrictEqual({
@@ -476,22 +476,22 @@ describe(worktreeVerdict, () => {
 
   it("should keep the worktree when its branch has no pull request and the ancestry check could not run", () => {
     const verdict = worktreeVerdict({
-      ancestry: { kind: "failed", reason: "fatal: bad revision" },
-      headSha: HEAD_SHA,
-      pullRequest: NO_PULL_REQUEST,
+      kind: "no-pull-request",
+      mainAncestry: { kind: "failed", reason: "fatal: bad revision" },
     });
 
     expect(verdict).toStrictEqual({
       kind: "keep",
-      reason: "no pull request, failed: fatal: bad revision",
+      reason:
+        "no pull request, git could not compare with main: fatal: bad revision",
     });
   });
 
   it("should keep the worktree when its pull request is still open", () => {
     const verdict = worktreeVerdict({
-      ancestry: { kind: "ancestor" },
-      headSha: HEAD_SHA,
+      kind: "pull-request",
       pullRequest: pullRequest("OPEN"),
+      pullRequestAncestry: { kind: "ancestor" },
     });
 
     expect(verdict).toStrictEqual({
@@ -500,34 +500,51 @@ describe(worktreeVerdict, () => {
     });
   });
 
-  it("should keep the worktree when its HEAD is a commit GitHub does not hold", () => {
+  it("should keep the worktree when its branch holds a commit the pull request does not", () => {
     const verdict = worktreeVerdict({
-      ancestry: { kind: "ancestor" },
-      headSha: "deadbee",
+      kind: "pull-request",
       pullRequest: pullRequest("MERGED", "UNKNOWN"),
+      pullRequestAncestry: { kind: "not-ancestor" },
     });
 
     expect(verdict).toStrictEqual({
       kind: "keep",
-      reason: "commits GitHub has not seen",
+      reason: "commits the pull request does not hold",
     });
   });
 
-  it("should remove the worktree when its pull request is merged", () => {
+  it("should keep the worktree when git could not compare its branch with the pull request's commit", () => {
     const verdict = worktreeVerdict({
-      ancestry: { kind: "not-ancestor" },
-      headSha: HEAD_SHA,
+      kind: "pull-request",
       pullRequest: pullRequest("MERGED", "UNKNOWN"),
+      pullRequestAncestry: {
+        kind: "failed",
+        reason: "fatal: Not a valid commit name 4b486bc",
+      },
+    });
+
+    expect(verdict).toStrictEqual({
+      kind: "keep",
+      reason:
+        "git could not compare with the pull request: fatal: Not a valid commit name 4b486bc",
+    });
+  });
+
+  it("should remove the worktree when its pull request is merged and holds its branch commits", () => {
+    const verdict = worktreeVerdict({
+      kind: "pull-request",
+      pullRequest: pullRequest("MERGED", "UNKNOWN"),
+      pullRequestAncestry: { kind: "ancestor" },
     });
 
     expect(verdict).toStrictEqual({ kind: "remove" });
   });
 
-  it("should remove the worktree when its pull request is closed", () => {
+  it("should remove the worktree when its pull request is closed and holds its branch commits", () => {
     const verdict = worktreeVerdict({
-      ancestry: { kind: "not-ancestor" },
-      headSha: HEAD_SHA,
+      kind: "pull-request",
       pullRequest: pullRequest("CLOSED", "UNKNOWN"),
+      pullRequestAncestry: { kind: "ancestor" },
     });
 
     expect(verdict).toStrictEqual({ kind: "remove" });

--- a/scripts/orchestrate-decisions.ts
+++ b/scripts/orchestrate-decisions.ts
@@ -255,19 +255,25 @@ export const worktreeProbe = (
 export const localVerdict = (isDirty: boolean): WorktreeVerdict | undefined =>
   isDirty ? { kind: "keep", reason: "uncommitted changes" } : undefined;
 
-/** What `git merge-base --is-ancestor` answered about two commits. */
+/**
+ * Where git put one commit relative to another's history. `absent` is the
+ * second commit missing from the repository, which is what the commit GitHub
+ * reports for a pull request is once the remote branch is deleted and nothing
+ * fetched it, and `failed` is a check that did not answer either way.
+ */
 export type Ancestry =
+  | { readonly commit: string; readonly kind: "absent" }
   | { readonly kind: "ancestor" }
   | { readonly kind: "failed"; readonly reason: string }
   | { readonly kind: "not-ancestor" };
 
 /**
  * Why the commits of a branch keep what holds them, or undefined when `holder`
- * already holds every one of them. A check that could not run is its own
- * answer, because reading it as "not an ancestor" would keep the branch with a
- * reason naming the wrong cause. A squash merge leaves the branch's commits
- * outside main's ancestry, so the reason states what git answered rather than
- * calling the branch unmerged.
+ * already holds every one of them. A commit this repository does not have and a
+ * check that did not run are each their own answer, because reading either as
+ * "not an ancestor" would keep the branch with a reason naming the wrong cause.
+ * A squash merge leaves the branch's commits outside main's ancestry, so the
+ * reason states what git answered rather than calling the branch unmerged.
  */
 export const ancestryKeepReason = (
   ancestry: Ancestry,
@@ -278,6 +284,9 @@ export const ancestryKeepReason = (
   }
   if (ancestry.kind === "not-ancestor") {
     return `commits ${holder} does not hold`;
+  }
+  if (ancestry.kind === "absent") {
+    return `${holder} is at commit ${ancestry.commit}, which this repository does not have`;
   }
   return `git could not compare with ${holder}: ${ancestry.reason}`;
 };

--- a/scripts/orchestrate-decisions.ts
+++ b/scripts/orchestrate-decisions.ts
@@ -255,60 +255,69 @@ export const worktreeProbe = (
 export const localVerdict = (isDirty: boolean): WorktreeVerdict | undefined =>
   isDirty ? { kind: "keep", reason: "uncommitted changes" } : undefined;
 
-/** What `git merge-base --is-ancestor` answered about a branch and main. */
+/** What `git merge-base --is-ancestor` answered about two commits. */
 export type Ancestry =
   | { readonly kind: "ancestor" }
   | { readonly kind: "failed"; readonly reason: string }
   | { readonly kind: "not-ancestor" };
 
 /**
- * Why the commits of a branch keep what holds them, or undefined when removing
- * it loses none. A check that could not run is its own answer, because reading
- * it as "not an ancestor" would keep the branch with a reason naming the wrong
- * cause. A squash merge leaves the branch's commits outside main's ancestry, so
- * the reason states what git answered rather than calling the branch unmerged.
+ * Why the commits of a branch keep what holds them, or undefined when `holder`
+ * already holds every one of them. A check that could not run is its own
+ * answer, because reading it as "not an ancestor" would keep the branch with a
+ * reason naming the wrong cause. A squash merge leaves the branch's commits
+ * outside main's ancestry, so the reason states what git answered rather than
+ * calling the branch unmerged.
  */
-export const ancestryKeepReason = (ancestry: Ancestry): string | undefined => {
+export const ancestryKeepReason = (
+  ancestry: Ancestry,
+  holder: string
+): string | undefined => {
   if (ancestry.kind === "ancestor") {
     return undefined;
   }
   if (ancestry.kind === "not-ancestor") {
-    return "commits main does not hold";
+    return `commits ${holder} does not hold`;
   }
-  return `failed: ${ancestry.reason}`;
+  return `git could not compare with ${holder}: ${ancestry.reason}`;
 };
 
-/** What GitHub and git report about the worktree of a branch the run named. */
-export interface WorktreeFacts {
-  readonly ancestry: Ancestry;
-  readonly headSha: string;
-  readonly pullRequest: PullRequest | undefined;
-}
+/**
+ * What GitHub and git report about the worktree of a branch the run named. Each
+ * shape names the commit whose history the branch was looked for in: main when
+ * GitHub reports no pull request for the branch, and the commit GitHub holds
+ * for it when there is one.
+ */
+export type WorktreeFacts =
+  | { readonly kind: "no-pull-request"; readonly mainAncestry: Ancestry }
+  | {
+      readonly kind: "pull-request";
+      readonly pullRequest: PullRequest;
+      readonly pullRequestAncestry: Ancestry;
+    };
 
 /**
- * Whether the worktree of a branch this run named can go. `headSha` is the
- * worktree's own HEAD, compared with the commit GitHub holds because a squash
- * merge leaves the branch's commits outside main's ancestry, where an ancestry
- * test would answer nothing. `pullRequest` is undefined when GitHub has none
- * for the branch, which is what a worker that died before opening one leaves,
- * and `ancestry` decides that case alone: a HEAD main already holds is a
- * worktree whose removal loses no commit.
+ * Whether the worktree of a branch this run named can go. Removing it deletes
+ * the branch, so what decides is whether anything else holds the branch's
+ * commits: main for a branch whose worker died before opening a pull request,
+ * and otherwise the commit GitHub holds, because a squash merge leaves the
+ * branch's commits outside main's ancestry. Ancestry rather than equality,
+ * because the branch also differs from GitHub's commit when it sits behind one
+ * a worker never pulled, and nothing of the branch's own is lost then.
  */
 export const worktreeVerdict = (facts: WorktreeFacts): WorktreeVerdict => {
-  const { ancestry, headSha, pullRequest } = facts;
-  if (pullRequest === undefined) {
-    const reason = ancestryKeepReason(ancestry);
-    return reason === undefined
+  if (facts.kind === "no-pull-request") {
+    const mainReason = ancestryKeepReason(facts.mainAncestry, "main");
+    return mainReason === undefined
       ? { kind: "remove" }
-      : { kind: "keep", reason: `no pull request, ${reason}` };
+      : { kind: "keep", reason: `no pull request, ${mainReason}` };
   }
+  const { pullRequest, pullRequestAncestry } = facts;
   if (pullRequest.state !== "MERGED" && pullRequest.state !== "CLOSED") {
     return { kind: "keep", reason: `pull request ${pullRequest.state}` };
   }
-  if (pullRequest.headRefOid !== headSha) {
-    return { kind: "keep", reason: "commits GitHub has not seen" };
-  }
-  return { kind: "remove" };
+  const reason = ancestryKeepReason(pullRequestAncestry, "the pull request");
+  return reason === undefined ? { kind: "remove" } : { kind: "keep", reason };
 };
 
 /** The one line `clean-worktrees` prints for a worktree. */

--- a/scripts/orchestrate.ts
+++ b/scripts/orchestrate.ts
@@ -60,6 +60,30 @@ const run = (file: string, args: readonly string[]): string =>
 const firstLine = (value: unknown): string =>
   (value instanceof Error ? value.message : String(value)).split("\n")[0] ?? "";
 
+interface CommandFailure {
+  readonly status: number | null;
+  readonly stderr: string;
+}
+
+const isCommandFailure = (value: unknown): value is CommandFailure =>
+  typeof value === "object" &&
+  value !== null &&
+  "status" in value &&
+  (typeof value.status === "number" || value.status === null) &&
+  "stderr" in value &&
+  typeof value.stderr === "string";
+
+/**
+ * What the failing command printed. `execFileSync`'s own message opens with
+ * `Command failed:` and the command line, and puts the command's stderr on the
+ * lines after it, so `firstLine` of that message hands back the command line
+ * alone.
+ */
+const commandMessage = (error: unknown): string =>
+  isCommandFailure(error) && error.stderr.trim() !== ""
+    ? firstLine(error.stderr.trim())
+    : firstLine(error);
+
 /**
  * Undefined covers both ways the platform can withhold the number: a command
  * that is absent (a Linux image without procps) throws, and one that runs but
@@ -130,7 +154,7 @@ const pollResult = (branches: readonly string[]): PollResult | undefined => {
       ? undefined
       : { exitCode: 0, line: formatEvent(event) };
   } catch (error) {
-    return { exitCode: 1, line: `gh-failed ${firstLine(error)}` };
+    return { exitCode: 1, line: `gh-failed ${commandMessage(error)}` };
   }
 };
 
@@ -179,29 +203,10 @@ const removeWorktree = (
   try {
     run("git", ["branch", "-D", branch]);
   } catch (error) {
-    return { kind: "branch-kept", reason: firstLine(error) };
+    return { kind: "branch-kept", reason: commandMessage(error) };
   }
   return { kind: "remove" };
 };
-
-interface CommandFailure {
-  readonly status: number | null;
-  readonly stderr: string;
-}
-
-const isCommandFailure = (value: unknown): value is CommandFailure =>
-  typeof value === "object" &&
-  value !== null &&
-  "status" in value &&
-  (typeof value.status === "number" || value.status === null) &&
-  "stderr" in value &&
-  typeof value.stderr === "string";
-
-/** What the failing command printed, rather than the wrapper's own message. */
-const commandMessage = (error: unknown): string =>
-  isCommandFailure(error) && error.stderr.trim() !== ""
-    ? firstLine(error.stderr.trim())
-    : firstLine(error);
 
 const NOT_ANCESTOR_STATUS = 1;
 
@@ -259,7 +264,7 @@ const verdictFor = (
       ? removeWorktree(worktree, probe.branch)
       : verdict;
   } catch (error) {
-    return { kind: "keep", reason: `failed: ${firstLine(error)}` };
+    return { kind: "keep", reason: `failed: ${commandMessage(error)}` };
   }
 };
 

--- a/scripts/orchestrate.ts
+++ b/scripts/orchestrate.ts
@@ -208,19 +208,34 @@ const removeWorktree = (
   return { kind: "remove" };
 };
 
-const NOT_ANCESTOR_STATUS = 1;
+/**
+ * Both commands below exit 1 to answer no: `rev-parse --verify --quiet` for a
+ * commit it cannot resolve, and silently, where a broken repository gives it
+ * 128 and a message; `merge-base --is-ancestor` for a commit outside the
+ * history it was given.
+ */
+const ANSWERED_NO_STATUS = 1;
 
 /**
- * Whether `commit` is in the history of `descendant`. Exit status 1 is git's
- * answer that it is not, where any other failure is the command not answering,
- * which is what a commit missing from this repository gives.
+ * Whether `commit` is in the history of `descendant`, or `descendant` is a
+ * commit this repository does not have. Resolving it comes first, because
+ * `merge-base` exits 128 both for a commit it cannot find and for a command
+ * that broke, and the commit GitHub reports for a merged pull request is one
+ * nothing local ever fetched whenever the remote branch is gone.
  */
 const ancestry = (commit: string, descendant: string): Ancestry => {
+  try {
+    run("git", ["rev-parse", "--verify", "--quiet", `${descendant}^{commit}`]);
+  } catch (error) {
+    return isCommandFailure(error) && error.status === ANSWERED_NO_STATUS
+      ? { commit: descendant, kind: "absent" }
+      : { kind: "failed", reason: commandMessage(error) };
+  }
   try {
     run("git", ["merge-base", "--is-ancestor", commit, descendant]);
     return { kind: "ancestor" };
   } catch (error) {
-    return isCommandFailure(error) && error.status === NOT_ANCESTOR_STATUS
+    return isCommandFailure(error) && error.status === ANSWERED_NO_STATUS
       ? { kind: "not-ancestor" }
       : { kind: "failed", reason: commandMessage(error) };
   }

--- a/scripts/orchestrate.ts
+++ b/scripts/orchestrate.ts
@@ -48,6 +48,7 @@ import type {
   Ancestry,
   PullRequest,
   Worktree,
+  WorktreeFacts,
   WorktreeVerdict,
 } from "./orchestrate-decisions";
 
@@ -144,9 +145,6 @@ const watchPrs = async (branches: readonly string[]): Promise<void> => {
   await watchPrs(branches);
 };
 
-const headSha = (path: string): string =>
-  run("git", ["-C", path, "rev-parse", "HEAD"]).trim();
-
 const isDirty = (path: string): boolean =>
   run("git", ["-C", path, "status", "--porcelain"]).trim() !== "";
 
@@ -208,18 +206,34 @@ const commandMessage = (error: unknown): string =>
 const NOT_ANCESTOR_STATUS = 1;
 
 /**
- * Ancestry asked of main by name, where `git branch -d` would ask it of
- * whichever branch this session happens to have checked out.
+ * Whether `commit` is in the history of `descendant`. Exit status 1 is git's
+ * answer that it is not, where any other failure is the command not answering,
+ * which is what a commit missing from this repository gives.
  */
-const ancestryOfMain = (branch: string): Ancestry => {
+const ancestry = (commit: string, descendant: string): Ancestry => {
   try {
-    run("git", ["merge-base", "--is-ancestor", branch, "main"]);
+    run("git", ["merge-base", "--is-ancestor", commit, descendant]);
     return { kind: "ancestor" };
   } catch (error) {
     return isCommandFailure(error) && error.status === NOT_ANCESTOR_STATUS
       ? { kind: "not-ancestor" }
       : { kind: "failed", reason: commandMessage(error) };
   }
+};
+
+/**
+ * What `worktreeVerdict` judges. The ancestry runs on the branch, which is the
+ * commit the worktree has checked out and the ref `removeWorktree` deletes.
+ */
+const worktreeFacts = (branch: string): WorktreeFacts => {
+  const pullRequest = prOf(branch);
+  return pullRequest === undefined
+    ? { kind: "no-pull-request", mainAncestry: ancestry(branch, "main") }
+    : {
+        kind: "pull-request",
+        pullRequest,
+        pullRequestAncestry: ancestry(branch, pullRequest.headRefOid),
+      };
 };
 
 /**
@@ -240,11 +254,7 @@ const verdictFor = (
     if (local !== undefined) {
       return local;
     }
-    const verdict = worktreeVerdict({
-      ancestry: ancestryOfMain(probe.branch),
-      headSha: headSha(worktree.path),
-      pullRequest: prOf(probe.branch),
-    });
+    const verdict = worktreeVerdict(worktreeFacts(probe.branch));
     return verdict.kind === "remove"
       ? removeWorktree(worktree, probe.branch)
       : verdict;
@@ -253,9 +263,13 @@ const verdictFor = (
   }
 };
 
-/** Deletes the branch once main holds its commits, and returns why it did not. */
+/**
+ * Deletes the branch once main holds its commits, and returns why it did not.
+ * Main is named, where `git branch -d` would check the branch against its
+ * upstream, or against HEAD when it has none.
+ */
 const deleteMergedBranch = (branch: string): string | undefined => {
-  const reason = ancestryKeepReason(ancestryOfMain(branch));
+  const reason = ancestryKeepReason(ancestry(branch, "main"), "main");
   if (reason !== undefined) {
     return reason;
   }

--- a/scripts/orchestrate.ts
+++ b/scripts/orchestrate.ts
@@ -172,6 +172,16 @@ const watchPrs = async (branches: readonly string[]): Promise<void> => {
 const isDirty = (path: string): boolean =>
   run("git", ["-C", path, "status", "--porcelain"]).trim() !== "";
 
+/** What git printed when it refused to delete the branch, or undefined. */
+const deleteBranch = (branch: string): string | undefined => {
+  try {
+    run("git", ["branch", "-D", branch]);
+    return undefined;
+  } catch (error) {
+    return commandMessage(error);
+  }
+};
+
 const RELOCK_REASON = "clean-worktrees could not remove it";
 
 /**
@@ -200,12 +210,10 @@ const removeWorktree = (
     }
     throw error;
   }
-  try {
-    run("git", ["branch", "-D", branch]);
-  } catch (error) {
-    return { kind: "branch-kept", reason: commandMessage(error) };
-  }
-  return { kind: "remove" };
+  const reason = deleteBranch(branch);
+  return reason === undefined
+    ? { kind: "remove" }
+    : { kind: "branch-kept", reason };
 };
 
 /**
@@ -288,18 +296,8 @@ const verdictFor = (
  * Main is named, where `git branch -d` would check the branch against its
  * upstream, or against HEAD when it has none.
  */
-const deleteMergedBranch = (branch: string): string | undefined => {
-  const reason = ancestryKeepReason(ancestry(branch, "main"), "main");
-  if (reason !== undefined) {
-    return reason;
-  }
-  try {
-    run("git", ["branch", "-D", branch]);
-    return undefined;
-  } catch (error) {
-    return commandMessage(error);
-  }
-};
+const deleteMergedBranch = (branch: string): string | undefined =>
+  ancestryKeepReason(ancestry(branch, "main"), "main") ?? deleteBranch(branch);
 
 const cleanWorktrees = (branches: readonly string[]): void => {
   const worktrees = agentWorktrees(


### PR DESCRIPTION
`clean-worktrees` の `kept ... (commits GitHub has not seen)` が、GitHub の方が進んでいる worktree にも出ていた。今日出た行がこれで、pull request は merge 済み、remote branch も削除済み、GitHub の `headRefOid` は `4b486bca4c59f0f069af7e95fa3d961de6cfb9f1`、worktree の branch tip は `728d56d` でその祖先だった。worker が `gh pr update-branch` の結果を pull していないだけで、理由文は事実の逆を書いていた。

```
kept /Users/.../.claude/worktrees/agent-a9016085aa1e3e199 (commits GitHub has not seen)
```

`worktreeVerdict` は 2 つの SHA を不一致で比べ、不一致すべてを push されていないローカル commit のせいにしていた。判定を `git merge-base --is-ancestor` の答えに載せ替え、方向を区別する。比べる対象は worktree の HEAD ではなく branch にした。worktree を消すと `removeWorktree` が `git branch -D` まで走るので、失われうるのは branch の commit で、checkout 済み branch の tip はその worktree の HEAD でもある。`git rev-parse HEAD` の fork が 1 つ減った。

## 判定と条件

| 条件 | 判定と理由 |
| --- | --- |
| pull request なし、branch が main の祖先 | `removed` |
| pull request なし、祖先でない | `kept (no pull request, commits main does not hold)` |
| pull request なし、main が解決できない | `kept (no pull request, main is at commit main, which this repository does not have)` |
| pull request が MERGED / CLOSED 以外 | `kept (pull request <state>)` |
| branch が pull request の commit の祖先 | `removed` |
| 祖先でない | `kept (commits the pull request does not hold)` |
| pull request の commit がローカルに無い | `kept (the pull request is at commit <sha>, which this repository does not have)` |
| 比較が走らなかった | `kept (git could not compare with the pull request: <git の stderr>)` |

5 行目が今回直った case で、以前は 2 つの SHA が違うだけで `commits GitHub has not seen` を出していた。7 行目と 8 行目は `ancestryKeepReason` に `holder` を渡す形にした結果で、以前の `failed: <stderr>` から「何との比較か」を含む形に変わった。同じ関数を通る stranded branch の行（`kept branch worktree-agent-x (...)`）も同じ文言になる。3 行目は main が無い repository でしか出ず、`holder` と commit 名が一致するので文としては不格好だが、真ではある。

## 走らなかった比較と、無い commit を分けた

GitHub が名指しした commit がローカルに無いとき、`git merge-base --is-ancestor` は答えずに exit 128 で落ちる。命令が壊れたときも 128 なので、当初は両方を `git could not compare with the pull request: fatal: Not a valid commit name ...` の 1 つに潰していた。git 自身の fatal が stderr にも出るので、同じ文が 2 行に出ていた。

`git rev-parse --verify --quiet <commit>^{commit}` で先に解決を試す形にした。この命令は解決できない commit に exit 1 を黙って返し、repository が壊れている場合は 128 と message を返すので、2 つの原因を分けられる（両方測った。`^{commit}` を付けない `--verify --quiet` は 40 桁の hex をそのまま通して exit 0 を返すので、存在確認にならない）。

どちらの case も判定は `keep`。unpush の commit を守るための check が走らなかったのだから、どちらが進んでいるかは測れていない。`removed` にすると `git branch -D` まで走り、測っていない前提で commit を捨てうる。A で push した branch に `gh pr update-branch` が remote だけの merge B を作り、その後ローカルで C を commit した worktree は、B が無いまま C を持っている。

観測された worktree（`agent-a9016085aa1e3e199`）はこの「commit がローカルに無い」case に当たる。`git cat-file -e 4b486bca4c59f0f069af7e95fa3d961de6cfb9f1^{commit}` はローカルで `fatal: Not a valid object name` を返すので、この worktree はこれからも `kept` のまま残る。この PR で変わるのは、理由が真になり、何が無いのかを名指しするところまで。消したいなら人が pull するか `git worktree remove` すればよい。

review で「判定前に `git fetch origin <headRefOid>` するか、GitHub の compare endpoint に方向を聞けば、この case も `removed` にできる」という指摘が出た。cleanup path に network I/O を足す変更なので取らず、ここに残す。

## 依頼された確認 2 点

**`formatVerdict` の他の branch と stranded-branch path で同じ嘘が出るか。** 出ない。`formatVerdict` は理由文を包むだけで、理由を作るのは `worktreeProbe`、`localVerdict`、`worktreeVerdict`、`verdictFor` の catch、`removeWorktree` の `branch-kept` で、どちらが進んでいるかを主張していたのは今回直した 1 本だけだった。stranded-branch path は `deleteMergedBranch` から `ancestryKeepReason(ancestry(branch, "main"), "main")` を呼ぶので、`commits main does not hold` は `git merge-base --is-ancestor <branch> main` の exit 1 がそのまま答えたことしか言っていない。scratch repository で両方向を出した。

```
kept branch worktree-agent-ahead (commits main does not hold)
removed branch worktree-agent-held
```

**end-to-end で示せるか。** 示せた。`run("gh", ...)` は PATH から `gh` を引くので、scratch repository と PATH 先頭に置いた偽 `gh` で `clean-worktrees` をそのまま走らせられる。branch を commit B に置き、GitHub 側の `headRefOid` を 3 通り与えた結果が下。上が修正後、下が修正前（`git show HEAD:` で取り出した同じ script）で、修正前は 3 case すべてに同じ嘘を出していた。

```
--- GitHub holds a descendant of HEAD (the observed case: update-branch never pulled)
removed WKD/repo/.claude/worktrees/agent-demo
--- GitHub names a commit this repository does not have
kept WKD/repo/.claude/worktrees/agent-demo (the pull request is at commit 4b486bca4c59f0f069af7e95fa3d961de6cfb9f1, which this repository does not have)
--- HEAD is a commit GitHub never saw
kept WKD/repo/.claude/worktrees/agent-demo (commits the pull request does not hold)
```

```
--- GitHub holds a descendant of HEAD (the observed case: update-branch never pulled)
kept WKD/repo/.claude/worktrees/agent-demo (commits GitHub has not seen)
--- GitHub names a commit this repository does not have
kept WKD/repo/.claude/worktrees/agent-demo (commits GitHub has not seen)
--- HEAD is a commit GitHub never saw
kept WKD/repo/.claude/worktrees/agent-demo (commits GitHub has not seen)
```

## 理由行が命令行を出していた（2 つ目の commit）

review で、`removeWorktree` の `branch-kept` と `verdictFor` の catch が `firstLine(error)` を使っていて、`execFileSync` の `Error.message` は `Command failed:` と命令行で始まり stderr はその後の行に入るので、1 行目を取ると原因が落ちる、と指摘された。`git branch -D wkd-no-such-branch` で測ると `message` は `Command failed: git branch -D wkd-no-such-branch`、`stderr` は `error: branch 'wkd-no-such-branch' not found` だった。`watch-prs` の `gh-failed` 行も同じ形で、dispatch-run skill は「message が名指しするものを直して watch を再開する」と書いているのに名指しされるのは命令行だった。3 か所を stderr を優先する `commandMessage` に変えた。偽 `gh` を exit 4 で落として確かめた（上が修正後、下が修正前）。

```
kept WKF/repo/.claude/worktrees/agent-demo (failed: gh: To get started with GitHub CLI, please run: gh auth login)
gh-failed gh: To get started with GitHub CLI, please run: gh auth login
```

```
kept WKF/repo/.claude/worktrees/agent-demo (failed: Command failed: gh pr list --state open --head feat/demo --limit 1 --json headRefOid,mergeable,state)
gh-failed Command failed: gh pr list --state open --head feat/demo --limit 1 --json headRefOid,mergeable,state
```

## 設計の選択肢

`WorktreeFacts` を discriminated union（`no-pull-request` は main の ancestry、`pull-request` は branch と `headRefOid` の ancestry）にした。flat な interface に `Ancestry | undefined` をもう 1 つ足す形も書けるが、pull request があるのに ancestry が undefined という起こらない状態が型に残る。

## 判断を残した review 指摘

- **方向が untested module の引数順にしか無い。** `ancestry(pullRequest.headRefOid, branch)` と書いても型は通り、テストも全部緑のまま答えが反転する（`scripts/orchestrate.ts` は coverage の対象外）。指摘は、`WorktreeProbe` と同じく純粋側が「どの 2 commit を比べるか」を返し、`orchestrate.ts` は実行だけする形にすること。取らなかった理由は、2 つの呼び出しがどちらも branch を第 1 引数に取る形に揃ったので取り違えが並べて見えること、型が main の ancestry を pull request の case に渡すのを防いでいること。question object を足す価値があると判断するなら別チケットで。
- **merge 後に branch を main へ rebase した worktree は `kept` のまま。** `pull-request` の case は main に何も聞かないので、tip の commit を main が持っていて pull request の head が持っていない worktree は `commits the pull request does not hold` になる。修正前も同じ挙動で、観測された case は squash merge なので main の ancestry でも助からない（`git merge-base --is-ancestor 728d56d main` はここで exit 1）。取るなら `pull-request` にも `mainAncestry` を足して、どちらかが持っていれば `removed` にする。merge 済み pull request 1 つあたり `git merge-base` が 1 fork 増える。
- **`worktreeProbe` の `never switched off the branch Claude Code created` は prefix からの推測。** `.claude/worktrees/agent-A` にある worktree が `worktree-agent-B` に立っていると、この理由は嘘になる（別の agent の branch に switch している）。同じ file の `createdBranchOf(worktree.path)` と比べれば分けられる。どちらの case も `keep` なので判定は変わらない。この PR は方向の 1 本に絞ったので直していない。
- **remove の 2 テストを `it.each` にする。** MERGED / CLOSED の 2 行が 1 literal しか違わない。この test file は 65 個の `it` を持ち `it.each` を 1 つも使っておらず（`prListing` の unreadable 8 本も並べて書いてある）、1 組だけ table にすると file の中で浮くので並べたままにした。
- **`pullRequest("MERGED", "UNKNOWN")` の第 2 引数は `worktreeVerdict` が読まない。** 既存の書き方で、merge 済み pull request に `gh` が実際に返す値なので残した。

review 指摘のうち 2 つは測って落とした。`git merge-base --is-ancestor <branch> <無い sha>` の stderr は `fatal: Not a valid commit name <sha>` で、テストの fixture が書いている文言と一致する（`Not a valid object name` は `cat-file`/`rev-parse` に `^{commit}` を付けたときの文言）。存在確認に提案された `git rev-parse --verify --quiet <sha>` は、40 桁 hex には exit 0 を返すので使えず、`^{commit}` を付けた形を採った。

## Gates

`bun run check`、`bun run test`（465 tests、`scripts/orchestrate-decisions.ts` の branch coverage 100%）、`bun run knip` を worktree で走らせて通した。ドキュメントは触っていない。`git grep -l "commits GitHub has not seen" <この PR の前の HEAD>` が返したのは `scripts/orchestrate-decisions.ts` と `scripts/orchestrate-decisions.test.ts` の 2 file だけで、instruction document 側はこの文言を引用していない。
