### PR TITLE
feat: .cursor/rules の mirror が壊れたことを CI で検出する

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,6 +108,9 @@ jobs:
       - name: Check markdown links
         run: bun .claude/hooks/check-md-links.ts
 
+      - name: Check the Cursor rule mirrors
+        run: bun scripts/check-cursor-rule-mirrors.ts
+
       # `vp check` runs format, lint and type checks in one pass, which is why
       # this workflow has no separate tsc step.
       - name: Run format, lint and type checks

--- a/scripts/check-cursor-rule-mirrors.test.ts
+++ b/scripts/check-cursor-rule-mirrors.test.ts
@@ -1,0 +1,267 @@
+// @vitest-environment node
+
+/**
+ * Exercise check-cursor-rule-mirrors.ts against the arrangements it must judge.
+ *
+ * Each case builds real files and real symlinks under a temp directory, then
+ * breaks the arrangement one way. A fixture made of plain data would not reach
+ * the decision this checker rests on, which the checker's own comment on
+ * `withFileTypes` states.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+import { main, mirrorReport } from "./check-cursor-rule-mirrors";
+
+const WORK = fs.mkdtempSync(path.join(os.tmpdir(), "cursor-rule-mirrors-"));
+const RULE_NAMES = ["alpha", "beta"];
+
+const rule = (root: string, name: string): string =>
+  path.join(root, `.claude/rules/${name}.md`);
+
+const mirror = (root: string, name: string): string =>
+  path.join(root, `.cursor/rules/${name}.mdc`);
+
+/** A tree with two rules, each mirrored the way AGENTS.md requires. */
+const mirroredTree = (): string => {
+  const root = fs.mkdtempSync(path.join(WORK, "case-"));
+  fs.mkdirSync(path.join(root, ".claude/rules"), { recursive: true });
+  fs.mkdirSync(path.join(root, ".cursor/rules"), { recursive: true });
+  RULE_NAMES.forEach((name) => {
+    fs.writeFileSync(rule(root, name), `# ${name}\n`);
+    fs.symlinkSync(`../../.claude/rules/${name}.md`, mirror(root, name));
+  });
+  return root;
+};
+
+describe("check-cursor-rule-mirrors", () => {
+  afterAll(() => {
+    fs.rmSync(WORK, { force: true, recursive: true });
+  });
+
+  it("should report no problem when every rule is mirrored by a symlink to it", () => {
+    const root = mirroredTree();
+
+    expect(mirrorReport(root)).toStrictEqual({
+      problems: [],
+      rules: ["alpha", "beta"],
+    });
+  });
+
+  it("should report the mirror when a symlink was replaced by a copy of the rule", () => {
+    const root = mirroredTree();
+
+    fs.rmSync(mirror(root, "alpha"));
+    fs.copyFileSync(rule(root, "alpha"), mirror(root, "alpha"));
+
+    expect(mirrorReport(root)).toStrictEqual({
+      problems: [
+        {
+          detail: "not a symlink to ../../.claude/rules/alpha.md",
+          entry: ".cursor/rules/alpha.mdc",
+        },
+      ],
+      rules: ["alpha", "beta"],
+    });
+  });
+
+  it("should report the mirror when it links to another rule", () => {
+    const root = mirroredTree();
+
+    fs.rmSync(mirror(root, "alpha"));
+    fs.symlinkSync("../../.claude/rules/beta.md", mirror(root, "alpha"));
+
+    expect(mirrorReport(root)).toStrictEqual({
+      problems: [
+        {
+          detail:
+            "links to ../../.claude/rules/beta.md instead of ../../.claude/rules/alpha.md",
+          entry: ".cursor/rules/alpha.mdc",
+        },
+      ],
+      rules: ["alpha", "beta"],
+    });
+  });
+
+  it("should report the mirror when its link reaches the rule by a detour", () => {
+    const root = mirroredTree();
+
+    fs.rmSync(mirror(root, "alpha"));
+    fs.symlinkSync(
+      "../../.claude/rules/../rules/alpha.md",
+      mirror(root, "alpha")
+    );
+
+    expect(mirrorReport(root)).toStrictEqual({
+      problems: [
+        {
+          detail:
+            "links to ../../.claude/rules/../rules/alpha.md instead of ../../.claude/rules/alpha.md",
+          entry: ".cursor/rules/alpha.mdc",
+        },
+      ],
+      rules: ["alpha", "beta"],
+    });
+  });
+
+  it("should report the mirror when its link is absolute", () => {
+    const root = mirroredTree();
+
+    fs.rmSync(mirror(root, "alpha"));
+    fs.symlinkSync(rule(root, "alpha"), mirror(root, "alpha"));
+
+    expect(mirrorReport(root)).toStrictEqual({
+      problems: [
+        {
+          detail: `links to ${rule(root, "alpha")} instead of ../../.claude/rules/alpha.md`,
+          entry: ".cursor/rules/alpha.mdc",
+        },
+      ],
+      rules: ["alpha", "beta"],
+    });
+  });
+
+  it("should report the mirror when its link text matches but resolves to nothing", () => {
+    const root = fs.mkdtempSync(path.join(WORK, "case-"));
+    fs.mkdirSync(path.join(root, ".claude/rules"), { recursive: true });
+    fs.mkdirSync(path.join(root, "nested/.cursor/rules"), { recursive: true });
+    fs.writeFileSync(rule(root, "alpha"), "# alpha\n");
+    fs.symlinkSync(
+      "../../.claude/rules/alpha.md",
+      path.join(root, "nested/.cursor/rules/alpha.mdc")
+    );
+
+    fs.symlinkSync("nested/.cursor", path.join(root, ".cursor"));
+
+    expect(mirrorReport(root)).toStrictEqual({
+      problems: [
+        {
+          detail:
+            "links to ../../.claude/rules/alpha.md, which resolves to nothing",
+          entry: ".cursor/rules/alpha.mdc",
+        },
+      ],
+      rules: ["alpha"],
+    });
+  });
+
+  it("should report a subdirectory when either rules directory holds one", () => {
+    const root = mirroredTree();
+
+    fs.mkdirSync(path.join(root, ".claude/rules/sub"));
+    fs.mkdirSync(path.join(root, ".cursor/rules/sub"));
+
+    expect(mirrorReport(root)).toStrictEqual({
+      problems: [
+        {
+          detail:
+            "a directory, and only the files directly in .claude/rules are read",
+          entry: ".claude/rules/sub",
+        },
+        {
+          detail:
+            "a directory, and only the files directly in .cursor/rules are read",
+          entry: ".cursor/rules/sub",
+        },
+      ],
+      rules: ["alpha", "beta"],
+    });
+  });
+
+  it("should report the missing mirror when a rule was added without one", () => {
+    const root = mirroredTree();
+
+    fs.writeFileSync(rule(root, "gamma"), "# gamma\n");
+
+    expect(mirrorReport(root)).toStrictEqual({
+      problems: [
+        {
+          detail: "missing: add a symlink to ../../.claude/rules/gamma.md",
+          entry: ".cursor/rules/gamma.mdc",
+        },
+      ],
+      rules: ["alpha", "beta", "gamma"],
+    });
+  });
+
+  it("should report the mirror when the rule it links to was deleted", () => {
+    const root = mirroredTree();
+
+    fs.rmSync(rule(root, "alpha"));
+
+    expect(mirrorReport(root)).toStrictEqual({
+      problems: [
+        {
+          detail: "no .claude/rules/alpha.md exists for it to mirror",
+          entry: ".cursor/rules/alpha.mdc",
+        },
+      ],
+      rules: ["beta"],
+    });
+  });
+
+  it("should report every rule when the mirror directory is gone", () => {
+    const root = mirroredTree();
+
+    fs.rmSync(path.join(root, ".cursor/rules"), { recursive: true });
+
+    expect(mirrorReport(root)).toStrictEqual({
+      problems: [
+        {
+          detail: "missing: add a symlink to ../../.claude/rules/alpha.md",
+          entry: ".cursor/rules/alpha.mdc",
+        },
+        {
+          detail: "missing: add a symlink to ../../.claude/rules/beta.md",
+          entry: ".cursor/rules/beta.mdc",
+        },
+      ],
+      rules: ["alpha", "beta"],
+    });
+  });
+
+  it("should report the rule directory when it holds no rule", () => {
+    const root = mirroredTree();
+
+    fs.rmSync(path.join(root, ".claude/rules"), { recursive: true });
+
+    expect(mirrorReport(root)).toStrictEqual({
+      problems: [
+        {
+          detail: "holds no rule, so this check compares nothing",
+          entry: ".claude/rules",
+        },
+        {
+          detail: "no .claude/rules/alpha.md exists for it to mirror",
+          entry: ".cursor/rules/alpha.mdc",
+        },
+        {
+          detail: "no .claude/rules/beta.md exists for it to mirror",
+          entry: ".cursor/rules/beta.mdc",
+        },
+      ],
+      rules: [],
+    });
+  });
+
+  it("should exit non-zero when a mirror is a copy of its rule", () => {
+    const root = mirroredTree();
+
+    fs.rmSync(mirror(root, "alpha"));
+    fs.copyFileSync(rule(root, "alpha"), mirror(root, "alpha"));
+
+    expect(main([root])).toBe(1);
+  });
+
+  it("should exit zero when every mirror is a symlink to its rule", () => {
+    const root = mirroredTree();
+
+    expect(main([root])).toBe(0);
+  });
+
+  it("should exit zero when this repository's own mirrors are in sync", () => {
+    expect(main([])).toBe(0);
+  });
+});

--- a/scripts/check-cursor-rule-mirrors.ts
+++ b/scripts/check-cursor-rule-mirrors.ts
@@ -1,0 +1,185 @@
+#!/usr/bin/env bun
+
+/**
+ * Report `.cursor/rules/*.mdc` entries that have stopped mirroring
+ * `.claude/rules/*.md`.
+ *
+ * ```
+ * bun scripts/check-cursor-rule-mirrors.ts         # this repository
+ * bun scripts/check-cursor-rule-mirrors.ts <root>  # a tree holding both directories
+ * ```
+ *
+ * A mirror is right when it is a symlink whose text is exactly
+ * `../../.claude/rules/<its own name>.md` and whose target exists, and when
+ * every rule has one. Returns a non-zero exit code for anything else,
+ * including a `.claude/rules` that holds no rule at all, which would otherwise
+ * pass with nothing compared.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+const REPO = path.resolve(import.meta.dirname, "..");
+
+const RULES = ".claude/rules";
+const MIRRORS = ".cursor/rules";
+
+/** The one link text a mirror may carry. */
+const linkTextFor = (name: string): string => `../../${RULES}/${name}.md`;
+
+/**
+ * The directory's entries, or none where it cannot be read.
+ *
+ * Deleting `.cursor/rules` is then reported as every rule losing its mirror,
+ * and deleting `.claude/rules` as a rule directory holding no rule.
+ */
+const readEntries = (dir: string): fs.Dirent[] => {
+  try {
+    return fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+};
+
+type EntryKind = "other" | "symlink";
+
+/**
+ * The `extension` entries by name with that suffix removed, each with its kind.
+ *
+ * The kind comes from the directory entry, where `statSync` follows the link
+ * and reports a copy and the symlink it replaced identically.
+ */
+const kindsOf = (
+  entries: readonly fs.Dirent[],
+  extension: string
+): Map<string, EntryKind> =>
+  new Map(
+    entries
+      .filter((entry) => entry.name.endsWith(extension))
+      .map((entry): [string, EntryKind] => [
+        path.basename(entry.name, extension),
+        entry.isSymbolicLink() ? "symlink" : "other",
+      ])
+  );
+
+export interface MirrorProblem {
+  readonly detail: string;
+  readonly entry: string;
+}
+
+/** A subdirectory holds files this check never reads, so it is reported. */
+const directoryProblems = (
+  display: string,
+  entries: readonly fs.Dirent[]
+): MirrorProblem[] =>
+  entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => ({
+      detail: `a directory, and only the files directly in ${display} are read`,
+      entry: `${display}/${entry.name}`,
+    }));
+
+/**
+ * What is wrong with one name's mirror, or null when it mirrors its rule.
+ *
+ * The link text is compared literally rather than resolved: an absolute link
+ * resolves in one checkout only, and `../../.claude/rules/../rules/prose.md`
+ * reaches the right file by a spelling nothing here writes. `existsSync`
+ * follows the link afterwards, so a matching text whose `../..` lands
+ * somewhere else is reported rather than passed.
+ */
+const detailFor = (
+  root: string,
+  name: string,
+  hasRule: boolean,
+  kind: EntryKind | undefined
+): string | null => {
+  if (kind === undefined) {
+    return `missing: add a symlink to ${linkTextFor(name)}`;
+  }
+  if (!hasRule) {
+    return `no ${RULES}/${name}.md exists for it to mirror`;
+  }
+  if (kind === "other") {
+    return `not a symlink to ${linkTextFor(name)}`;
+  }
+  const mirror = path.join(root, MIRRORS, `${name}.mdc`);
+  const link = fs.readlinkSync(mirror);
+  if (link !== linkTextFor(name)) {
+    return `links to ${link} instead of ${linkTextFor(name)}`;
+  }
+  return fs.existsSync(mirror)
+    ? null
+    : `links to ${linkTextFor(name)}, which resolves to nothing`;
+};
+
+export interface MirrorReport {
+  readonly problems: readonly MirrorProblem[];
+  readonly rules: readonly string[];
+}
+
+/** Judges every name either directory holds, so both directions are decided. */
+export const mirrorReport = (root: string): MirrorReport => {
+  const ruleEntries = readEntries(path.join(root, RULES));
+  const mirrorEntries = readEntries(path.join(root, MIRRORS));
+  const rules = [...kindsOf(ruleEntries, ".md").keys()].toSorted();
+  const mirrors = kindsOf(mirrorEntries, ".mdc");
+  const ruleNames = new Set(rules);
+  const emptyRules =
+    rules.length === 0
+      ? [
+          {
+            detail: "holds no rule, so this check compares nothing",
+            entry: RULES,
+          },
+        ]
+      : [];
+  const broken = [...new Set([...rules, ...mirrors.keys()])]
+    .toSorted()
+    .flatMap((name) => {
+      const detail = detailFor(
+        root,
+        name,
+        ruleNames.has(name),
+        mirrors.get(name)
+      );
+      return detail === null
+        ? []
+        : [{ detail, entry: `${MIRRORS}/${name}.mdc` }];
+    });
+  return {
+    problems: [
+      ...emptyRules,
+      ...directoryProblems(RULES, ruleEntries),
+      ...directoryProblems(MIRRORS, mirrorEntries),
+      ...broken,
+    ],
+    rules,
+  };
+};
+
+export const main = (argv: readonly string[]): number => {
+  const { problems, rules } = mirrorReport(path.resolve(argv[0] ?? REPO));
+  if (problems.length > 0) {
+    console.log(
+      [
+        `Cursor rule mirrors out of sync: ${problems.length}`,
+        ...problems.map(({ detail, entry }) => `  ${entry}: ${detail}`),
+        "",
+        `Every ${RULES}/<name>.md is mirrored at ${MIRRORS}/<name>.mdc as a`,
+        "symlink. Create one with:",
+        `  ln -s ../../${RULES}/<name>.md ${MIRRORS}/<name>.mdc`,
+      ].join("\n")
+    );
+    return 1;
+  }
+  console.log(
+    `cursor rule mirrors ok (${rules.length} rules, each symlinked into ${MIRRORS})`
+  );
+  return 0;
+};
+
+const [, entry] = process.argv;
+if (entry !== undefined && path.resolve(entry) === import.meta.filename) {
+  process.exit(main(process.argv.slice(2)));
+}


### PR DESCRIPTION
## 何が変わるか

`.claude/rules/*.md` は `.cursor/rules/*.mdc` の file-level symlink 経由で Cursor session に渡る。この取り決めを判定する gate は無く、`ls -l .cursor/rules/` の 3 本が symlink であることに誰も依存できていなかった。`scripts/check-cursor-rule-mirrors.ts` と CI の 1 step を追加する。

mirror が正しいのは、symlink であり、link のテキストが `../../.claude/rules/<自分と同じ名前>.md` そのものであり、その先が存在し、かつ rule 側にも同名の mirror があるとき。それ以外は非ゼロで終了する。

## 判定を壊して落ちるのを見た記録

`bun scripts/check-cursor-rule-mirrors.ts` を、実際の repository を 3 通りに壊して実行し、戻した。

1. 手を入れる前（`.cursor/rules/` が symlink 3 本）: `cursor rule mirrors ok (3 rules, each symlinked into .cursor/rules)`、exit 0。
2. `prose.mdc` を `prose.md` の copy に置き換え: `.cursor/rules/prose.mdc: not a symlink to ../../.claude/rules/prose.md`、exit 1。`git restore` で戻した。
3. `prose.mdc` を `../../.claude/rules/react.md` に貼り替え: `.cursor/rules/prose.mdc: links to ../../.claude/rules/react.md instead of ../../.claude/rules/prose.md`、exit 1。`git restore` で戻した。
4. `.claude/rules/zz-mirror-probe.md` を mirror なしで追加: `.cursor/rules/zz-mirror-probe.mdc: missing: add a symlink to ../../.claude/rules/zz-mirror-probe.md`、exit 1。削除して 1 の出力に戻り、`git status` は clean。

review が見つけた 2 つの silent pass も同じやり方で確認した。`.cursor` を `nested/.cursor` への symlink にすると link のテキストは一致するのに `../..` が別の場所に着く。追加した `existsSync` で `links to ../../.claude/rules/alpha.md, which resolves to nothing`、exit 1。`.claude/rules/sub/nested.md` を置くと nested な rule が mirror されないまま通過していた。追加した directory の判定で `.claude/rules/sub: a directory, and only the files directly in .claude/rules are read`、exit 1。

`scripts/check-cursor-rule-mirrors.test.ts` の 14 test が同じ arrangement を temp directory 上の実 file と実 symlink で固定する。

## symlink が actions/checkout を越えることの確認

`git ls-files -s .cursor/rules/` が 3 entry すべてを mode 120000 で持ち、`git cat-file -p HEAD:.cursor/rules/prose.mdc` は blob の中身が link のテキスト `../../.claude/rules/prose.md` であることを示す。この worktree 自体が `git worktree add` の checkout で作られ、そこで `.cursor/rules/` は symlink として現れた（`ls -l`）。`core.symlinks` は未設定。この PR の CI step が pass すること自体が ubuntu-latest 上の `actions/checkout` での確認になる。落ちていれば `not a symlink to ...` が 3 件出る。

## 置き場所の判断

`scripts/` の script を CI の step が呼ぶ形にした。`check:pins`（`scripts/check-toolchain-pins.ts`）と markdown link（`.claude/hooks/check-md-links.ts`）が同じ形で、`main(argv)` が exit code を返して末尾の entry guard から呼ばれる shape も後者に合わせている。ci.yaml に bash の step として書くこともできたが、それだと判定の正しさを固定する test が持てず、`statSync` と `lstatSync` の違いのような壊れ方を後から誰も検出できない。

`vitest.config.mts` の `coverage.include` は `scripts/` を directory では見ておらず、`scripts/orchestrate-decisions.ts` を 1 行で名指ししている。この module は `readdirSync` / `readlinkSync` / `existsSync` に届くので AGENTS.md の Testing に従って list には入れない。`.claude/hooks/check-md-links.ts` も同じ理由で入っていない。

## 前提として置いたこと

- pre-push (`lefthook.yml`) と `package.json` の script、`.claude/settings.json` の allow には入れていない。scope 外の file を並行 PR が持っているため。`check:pins` と markdown link は両方から走るので、この gate だけ CI 専用になっている。
- `.claude/rules/` の subdirectory は recursive に読まず、directory があること自体を落とす。Claude Code と Cursor が nested な rule file を読むかを確認できていないので、読む前提で mirror を作るより、置かれた時点で落ちる方を選んだ。
- symlink かどうかは `readdirSync` の Dirent から読む。macOS APFS では `lstatSync` と一致した。ubuntu-latest では確認していない。d_type が不明な entry は `"other"` になり、pass ではなく report 側に倒れる。

## review で決定を要したもの

`main` の default root branch（引数なしで `REPO` を読む）に test が無い、という指摘に対し、`expect(main([])).toBe(0)` を足した。branch が埋まる代わりに、この test は誰かが実際の mirror を壊したときに module の外の理由で落ちる。pre-push にこの script が無い今、`bun run test` が local の 2 つ目の gate になる方を取った。

## 走らせた gate

`bun run check` / `bun run test`（20 files, 476 tests, branches 100%）/ `bun run knip` / `bun run doctor --no-score` / `mise exec -- actionlint`、すべて pass。


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI gate that fails when any `.cursor/rules/*.mdc` mirror stops being a symlink to its matching `.claude/rules/*.md` rule. Previously, a mirror could be replaced by a file copy, point to the wrong rule, or be missing without anything failing.

- The new script `scripts/check-cursor-rule-mirrors.ts` verifies each mirror is a symlink whose link text is exactly `../../.claude/rules/<same name>.md`, that the rule exists, and that every rule has a mirror; it also fails on subdirectories and an empty rules directory.
- A CI step runs the script, and 14 tests cover the failure modes.

<sup>Written for commit 6d4eed968bf492726587a0d54f1909a7e5b0b94b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imaimai17468/imaimai-front-templete/pull/145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

