### PR TITLE
fix: Stop gate が turn 内で見つけた失敗を残らず報告する

### DIFF
--- a/.claude/hooks/stop-gate.sh
+++ b/.claude/hooks/stop-gate.sh
@@ -5,13 +5,14 @@
 #      than this turn's diff, so CI runs knip and lefthook's pre-push runs
 #      similarity-ts
 #    — runs only when code-relevant files changed (docs-only turns skip it)
-#    — every step runs even after an earlier one failed, and one block names
-#      all of them, so no failure waits for a later Stop to be reported
-#    — respects stop_hook_active: if this Stop was already blocked once, a
-#      failing gate downgrades to a warning instead of blocking again, so a
-#      pre-existing failure the agent cannot fix does not loop forever
 # 2. Markdown link check — blocking; dead relative links are decidable by opening
 #    the path, so they belong here rather than in a reviewer's judgment
+#
+# Every step above runs even after an earlier one failed, and one block names
+# all of them, so no failure waits for a later Stop to be reported. That block
+# respects stop_hook_active: if this Stop was already blocked once, it
+# downgrades to a warning instead of blocking again, so a pre-existing failure
+# the agent cannot fix does not loop forever.
 
 set -uo pipefail
 
@@ -55,18 +56,22 @@ emit_block() { # $1 = summary, $2 = reason body (stdin-free)
 FAILED_STEPS=""
 FAILURE_OUTPUT=""
 
-# A failing step is collected instead of emitted, so the caller can run the
-# remaining steps and report every failure in one block.
+# A failure is collected instead of emitted, so the steps after it still run and
+# one block names all of them.
+record_failure() { # $1 = step name, $2 = the step's output
+  FAILED_STEPS="${FAILED_STEPS:+$FAILED_STEPS, }$1"
+  FAILURE_OUTPUT="${FAILURE_OUTPUT}===== $1 =====
+$2
+
+"
+}
+
 # `local out` is separate from the assignment because `local out=$(...)` would
 # report local's own exit status and lose the one `bun run` returned.
 run_step() { # $1 = the `bun run` script to run
   local out
   out=$(bun run "$1" 2>&1) && return 0
-  FAILED_STEPS="${FAILED_STEPS:+$FAILED_STEPS, }bun run $1"
-  FAILURE_OUTPUT="${FAILURE_OUTPUT}===== bun run $1 =====
-$out
-
-"
+  record_failure "bun run $1" "$out"
 }
 
 # Skip when there are no changes
@@ -91,9 +96,6 @@ if [ "$CODE_CHANGED" -gt 0 ]; then
   # file walk. `bun run test` is `vp test --run --coverage`.
   run_step check
   run_step test
-  if [ -n "$FAILED_STEPS" ]; then
-    emit_block "$FAILED_STEPS failed. Fix before ending the turn." "$FAILURE_OUTPUT"
-  fi
 fi
 
 # ==== 2. Markdown link check ====
@@ -105,15 +107,18 @@ fi
 # 2026-07-29, dead links left in files the same commit did not edit).
 LINKS_AVAILABLE=true
 if command -v bun >/dev/null 2>&1; then
-  LINKS=$(bun "$ROOT/.claude/hooks/check-md-links.ts" 2>&1)
-  LINKS_RC=$?
-  if [ $LINKS_RC -ne 0 ]; then
-    emit_block "dead markdown links. Fix the paths before ending the turn." "$LINKS"
-  fi
+  LINKS=$(bun "$ROOT/.claude/hooks/check-md-links.ts" 2>&1) ||
+    record_failure "markdown link check" "$LINKS"
 else
   # A missing runtime downgrades the step; it never silently passes
   # (AGENTS.md, "Degraded Environments"). Reported in the summary below.
   LINKS_AVAILABLE=false
+fi
+
+# ==== Report every failure the steps above collected ====
+
+if [ -n "$FAILED_STEPS" ]; then
+  emit_block "$FAILED_STEPS failed. Fix before ending the turn." "$FAILURE_OUTPUT"
 fi
 
 # Computed once here and read by both summary branches below. Nothing between

--- a/.claude/hooks/stop-gate.sh
+++ b/.claude/hooks/stop-gate.sh
@@ -119,16 +119,17 @@ else
   LINKS_AVAILABLE=false
 fi
 
+# Set below the `command -v bun` branch that assigns LINKS_AVAILABLE, and read
+# by the block body and by both summary branches, so a Stop that blocks on
+# another step still says whether this step ran.
+LINK_NOTE="md links: clean"
+[ "$LINKS_AVAILABLE" = "false" ] && LINK_NOTE="md links: SKIPPED (bun not installed)"
+
 # ==== Report every failure the steps above collected ====
 
 if [ -n "$FAILED_STEPS" ]; then
-  emit_block "$FAILED_STEPS failed. Fix before ending the turn." "$FAILURE_OUTPUT"
+  emit_block "$FAILED_STEPS failed. Fix before ending the turn." "$FAILURE_OUTPUT$LINK_NOTE"
 fi
-
-# Computed once here and read by both summary branches below. Nothing between
-# this point and the summary can exit, so the position is for reuse, not order.
-LINK_NOTE="md links: clean"
-[ "$LINKS_AVAILABLE" = "false" ] && LINK_NOTE="md links: SKIPPED (bun not installed)"
 
 if [ "$CODE_CHANGED" -gt 0 ]; then
   jq -n --arg links "$LINK_NOTE" '{"systemMessage":("✅ Stop gate: typecheck / lint / format and the test suite pass (" + $links + ")")}'

--- a/.claude/hooks/stop-gate.sh
+++ b/.claude/hooks/stop-gate.sh
@@ -5,11 +5,11 @@
 #      than this turn's diff, so CI runs knip and lefthook's pre-push runs
 #      similarity-ts
 #    — runs only when code-relevant files changed (docs-only turns skip it)
+#    — every step runs even after an earlier one failed, and one block names
+#      all of them, so no failure waits for a later Stop to be reported
 #    — respects stop_hook_active: if this Stop was already blocked once, a
 #      failing gate downgrades to a warning instead of blocking again, so a
-#      pre-existing failure the agent cannot fix does not loop forever. The
-#      steps below fail fast, so the second Stop can carry a failure the first
-#      one never reported
+#      pre-existing failure the agent cannot fix does not loop forever
 # 2. Markdown link check — blocking; dead relative links are decidable by opening
 #    the path, so they belong here rather than in a reviewer's judgment
 
@@ -52,12 +52,21 @@ emit_block() { # $1 = summary, $2 = reason body (stdin-free)
   exit 0
 }
 
+FAILED_STEPS=""
+FAILURE_OUTPUT=""
+
+# A failing step is collected instead of emitted, so the caller can run the
+# remaining steps and report every failure in one block.
 # `local out` is separate from the assignment because `local out=$(...)` would
 # report local's own exit status and lose the one `bun run` returned.
-run_or_block() { # $1 = the `bun run` script to run
+run_step() { # $1 = the `bun run` script to run
   local out
-  out=$(bun run "$1" 2>&1) ||
-    emit_block "bun run $1 failed. Fix before ending the turn." "$out"
+  out=$(bun run "$1" 2>&1) && return 0
+  FAILED_STEPS="${FAILED_STEPS:+$FAILED_STEPS, }bun run $1"
+  FAILURE_OUTPUT="${FAILURE_OUTPUT}===== bun run $1 =====
+$out
+
+"
 }
 
 # Skip when there are no changes
@@ -80,8 +89,11 @@ CODE_CHANGED=$(printf '%s\n' "$ALL_FILES" | grep -cE '\.(ts|mts|cts|tsx|js|jsx|m
 if [ "$CODE_CHANGED" -gt 0 ]; then
   # `bun run check` is `vp check`, which formats, lints and type-checks over one
   # file walk. `bun run test` is `vp test --run --coverage`.
-  run_or_block check
-  run_or_block test
+  run_step check
+  run_step test
+  if [ -n "$FAILED_STEPS" ]; then
+    emit_block "$FAILED_STEPS failed. Fix before ending the turn." "$FAILURE_OUTPUT"
+  fi
 fi
 
 # ==== 2. Markdown link check ====

--- a/.claude/hooks/stop-gate.sh
+++ b/.claude/hooks/stop-gate.sh
@@ -109,21 +109,21 @@ fi
 # deleted, and the file holding the link is then untouched. Scoping to the diff
 # would have missed the case that motivated the check (docs/adr/ deleted on
 # 2026-07-29, dead links left in files the same commit did not edit).
-LINKS_AVAILABLE=true
+# LINK_NOTE carries this step's own verdict into the block body and into both
+# summary branches, so a Stop that blocks on another step still says what this
+# one did. Each branch below sets it, because a note left at "clean" while the
+# check failed would contradict the failure section in the same body.
+LINK_NOTE="md links: clean"
 if command -v bun >/dev/null 2>&1; then
-  LINKS=$(bun "$ROOT/.claude/hooks/check-md-links.ts" 2>&1) ||
+  if ! LINKS=$(bun "$ROOT/.claude/hooks/check-md-links.ts" 2>&1); then
     record_failure "markdown link check" "$LINKS"
+    LINK_NOTE="md links: FAILED"
+  fi
 else
   # A missing runtime downgrades the step; it never silently passes
-  # (AGENTS.md, "Degraded Environments"). Reported in the summary below.
-  LINKS_AVAILABLE=false
+  # (AGENTS.md, "Degraded Environments").
+  LINK_NOTE="md links: SKIPPED (bun not installed)"
 fi
-
-# Set below the `command -v bun` branch that assigns LINKS_AVAILABLE, and read
-# by the block body and by both summary branches, so a Stop that blocks on
-# another step still says whether this step ran.
-LINK_NOTE="md links: clean"
-[ "$LINKS_AVAILABLE" = "false" ] && LINK_NOTE="md links: SKIPPED (bun not installed)"
 
 # ==== Report every failure the steps above collected ====
 

--- a/.claude/hooks/stop-gate.sh
+++ b/.claude/hooks/stop-gate.sh
@@ -38,13 +38,17 @@ STOP_ACTIVE=$(printf '%s' "$INPUT" | jq -r \
 
 # Emit a block — downgraded to a warning when this Stop was already blocked
 # once (stop_hook_active), to prevent an unfixable failure from looping.
-emit_block() { # $1 = summary, $2 = reason body (stdin-free)
+# The body reaches jq through a pipe rather than argv: `--arg body "$2"` made
+# execve fail with E2BIG once a step's diagnostics crossed ARG_MAX (1048576 on
+# macOS), and the exit below then ended the turn having printed nothing.
+# `printf` is a shell builtin, so the body never passes through an argv again.
+emit_block() { # $1 = summary, $2 = reason body
   if [ "$STOP_ACTIVE" = "true" ]; then
-    jq -n --arg sum "$1" --arg body "$2" '{
+    printf '%s' "$2" | jq -n --arg sum "$1" --rawfile body /dev/stdin '{
       systemMessage: ("⚠️ Stop gate STILL failing (not re-blocking — stop_hook_active): " + $sum + " — if this failure is pre-existing or unfixable, report it to the user explicitly; do not treat it as passed.\n" + $body)
     }'
   else
-    jq -n --arg sum "$1" --arg body "$2" '{
+    printf '%s' "$2" | jq -n --arg sum "$1" --rawfile body /dev/stdin '{
       systemMessage: ("⛔ Stop block: " + $sum),
       decision: "block",
       reason: ($sum + "\n\n" + $body)


### PR DESCRIPTION
## 直した欠陥

`.claude/hooks/stop-gate.sh` は `bun run check` が失敗した時点で `emit_block` を呼んで exit していた。`check` と `test` の両方を壊した turn では次の順序になる。

1. 1 回目の Stop: `check` が失敗して block、agent は `check` を直す。
2. 2 回目の Stop: `stop_hook_active` が立っているので、失敗した `test` は warning に降格して turn が終わる。

suite の失敗は、gate が block しない turn の warning として 1 度だけ報告されていた。降格自体は直せない失敗が無限に block するのを防ぐためのもので、そこは正しい。壊れていたのは、gate が一度も block していない失敗を「既に報告して拒否された失敗」として扱っていた点。

## 選んだ形

**すべての step を必ず走らせて、失敗を 1 つの block にまとめる。**

`run_or_block` を `record_failure` と `run_step` に分けた。`run_step` は失敗を `FAILED_STEPS`（summary 用のステップ名）と `FAILURE_OUTPUT`（ステップ名の見出し付き出力）に溜めるだけで `emit_block` を呼ばない。`check` と `test` を走らせ、markdown link check も走らせた後、`FAILED_STEPS` が空でなければ 1 回だけ `emit_block` する。降格は turn 単位のまま残る。

もう一方の候補は、fail-fast を残して降格を step ごとにする形（そのステップが既に block したかどうかを見る）だった。採らなかった理由は、`stop_hook_active` が turn ごとの真偽値 1 つしか運ばないので、step ごとの降格には Stop をまたいで残る状態（どの step が block 済みか）が必要になること。その状態を書く場所と、いつ捨てるかを決める根拠が hook 側に無く、リセットの契機を間違えれば「turn 50 で初めて出た失敗が turn 1 の block を理由に降格する」という今と同じ欠陥に戻る。得られるのは失敗時に後続の step を省ける時間だけで、その時間は下の計測どおり pass 経路が既に払っている。

`emit_block` の中身、`stop_hook_active` / `loop_count` の対応、`CODE_CHANGED` の判定、link check の走査範囲には触っていない。

## 2 つ目の commit（altitude レビュー指摘から）

`simplify` の altitude レビューが、同じ欠陥が quality gate と markdown link check の間にも残ることを指摘した。1 回目の Stop で quality gate が block して exit すると link check は評価すらされず、2 回目の Stop で quality gate が通って初めて link check が走り、`stop_hook_active` を理由に warning へ降格する。そこで link check も `record_failure` に載せ、`emit_block` の呼び出しを両セクションの後の 1 か所に移した。

これで header comment の「Every step above runs even after an earlier one failed」がファイル全体について真になる（1 つ目の commit の時点では quality gate の中だけの話だった）。

副作用として link check だけが失敗したときの summary 文が変わる。`⛔ Stop block: dead markdown links. Fix the paths before ending the turn.` から `⛔ Stop block: markdown link check failed. Fix before ending the turn.` へ。死んだリンクの一覧は body に入る。

## 3 つ目の commit（code-reviewer 指摘、major）

`emit_block` は body を `jq -n --arg body "$2"` で渡していた。body が ARG_MAX（この macOS で `getconf ARG_MAX` は 1048576）を超えると jq の execve が E2BIG で失敗し、関数末尾の `exit 0` がそのまま走る。hook は stdout に何も書かずに exit 0 で終わり、失敗は agent に届かない。失敗を 1 つの block にまとめたぶん、複数 step の合計でもこの上限に届くようになっていた。

壊して見た結果: `src/lib/` に型エラー 6000 行の `.ts` を置くと `bun run check` の出力が 2309955 バイトになる。この tree で hook に Stop payload を食わせると stdout 0 バイト、exit 0、stderr に `stop-gate.sh: line 47: /usr/bin/jq: Argument list too long` だけ。

body を `printf '%s' "$2" | jq -n --rawfile body /dev/stdin` で渡すようにした。`printf` は shell builtin なので body が argv を通らず、上限自体が消える。同じ tree で 2394218 バイトの block が `decision: "block"` 付きで出た。小さい失敗 1 件の出力は修正前と `reason` 内の計測時間（`4.4s` と `3.6s`）以外は同一。`--rawfile` は jq 1.6 以降にある（この環境は `jq-1.7.1-apple`）。

## 4 つ目の commit（code-reviewer 指摘、minor）

`bun` が PATH に無いと link check は走らず `LINKS_AVAILABLE=false` になるが、同じ状態では `bun run check` と `bun run test` も `command not found` で失敗するので `emit_block` が `LINK_NOTE` の計算より前に exit し、block は link check について何も言わなかった。`LINK_NOTE` の計算を `emit_block` の前へ移し、block の body 末尾に足した。

確認: 未追跡の `.ts` を置いて `PATH=/usr/bin:/bin` で hook を走らせると、body に 2 つの `command not found` に続いて `md links: SKIPPED (bun not installed)` が出た。通常の block では同じ位置に `md links: clean` が出る。

## 5 つ目の commit（cubic 指摘、P3）

4 つ目の commit が入れた欠陥。link check の失敗は `record_failure` に記録されるだけで `LINKS_AVAILABLE` は true のままなので、`LINK_NOTE` が `md links: clean` に留まり、`===== markdown link check =====` の失敗詳細を含む同じ body の末尾に付いていた。`LINKS_AVAILABLE` の真偽値をやめ、clean / `md links: FAILED` / `md links: SKIPPED (bun not installed)` の 3 分岐がそれぞれ `LINK_NOTE` を書くようにした。

## 直していない指摘

cubic の P2 は「集約分岐に自動テストが無い。shell fixture のテストを足せ」。直していない。この repository に shell を走らせるテストの仕組みは無く（`.claude/hooks/` のテストは `check-md-links.ts` の 1 本だけ）、runner とその依存を選ぶのは別チケットの判断。代わりに各分岐を hook 実行で確かめた結果を下の表に置いた。仕組みを足すかどうかはユーザーの判断。

## 計測

warm（この worktree で 2 回目以降、他の worker が同時に check / test を回している状態）:

| 実行 | wall |
| --- | --- |
| hook 全体・tree が pass | 12.1 s / 13.0 s |
| hook 全体・`check` だけ失敗 | 14.0 s |
| hook 全体・`test` だけ失敗（1 回目 / 2 回目の Stop） | 12.0 s / 11.5 s |
| hook 全体・`check` と `test` が失敗（2 回目の Stop） | 15.0 s |
| hook 全体・3 step すべて失敗（1 回目の Stop） | 11.4 s |
| `bun run check` 単体 | 16.4 s |
| `bun run test` 単体（1 件失敗） | 6.9 s |

cold（`bun install` 直後のこの worktree での初回、`check` と `test` が失敗）: **188.6 s**。この間 CPU 使用率は 19% で、他の worker の check / test と取り合っていた。`bun run check` 自身の報告は 42.2 s。

この形の worst case は「`check` と `test` の両方が走る」で、それは #140 が 240 s を設定した対象（cold sum 89.5 s）と同じ経路。pass する turn は #140 でも両方走っていたので worst case は増えていない。増えたのは「`check` が失敗した turn も `test` を走らせる」ぶんで、上限は pass 経路と同じ。cold で観測した 188.6 s は 240 s の内側なので `.claude/settings.json` の timeout は据え置いた。余裕が 51 s しかない点は数字として残す（並列 worker のいない機械なら空く）。

## 壊して確かめたこと

`shellcheck` がこの環境の PATH に無いので、shell の静的 lint はかけられていない（not run）。代わりに hook に Stop payload を食わせて挙動を見た。probe は一時ファイルで作った（`src/lib/` に型エラーの `.ts` で `check` を壊し、失敗する `.test.ts` で `test` を壊し、`docs/` に死んだ相対リンクの `.md` を置いて link check を壊した）。すべて削除して `git status` が clean であることを確認してから stage した。

| 壊した step | payload | 受け取ったもの |
| --- | --- | --- |
| `check` + `test` | `stop_hook_active` なし | `decision: "block"`、`bun run check, bun run test failed. Fix before ending the turn.`、body に `===== bun run check =====` と `===== bun run test =====`（`grep -c '^===== '` で 2） |
| `check` + `test` | `stop_hook_active: true` | `decision` キー無し、`⚠️ Stop gate STILL failing (not re-blocking — stop_hook_active): bun run check, bun run test failed.` |
| `check` + `test` + link | なし | `decision: "block"`、`bun run check, bun run test, markdown link check failed.`、body に 3 つの見出し |
| `check` のみ | なし / `true` | `⛔ Stop block: bun run check failed. Fix before ending the turn.` / 同文の warning、`decision` キー無し |
| `test` のみ | なし / `true` | `⛔ Stop block: bun run test failed. Fix before ending the turn.` / 同文の warning、`decision` キー無し |
| link のみ | なし / `true` | `⛔ Stop block: markdown link check failed. Fix before ending the turn.` + 死んだリンクの一覧 / 同文の warning、`decision` キー無し |
| なし（code 変更あり） | なし | `✅ Stop gate: typecheck / lint / format and the test suite pass (md links: clean)` |
| なし（code 変更なし） | なし | `✅ Stop gate: no code-relevant changes (quality gate skipped, md links: clean)` |
| `check`（出力 2309955 バイト） | なし | 2394218 バイトの block（修正前は stdout 0 バイト + exit 0） |
| `check` + `test`（`PATH=/usr/bin:/bin`） | なし | 2 つの `command not found` と `md links: SKIPPED (bun not installed)` |
| link のみ（5 つ目の commit 後） | なし | body 末尾が `md links: FAILED` |

1 step だけ失敗したときの `check` / `test` の summary 文は #140 と同じ文字列。body には `===== bun run <script> =====` の見出しが 1 行増える。

## 前提として置いたこと

- `bun run check` の後に `bun run test` を走らせる順序は変えていない。`check` は format を書き込むので、失敗した `check` の後に `test` を走らせても suite が見るのは format 済みの tree。
- efficiency レビューが `check` と `test` の並列実行を提案したが採らなかった。`bun run check` は format を in-place で書き、`bun run test` は同じファイルを読むので競合する。加えて 1 worker のピークメモリが上がり、AGENTS.md の dispatch 計算（worker あたり 4 GiB）の前提が変わる。
- 失敗の蓄積は配列ではなく 2 本の文字列（`FAILED_STEPS` と `FAILURE_OUTPUT`）にした。`emit_block` が summary と body の 2 引数を取るので、片方から他方を作り直す必要がない形になる。使っている構文は `${VAR:+...}` の parameter expansion と `&&` / `||` だけ。

## 検証

`bun run check`、`bun run test`（coverage branches 100%）、`bun .claude/hooks/check-md-links.ts` がいずれも pass。lefthook の pre-push が走らせる `bun run cf-typegen:check`、`bun run check:pins`、`mise exec -- actionlint`、`similarity-ts ./src --fail-on-duplicates` も手元で pass。`shellcheck` は not run（PATH に無い）。

probe ファイルは commit 前にすべて削除し、`git status --porcelain --untracked-files=all` が `.claude/hooks/stop-gate.sh` の 1 行だけになることを毎回確認した。
