### PR TITLE
docs: README が Stop gate と検査の実行場所を実態どおりに書く

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ bun run dev
 
 [mise](https://mise.jdx.dev/) を使わない場合は、`package.json` の `engines.node` を満たす Node と、`mise.toml` が指定する版の Bun を手動で用意してください。Cursor Cloud Agent 環境では `.cursor/environment.json` が同じセットアップ（`scripts/cloud-agent-install.sh`）を自動実行します。shims の PATH 追記は rc ファイルを読むシェルにしか効かないため、rc を読まない非対話シェルからは `mise exec -- <コマンド>` で実行してください。
 
-`bun run dev` は [portless](https://github.com/vercel-labs/portless) 経由で起動し、`https://my-app.localhost` で開きます。linked worktree ではブランチ名の末尾が前に付き（`https://fix-ui.my-app.localhost`）、worktree ごとに URL が分かれるのでポートの取り合いが起きません。初回は proxy が 443 を使うために `sudo` を求めます。`sudo` を使わない場合は先に `bunx portless proxy start --port 1355` を実行すると、URL に `:1355` が付きます。`@cloudflare/vite-plugin` により、`bun run dev` でも Cloudflare D1 / R2 バインディングが有効です。
+`bun run dev` は [portless](https://github.com/vercel-labs/portless) 経由で起動し、`https://my-app.localhost` で開きます。linked worktree ではブランチ名の末尾がサブドメインとして前に付きます（ブランチ `fix-ui` なら `https://fix-ui.my-app.localhost`）。付くのは末尾だけなので、`feat/x` と `fix/x` は同じ URL になり、`main` と `master` のブランチには何も付きません。dev サーバのポートは portless が空きから割り当てるので、worktree を並べて起動してもポートの取り合いは起きません。初回は proxy が 443 を使うために `sudo` を求めます。`sudo` を使わない場合は先に `bunx portless proxy start --port 1355` を実行すると、URL に `:1355` が付きます。`@cloudflare/vite-plugin` により、`bun run dev` でも Cloudflare D1 / R2 バインディングが有効です。
 
 データベース・認証・ストレージのセットアップ手順は [docs/DATABASE_SETUP.md](./docs/DATABASE_SETUP.md)、デプロイ・ロールバック・シークレット運用は [docs/DEPLOYMENT.md](./docs/DEPLOYMENT.md)、このテンプレートを新規プロジェクトに使う手順は [docs/FORKING.md](./docs/FORKING.md)、サーバ境界を oRPC / BFF 構成へ動かす場合の前提は [docs/SERVER_BOUNDARY.md](./docs/SERVER_BOUNDARY.md) を参照。
 
@@ -50,7 +50,7 @@ bun run dev
 - **自作 vite プラグイン** (`tools/vite-plugins/`)：`vite.config.ts` から読み込まれる。`wrangler.toml` の変更を検知して `bun run cf-typegen` を走らせ、dev 起動時は `worker-configuration.d.ts` が `wrangler.toml` より古いときだけ生成する
 - **[react-doctor](https://github.com/millionco/react-doctor)**：React 向け追加ルール (`oxlint.react-doctor.ts`)
 - **[oxfmt](https://oxc.rs/docs/guide/usage/formatter)**：Formatter (`vite.config.ts` の `fmt` ブロック)
-- **[portless](https://github.com/vercel-labs/portless)**：dev サーバに名前付き HTTPS URL を割り当てる proxy。`bun run dev` が経由し、worktree ごとに URL が分かれる
+- **[portless](https://github.com/vercel-labs/portless)**：dev サーバに名前付き HTTPS URL を割り当てる proxy。`bun run dev` が経由する
 - **[lefthook](https://github.com/evilmartians/lefthook)**：Git hooks (`lefthook.yml`、`bun install` 時に `prepare` スクリプトで自動セットアップ)
 - **[knip](https://knip.dev/)**：Unused deps/exports/files detection (`knip.json`)
 - **[similarity-ts](https://github.com/mizchi/similarity)**：Code similarity detector

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ TanStack Start + TypeScript + Tailwind CSS + shadcn/ui を使用したモダン�
 git clone <your-repo-url>
 cd <your-repo-name>
 mise install                 # Node / Bun / actionlint を mise.toml の版で用意
-cargo install similarity-ts  # Stop gate の重複検出（Rust 製）
+cargo install similarity-ts  # lefthook の pre-push が回す重複検出（Rust 製）
 bun install
 cp .env.local.example .env.local
 bun run dev
@@ -31,7 +31,7 @@ bun run dev
 
 `src/routeTree.gen.ts` は `bun run dev` と `bun run build` が生成し、ルートファイルの追加や削除に追従します。`worker-configuration.d.ts` は `bun run dev` が生成し、`wrangler.toml` の編集にも追従します（build は生成しません）。dev を起動せずに `bun run check` や `bun run test` を走らせるときだけ、先に `bun run generate-routes` と `bun run cf-typegen` を叩いてください。
 
-`similarity-ts` が無い環境では SessionStart の env-check が欠落を報告し、Stop gate は重複検出を「スキップした」と明示します（黙って合格扱いにはなりません）。
+`similarity-ts` が無い環境では、lefthook の pre-push が重複検出（`similarity-ts ./src --fail-on-duplicates`）を飛ばして push を通します。その欠落は SessionStart の env-check がセッション開始時に報告します。
 
 [mise](https://mise.jdx.dev/) を使わない場合は、`package.json` の `engines.node` を満たす Node と、`mise.toml` が指定する版の Bun を手動で用意してください。Cursor Cloud Agent 環境では `.cursor/environment.json` が同じセットアップ（`scripts/cloud-agent-install.sh`）を自動実行します。shims の PATH 追記は rc ファイルを読むシェルにしか効かないため、rc を読まない非対話シェルからは `mise exec -- <コマンド>` で実行してください。
 
@@ -97,7 +97,7 @@ src/
 - **[AGENTS.md](./AGENTS.md)**：規約の本体。毎セッション自動でロードされます（`CLAUDE.md` はこれを読み込むだけ）
 - **`.claude/rules/`**：規約の分冊。path scope を持つものは対象ファイルを編集するときだけ、持たないものは毎セッション読み込まれます
 - **`.claude/skills/`**：名前のついた作業の手順。チケット粒度の作業は `ticket-work` が持ち、AGENTS.md はそれを指します
-- **`.claude/hooks/`**：規約を機械的に強制する側。SessionStart で依存の欠落を報告し、Bash 実行前にガードを掛け、Stop で品質ゲート（typecheck / lint / format / knip / similarity / markdown リンク）を回します
+- **`.claude/hooks/`**：規約を機械的に強制する側。SessionStart で依存の欠落を報告し、Bash 実行前にガードを掛け、Stop ではコードが変わった turn だけ `bun run check`（format / lint / 型検査）と `bun run test` を回します。markdown のリンク切れ検査は変更があれば毎回走ります。ツリー全体を判定する検査は Stop に置かず、knip は CI、`similarity-ts` は lefthook の pre-push が回します
 
 コミット前のレビューは `code-reviewer` エージェントが担い、PR ブランチへのコミットと push はエージェントが AGENTS.md の規律に従って自分で行います。`main` へは PR 経由でだけ入ります。
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ bun run dev
 
 `similarity-ts` が無い環境では、lefthook の pre-push が重複検出（`similarity-ts ./src --fail-on-duplicates`）を飛ばして push を通します。その欠落は SessionStart の env-check がセッション開始時に報告します。
 
-[mise](https://mise.jdx.dev/) を使わない場合は、`package.json` の `engines.node` を満たす Node と、`mise.toml` が指定する版の Bun を手動で用意してください。Cursor Cloud Agent 環境では `.cursor/environment.json` が同じセットアップ（`scripts/cloud-agent-install.sh`）を自動実行します。shims の PATH 追記は rc ファイルを読むシェルにしか効かないため、rc を読まない非対話シェルからは `mise exec -- <コマンド>` で実行してください。
+[mise](https://mise.jdx.dev/) を使わない場合は、`package.json` の `engines.node` を満たす Node と、`mise.toml` が指定する版の Bun を手動で用意してください。Cursor Cloud Agent 環境では `.cursor/environment.json` が `scripts/cloud-agent-install.sh` を自動実行し、mise と依存の導入から `generate-routes` / `cf-typegen` までを済ませます（`bun install` は `--ignore-scripts` なので lefthook の hook は入りません）。shims の PATH 追記は rc ファイルを読むシェルにしか効かないため、rc を読まない非対話シェルからは `mise exec -- <コマンド>` で実行してください。
 
 `bun run dev` は [portless](https://github.com/vercel-labs/portless) 経由で起動し、`https://my-app.localhost` で開きます。linked worktree ではブランチ名の末尾がサブドメインとして前に付きます（ブランチ `fix-ui` なら `https://fix-ui.my-app.localhost`）。付くのは末尾だけなので、`feat/x` と `fix/x` は同じ URL になり、`main` と `master` のブランチには何も付きません。dev サーバのポートは portless が空きから割り当てるので、worktree を並べて起動してもポートの取り合いは起きません。初回は proxy が 443 を使うために `sudo` を求めます。`sudo` を使わない場合は先に `bunx portless proxy start --port 1355` を実行すると、URL に `:1355` が付きます。`@cloudflare/vite-plugin` により、`bun run dev` でも Cloudflare D1 / R2 バインディングが有効です。
 


### PR DESCRIPTION
## 直したこと

README.md が「どの検査がどこで走るか」を3箇所で誤って書いていた。

1. クイックスタート 26 行目の `cargo install similarity-ts` の注記が「Stop gate の重複検出」。→ 「lefthook の pre-push が回す重複検出（Rust 製）」。
2. 34 行目「`similarity-ts` が無い環境では SessionStart の env-check が欠落を報告し、Stop gate は重複検出を『スキップした』と明示します」。→ 「lefthook の pre-push が重複検出（`similarity-ts ./src --fail-on-duplicates`）を飛ばして push を通し、その欠落は SessionStart の env-check がセッション開始時に報告する」。
3. 100 行目の `.claude/hooks/` の説明が Stop の品質ゲートを typecheck / lint / format / knip / similarity / markdown リンクと並べていた。→ 「コードが変わった turn だけ `bun run check`（format / lint / 型検査）と `bun run test`、markdown のリンク切れ検査は変更があれば毎回、ツリー全体を判定する knip は CI、`similarity-ts` は lefthook の pre-push」。

根拠は `.claude/hooks/stop-gate.sh`（`run_or_block check` と `run_or_block test`、`bun .claude/hooks/check-md-links.ts`、knip も similarity-ts も呼ばない）、`lefthook.yml` の pre-push `similarity` step（`skip: - run: "! command -v similarity-ts"`）、`.github/workflows/ci.yaml` の "Detect unused code (knip)"、`.claude/hooks/session-start-env-check.sh` の `similarity-ts not on PATH` 行。

## いつから偽だったか

3箇所とも a3a2bae「docs: README をコアだけにする」(2026-08-23) が今の文言を入れた時点では事実で、e5f4714「refactor: stop gate がツリー全体を判定する検査を持たない」(2026-08-25) が knip と similarity を stop-gate.sh から外して lefthook.yml に移したときに偽になった。この commit が触ったのは `.claude/hooks/session-start-env-check.sh` / `.claude/hooks/stop-gate.sh` / `.claude/settings.json` / `lefthook.yml` の4ファイルで、README.md は含まれていない。100 行目の列挙は 324cc04 (#140, 2026-09-08) が `bun run test` を Stop gate に足した分も落としていた。

## ついでに直した2箇所

- **portless の URL（38 行目と Tools の 53 行目）**：「worktree ごとに URL が分かれるのでポートの取り合いが起きません」。`node_modules/portless/dist/cli.js` の `branchToPrefix` はブランチ名を `/` で切った末尾だけを prefix にし、`main` / `master` は `DEFAULT_BRANCHES` として prefix を返さない。`feat/x` と `fix/x` は同じ URL になり、main の worktree は main checkout と同じ URL になる。ポートの取り合いが起きない理由も URL の分離ではなく、portless が空きポートを割り当てて dev サーバに渡すため（portless 0.15.6 の README: 4000-4999 の空きを `PORT` で渡し、`PORT` を見ない Vite / VitePlus には `--port` を注入する）。条件を分けて書き直し、Tools 側の重複した一節は落とした。
- **Cursor Cloud Agent（36 行目）**：「`.cursor/environment.json` が同じセットアップを自動実行します」。`scripts/cloud-agent-install.sh` は `bun install --frozen-lockfile --ignore-scripts` なので `prepare`（`lefthook install`）が走らず、`cargo install similarity-ts` も無い。中身（mise 導入、`mise install`、install、`generate-routes`、`cf-typegen`）と、hook が入らないことに書き換えた。

## 検査して正しかった記述

いずれも同じ turn で対象を開くか実行して確認した。

- 32 行目：`src/routeTree.gen.ts` を退避して `bun run build` を実行し、再生成されることを確認（✓ built in 18.39s、生成物 5198 bytes）。`worker-configuration.d.ts` を build が生成しないのは `tools/vite-plugins/wrangler-types-plugin.ts` が `apply: "serve"` のため（✓）。dev での `wrangler.toml` 追従と、起動時に types が config より古いときだけ生成する挙動は `tools/vite-plugins/wrangler-types.ts` の `needsRegenerate` / `server.watcher.on("change")`（✓）。
- 25 行目 `mise install` が Node / Bun / actionlint を用意：`mise.toml` に3つとも（node 26.7.0 / bun 1.3.1 / actionlint 1.7.12）（✓）。
- 28 行目 `.env.local.example` の存在（✓）。
- 36 行目前半：`package.json` の `engines.node` と `mise.toml` の bun 指定（✓）。
- 38 行目：`https://my-app.localhost` の `my-app` は `package.json` の `name`（`portless.json` も `portless` key も無く、portless は package name から推論する）（✓）。443 と sudo（portless README: 初回に CA を作り 443 を bind、macOS / Linux では sudo に昇格）（✓）。`--port 1355` は `-p, --port <number>` として存在し、`formatUrl` が既定ポート以外を `:port` として URL に付ける（✓）。D1 / R2 バインディングは `vite.config.ts` の `cloudflare()` と `wrangler.toml` の `[[d1_databases]]` / `[[r2_buckets]]`（✓）。
- 15 / 46 / 47 行目：`bun run check` = `vp check`、TypeScript 7.0.2、`vite.config.ts` の `lint` / `fmt` ブロック（✓）。
- 49 行目：`lint.jsPlugins` が `tools/oxlint-plugins/style-rules.js` と `arch-rules.js` を読み、`arch-rules/layer-boundaries` / `component-file-naming` / `one-component-per-file` / `test-naming-format` / `single-expect` が error（✓）。
- 50 行目：上記 vite プラグインの2つの挙動（✓）。
- 51 / 54 / 55 / 57 行目：`oxlint.react-doctor.ts` の import、`package.json` の `prepare: lefthook install`、`knip.json`、`mise.toml` の actionlint 固定（✓）。
- 40 行目のリンク4本と文書内の相対リンク：`bun .claude/hooks/check-md-links.ts` が 21 ファイルで dead link 0（✓）。
- 62-89 行目のツリー：`src/` を走査して各エントリを確認。`__root.tsx` の ThemeProvider / Header / Toaster、`profile.tsx` の `beforeLoad` での redirect、`src/routes/api/` の `auth.$.ts` と `avatars.ts`、`src/server/cloudflare.ts` の `cloudflare:workers`、`src/test/` の router harness と stub、`wrangler.toml` の `main = "./src/ssr.tsx"`（✓）。ツリーが `src/env.d.ts` と `src/lib/utils.test.ts` を載せていないのは誤りではないので、構成を触らない方針どおり残した。
- 95-99 行目：4つの層のディレクトリが存在し、`.claude/rules/` は design.md / react.md が `paths` + `globs` + `alwaysApply: false`、prose.md が `alwaysApply: true` で path scope 無し（✓）。`ticket-work` skill も存在（✓）。
- 102 行目：`.claude/agents/code-reviewer.md` が pre-commit reviewer として存在し、`.claude/skills/ticket-work/SKILL.md` の step 7 が dispatch する（✓）。

## 触らなかったもの

- 56 行目の similarity-ts の Tools 行（「Code similarity detector」）：走る場所を主張していないので偽ではない。走る場所は 34 行目と 100 行目が持つ。
- `.claude/hooks/stop-gate.sh`、`AGENTS.md`、`lefthook.yml`、`.github/workflows/ci.yaml`：並行 PR の担当範囲。README を実装に合わせる方向だけで直した。
- `bun run check` / `bun run test`：docs のみの変更なので走らせていない。pre-push は通っている（check 44.11s、similarity、actionlint、cf-typegen-check、toolchain-pins すべて ✔️）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
README が検査の実行場所と開発環境の設定を実態と違う書き方をしていたのを修正し、Stop gate が走らせていない検査を実際の実行場所に書き換えた。docs のみの変更で、検査の実行には影響しない。

**修正内容**

- Stop gate が回すのはコードが変わった turn の `bun run check` / `bun run test` と markdown リンク検査だけで、`similarity-ts` は lefthook の pre-push、knip は CI が担当する。
- `similarity-ts` の欠落は Stop gate ではなく SessionStart の env-check が報告する。
- portless のサブドメインにはブランチ名の末尾だけが付き、ポートの取り合いが起きないのは空きポートの割り当てによる。
- Cloud Agent のセットアップは `--ignore-scripts` で lefthook の hook が入らず、`similarity-ts` の導入も無い。

<sup>Written for commit 66f28b7edbb1fa4cbfd2cd26b5b753b837a0fc28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imaimai17468/imaimai-front-templete/pull/143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

