### PR TITLE
fix: 全体を stage する git add を hook が拒むようにする

### DIFF
--- a/.claude/hooks/pre-bash-guard.sh
+++ b/.claude/hooks/pre-bash-guard.sh
@@ -43,6 +43,43 @@ deny() { # $1 = reason
   }'
 }
 
+# Drop a heredoc body, keeping the operator line, the terminator's own line and
+# everything after it: text a command receives on stdin is data rather than a
+# filename or a nested command, while a command chained after the terminator is
+# a command. Dropping only when the body ran to the end of the input instead
+# read the body as commands whenever anything followed, so
+# `git commit -F - <<'MSG'` / `git add -A was refused` / `MSG` / `git push`
+# was refused for a command nobody wrote. With no terminator the body cannot be
+# told from the rest, so every line is kept. A redirect belongs to the operator
+# line, which is kept either way. Guards 1, 2 and 3 all read the result.
+drop_heredoc_body() {
+  awk '
+    BEGIN { q = sprintf("%c", 39); op = 0; term = 0 }
+    { lines[NR] = $0 }
+    op == 0 && /<<-?[ \t]*[^ \t]/ {
+      op = NR
+      d = $0
+      sub(/^.*<<-?[ \t]*/, "", d)
+      gsub(/["]/, "", d)
+      gsub(q, "", d)
+      sub(/[ \t].*$/, "", d)
+      next
+    }
+    op > 0 && term == 0 && d != "" {
+      trimmed = $0
+      sub(/^[ \t]+/, "", trimmed)
+      sub(/[ \t]+$/, "", trimmed)
+      if (trimmed == d) { term = NR }
+    }
+    END {
+      for (i = 1; i <= NR; i++) {
+        if (term > 0 && i > op && i <= term) { continue }
+        print lines[i]
+      }
+    }
+  '
+}
+
 CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""')
 
 # --- Guard 1: .env protection (applies to parent and sidechains alike) ---
@@ -92,29 +129,8 @@ if [ -n "$TEXT_FLAG_PATTERN" ]; then
     *) SCRUBBED=$(printf '%s' "$SCRUBBED" | scrub_message_body '"') ;;
   esac
   # A `-F -` / `--body-file -` body arrives as a heredoc instead, by a route the
-  # flag scrub above does not cover. Drop it only when the command's last line
-  # is the delimiter: then nothing follows the body, so nothing is hidden. A
-  # redirect belongs to the operator line, which is kept either way, and a
-  # command chained after the terminator leaves a different last line.
-  SCRUBBED=$(printf '%s' "$SCRUBBED" | awk '
-    BEGIN { q = sprintf("%c", 39); op = 0 }
-    { last = $0; lines[NR] = $0 }
-    op == 0 && /<<-?[ \t]*[^ \t]/ {
-      op = NR
-      d = $0
-      sub(/^.*<<-?[ \t]*/, "", d)
-      gsub(/["]/, "", d)
-      gsub(q, "", d)
-      sub(/[ \t].*$/, "", d)
-    }
-    END {
-      trimmed = last
-      sub(/^[ \t]+/, "", trimmed)
-      sub(/[ \t]+$/, "", trimmed)
-      keep = (op > 0 && d != "" && trimmed == d) ? op : NR
-      for (i = 1; i <= keep; i++) print lines[i]
-    }
-  ')
+  # flag scrub above does not cover.
+  SCRUBBED=$(printf '%s' "$SCRUBBED" | drop_heredoc_body)
 fi
 # `.env` is one of several spellings the shell turns into the same filename: it
 # drops a backslash and a quote pair from a word, so `.e\nv`, `.en"v"` and

--- a/.claude/hooks/pre-bash-guard.sh
+++ b/.claude/hooks/pre-bash-guard.sh
@@ -151,9 +151,10 @@ if printf '%s\n%s\n%s' "$SCRUBBED" "$UNESCAPED" "$UNQUOTED" | grep -qE '(^|[[:sp
   exit 0
 fi
 
-# Whitespace-normalized command, shared by the guards below: irregular spacing
-# ("git  commit", tabs, newlines) must not slip past a match.
-NORM=$(printf '%s' "$CMD" | tr -s '[:space:]' ' ')
+# Whitespace-normalized command for Guard 2, its only reader: the segment
+# filter below matches the literal " find ", so irregular spacing (`find  .`,
+# tabs, newlines) must not slip past it.
+NORM=$(printf '%s' "$CMD" | drop_heredoc_body | tr -s '[:space:]' ' ')
 
 # --- Guard 2: find with broad reach, or an action that runs or deletes ---
 # `find` itself is allow-listed: path discovery is
@@ -179,11 +180,14 @@ NORM=$(printf '%s' "$CMD" | tr -s '[:space:]' ' ')
 # root behind a narrow one. Quotes are stripped and every leading operand is
 # checked.
 FIND_ASK=""
-# Everything from the first heredoc/herestring operator onward is data, not a
-# command — a commit message describing `find . | xargs cat` must not trip this.
-# Guard 1 scrubs `-m` bodies for the same reason; this is the heredoc case, found
-# when the first version of this guard refused the commit that introduced it.
-NORM_FIND=$(printf '%s' "${NORM%%<<*}" | tr -d "'\"\`")
+# A heredoc body is data, not a command — a commit message describing
+# `find . | xargs cat` must not trip this. Guard 1 scrubs `-m` bodies for the
+# same reason; this is the heredoc case, found when the first version of this
+# guard refused the commit that introduced it. NORM's `drop_heredoc_body` drops
+# the body by reading the terminator. Truncating from the first `<<` instead
+# left `cat <<EOF` / `x` / `EOF` / `find / -type f` allowed, because everything
+# after the terminator went with the body.
+NORM_FIND=$(printf '%s' "$NORM" | tr -d "'\"\`")
 while IFS= read -r SEG; do
   [ -n "$FIND_ASK" ] && break
   case " $SEG " in

--- a/.claude/hooks/pre-bash-guard.sh
+++ b/.claude/hooks/pre-bash-guard.sh
@@ -5,6 +5,9 @@
 #    grep, head, tail, redirections) could walk around it.
 # 2. find gate — prompt for the `find` shapes that reach past the deny list or
 #    run/delete, while leaving scoped path discovery unattended.
+# 3. git add gate — refuse a `git add` (or its `git stage` synonym) whose
+#    operands are not explicit paths, because a blanket stage puts files in the
+#    commit that nobody chose.
 
 set -euo pipefail
 
@@ -237,6 +240,174 @@ if [ -n "$FIND_ASK" ]; then
   # already-allowed command is unstated, and a guard that silently does nothing
   # is worse than a strict one. Revisit if that behaviour is ever confirmed.
   deny "PreToolUse(Bash): this \`find\` is refused because ${FIND_ASK}. A find scoped to a subdirectory, without -exec/-execdir/-ok/-okdir/-delete/-fprint/-fls, runs unattended — narrow it if that is enough. If the broad form is genuinely needed, ask the user to run it."
+  exit 0
+fi
+
+# --- Guard 3: a git add whose operands are not explicit paths ---
+# `-A`, `--all` and `--no-ignore-removal` stage every change in the worktree and
+# `-u`/`--update` every tracked one; `.`, `./`, `..`, `/` and a bare `*` name no
+# file of their own; a glob in an operand's first component reaches the whole
+# tree, so `git add '*.ts'` from the root staged every `.ts` in the scratch
+# repository; `:/` and `:(top)` each staged all of it from a subdirectory; and
+# `git stage` ran the same builtin (git 2.50.1, 2026-09-08). `git add -p` keeps
+# working: it selects hunks instead of sweeping the tree.
+#
+# The text is Guard 1's SCRUBBED, so a `git`/`gh` message body quoting a refused
+# shape stays prose, plus one more heredoc drop so a body written under any other
+# command is prose too. The command is then split on `;|&()` and on newlines,
+# because the shapes a reviewer used against Guard 2 reach this guard as well:
+# `git add "."`, `git  add  -A`, `git status && git add -A`, and
+# `GIT_DIR=x git add .`.
+#
+# `git` has to open the segment, behind nothing but assignments and a wrapper
+# such as `env`, `sh -c` or `xargs`. That anchor is what leaves
+# `rg 'git add .' src` unattended instead of refusing a search for the text it
+# looks for. Two routes stay out of reach: a shell function or a script file,
+# which no token walk sees, and an operand that only the shell can resolve, so
+# `git add "$FILE"` and `git add $(git diff --name-only)` pass as named paths.
+# This binds the habit rather than a deliberate bypass.
+#
+# The shell drops a quote pair and a backslash from a word, so `g""it`, `\-A`
+# and `\*` all reach git undecorated; Guard 1 normalizes the same two
+# decorations at UNQUOTED for the same reason. Both run as parameter
+# expansions, so neither forks a `tr`, and both run before the early-out below,
+# which otherwise let `g""it add -A` past with no literal `git` in its text.
+ADD_PLAIN=${SCRUBBED//[\"\'\`]/}
+ADD_PLAIN=${ADD_PLAIN//\\/}
+# Only a segment a literal `git` opens can be refused, so a command whose text
+# holds no `git` leaves before the awk fork below. This hook runs on every Bash
+# call, and on `ls -la` over two rounds of 60 interleaved runs it took 173 ms
+# and 184 ms with this case against 181 ms and 203 ms without it (a machine
+# under parallel load, 2026-09-08). Guard 3 is the last guard, so exiting here
+# and reaching the end of the file do the same thing.
+case "$ADD_PLAIN" in
+  *git*) ;;
+  *) exit 0 ;;
+esac
+ADD_REFUSED=""
+# A line of the split that reads `EOF` does not end the heredoc below, because
+# bash finds that delimiter in the script text before expanding anything into
+# the body.
+ADD_TEXT=$(printf '%s' "$ADD_PLAIN" | drop_heredoc_body)
+ADD_SEGMENTS=${ADD_TEXT//[;|\&()]/$'\n'}
+# A bare `*` operand has to survive word splitting as itself rather than
+# expanding to the working directory's entries.
+set -f
+while IFS= read -r SEG; do
+  STATE=prefix
+  SKIP_VALUE=0
+  SUB=""
+  HAS_SELECTION=0
+  for TOK in $SEG; do
+    if [ "$SKIP_VALUE" -eq 1 ]; then
+      SKIP_VALUE=0
+      continue
+    fi
+    case "$STATE" in
+      prefix)
+        case "$TOK" in
+          git) STATE=subcommand ;;
+          # An assignment, a redirect, a command that runs another command, or
+          # such a command's own flag or count (`timeout 5`) stands between the
+          # start of the segment and the git it runs.
+          *=* | -* | *'>'* | *'<'* | [0-9]* | env | command | exec | eval | xargs | sh | bash | zsh | sudo | time | timeout | nohup) ;;
+          *) break ;;
+        esac
+        ;;
+      subcommand)
+        case "$TOK" in
+          # git's own options that take the following token as their value
+          # (`git --help`, git 2.50.1). Skipping the value keeps a value that
+          # happens to read like a subcommand from ending the walk.
+          -C | -c | --git-dir | --work-tree | --namespace | --exec-path | --config-env)
+            SKIP_VALUE=1
+            ;;
+          -*) ;;
+          add | stage)
+            SUB=$TOK
+            STATE=operands
+            ;;
+          *) break ;;
+        esac
+        ;;
+      operands)
+        case "$TOK" in
+          --all | --no-ignore-removal)
+            ADD_REFUSED="\`${TOK}\` stages every change in the worktree instead of the paths you name"
+            break
+            ;;
+          --update)
+            ADD_REFUSED="\`--update\` stages every tracked change in the worktree instead of the paths you name"
+            break
+            ;;
+          --patch | --interactive | --edit) HAS_SELECTION=1 ;;
+          --*) ;;
+          -*)
+            # git clusters its short options (`git add -Av` staged the whole
+            # scratch repository), so the letters are read one by one.
+            case "${TOK#-}" in
+              *A*)
+                ADD_REFUSED="the short option -A stages every change in the worktree instead of the paths you name"
+                break
+                ;;
+              *u*)
+                ADD_REFUSED="the short option -u stages every tracked change in the worktree instead of the paths you name"
+                break
+                ;;
+              *[pie]*) HAS_SELECTION=1 ;;
+            esac
+            ;;
+          :*)
+            ADD_REFUSED="an operand begins with \`:\`, so it is pathspec magic rather than a path: \`:\` is the working directory, and \`:/\` and \`:(top)\` are the repository root"
+            break
+            ;;
+          *)
+            # Strip the punctuation a path is built from. An operand left empty
+            # spells the working directory, a parent, a root or a glob, and
+            # names no file of its own.
+            if [ -z "${TOK//[.*?~\/]/}" ]; then
+              ADD_REFUSED="\`${TOK}\` names no file or directory of its own"
+              break
+            fi
+            # A glob in the first path component starts its match at the top:
+            # `git add '*.ts'` from the repository root staged every `.ts` in
+            # the tree, including the ones nobody listed. A glob further down
+            # (`src/components/ui/*.tsx`) is bounded by the directory named
+            # ahead of it.
+            case "${TOK%%/*}" in
+              *[*?]*)
+                ADD_REFUSED="the first path component of \`${TOK}\` is a glob, so it matches names you did not list"
+                break
+                ;;
+            esac
+            HAS_SELECTION=1
+            ;;
+        esac
+        ;;
+    esac
+  done
+  # An allowed invocation either names a path or selects hunks. This branch is
+  # what makes that the rule rather than a list of bad flags, and it is the only
+  # refusal that `--pathspec-from-file=paths.txt` and
+  # `git diff --name-only | xargs git add` reach: both take their operands from
+  # somewhere the command text does not show. A bare `git add` stages nothing by
+  # itself and prints `hint: Maybe you wanted to say 'git add .'?`
+  # (git 2.50.1), so the refusal names the right form before the hint names the
+  # wrong one.
+  if [ -z "$ADD_REFUSED" ] && [ -n "$SUB" ] && [ "$HAS_SELECTION" -eq 0 ]; then
+    ADD_REFUSED="it names no path to stage"
+  fi
+  # The loop body runs in this shell, so SUB survives the break and names the
+  # subcommand the refusal came from.
+  if [ -n "$ADD_REFUSED" ]; then
+    break
+  fi
+done <<EOF
+$ADD_SEGMENTS
+EOF
+set +f
+if [ -n "$ADD_REFUSED" ]; then
+  deny "PreToolUse(Bash): this \`git ${SUB}\` is refused because ${ADD_REFUSED}. Name the files this commit needs (\`git add src/foo.ts src/bar.ts\`), and take part of a file with \`git add -p\`. \`git status --short\` lists what changed."
   exit 0
 fi
 

--- a/scripts/test-bash-guard.ts
+++ b/scripts/test-bash-guard.ts
@@ -296,6 +296,16 @@ group("env protection: a git message body is prose, a chained command is not", [
     why: "a redirect on the operator line",
   },
   {
+    command: `${COMMIT} -F - <<'MSG'\nkeep the .env guard\nMSG\ngit push`,
+    expected: "allow",
+    why: "a heredoc body stays prose when a command follows the terminator",
+  },
+  {
+    command: "cat <<'EOF'\n.env\nEOF\necho done",
+    expected: "block",
+    why: "a heredoc body outside a git command blocks with a command after it too",
+  },
+  {
     command: "cat <<'EOF'\n.env\nEOF",
     expected: "block",
     why: "a heredoc body outside a git command still blocks",

--- a/scripts/test-bash-guard.ts
+++ b/scripts/test-bash-guard.ts
@@ -5,11 +5,11 @@
  *
  *     bun run scripts/test-bash-guard.ts
  *
- * The guard carries two decisions that are easy to break and impossible to
- * notice: the protected-env-file block and the `find` gate. Each case below
- * feeds the real hook a synthetic PreToolUse payload and asserts the decision it
- * returns. Nothing in the repository is modified and no command from a case is
- * ever executed.
+ * The guard carries three decisions that are easy to break and impossible to
+ * notice: the protected-env-file block, the `find` gate and the git add gate.
+ * Each case below feeds the real hook a synthetic PreToolUse payload and asserts
+ * the decision it returns. Nothing in the repository is modified and no command
+ * from a case is ever executed.
  *
  * Not named `*.test.ts` on purpose: vitest would then run it on every
  * `bun run test` and in CI, where a hook that only runs during local agent
@@ -495,6 +495,271 @@ group("env protection: escapes and quotes do not hide the name", [
     command: `${COMMIT} -m 'match \\.env in the guard'`,
     expected: "allow",
     why: "the escaped spelling written in a message body stays prose",
+  },
+]);
+
+group("git add: named paths and hunk selection stay unattended", [
+  {
+    command: "git add src/foo.ts",
+    expected: "allow",
+    why: "one named path",
+  },
+  {
+    command: "git add src/foo.ts src/bar.ts",
+    expected: "allow",
+    why: "two named paths",
+  },
+  {
+    command: "git add ./src/foo.ts",
+    expected: "allow",
+    why: "a ./ prefix on a named path",
+  },
+  {
+    command: "git add ../sibling/foo.ts",
+    expected: "allow",
+    why: "a path outside the working directory is still named",
+  },
+  {
+    command: "git add src/components/ui/*.tsx",
+    expected: "allow",
+    why: "a glob under a named directory",
+  },
+  { command: "git add -p", expected: "allow", why: "hunk selection" },
+  {
+    command: "git add -p src/foo.ts",
+    expected: "allow",
+    why: "hunk selection within a named path",
+  },
+  {
+    command: "git add --patch",
+    expected: "allow",
+    why: "the long spelling of hunk selection",
+  },
+  {
+    command: "git add -i",
+    expected: "allow",
+    why: "interactive selection",
+  },
+  {
+    command: "git add -e",
+    expected: "allow",
+    why: "editing the diff is a selection too",
+  },
+  {
+    command: "git add --chmod=+x src/setup.sh",
+    expected: "allow",
+    why: "a long flag that is not a blanket stage, beside a named path",
+  },
+  {
+    command: "git add -n src/foo.ts",
+    expected: "allow",
+    why: "a dry run of a named path",
+  },
+  {
+    command: "git stage src/foo.ts",
+    expected: "allow",
+    why: "the git stage synonym with a named path",
+  },
+  {
+    command: "git commit -F msg.txt",
+    expected: "allow",
+    why: "another git subcommand is not this guard's business",
+  },
+]);
+
+group("git add: a blanket stage is refused", [
+  { command: "git add -A", expected: "block", why: "-A" },
+  { command: "git add --all", expected: "block", why: "--all" },
+  {
+    command: "git add --no-ignore-removal",
+    expected: "block",
+    why: "the third spelling of -A",
+  },
+  { command: "git add -u", expected: "block", why: "-u" },
+  { command: "git add --update", expected: "block", why: "--update" },
+  {
+    command: "git add -Av",
+    expected: "block",
+    why: "-A inside a short option cluster",
+  },
+  {
+    command: "git add -A src/foo.ts",
+    expected: "block",
+    why: "-A adds nothing once the path is named",
+  },
+  { command: "git add .", expected: "block", why: "the working directory" },
+  { command: "git add ./", expected: "block", why: "bare ./" },
+  { command: "git add ..", expected: "block", why: "the parent directory" },
+  { command: "git add /", expected: "block", why: "the filesystem root" },
+  { command: 'git add "*"', expected: "block", why: "a bare glob" },
+  {
+    command: "git add '?'",
+    expected: "block",
+    why: "a bare single-character glob",
+  },
+  { command: "git add '~'", expected: "block", why: "the home directory" },
+  {
+    command: "git add -- .",
+    expected: "block",
+    why: "a -- separator does not make it a path",
+  },
+  {
+    command: "git add ':/'",
+    expected: "block",
+    why: ":/ reaches the repository root",
+  },
+  {
+    command: "git add ':(top)'",
+    expected: "block",
+    why: ":(top) reaches the repository root",
+  },
+  {
+    command: "git stage -A",
+    expected: "block",
+    why: "the git stage synonym runs the same builtin",
+  },
+  {
+    command: "git add '*.ts'",
+    expected: "block",
+    why: "a glob in the first path component matches from the top of the tree",
+  },
+  {
+    command: "git add '**/*.ts'",
+    expected: "block",
+    why: "a leading ** matches from the top too",
+  },
+]);
+
+// The shell drops a quote pair and a backslash from a word, so each command
+// below hands git the same undecorated operand as its plain spelling.
+group("git add: escapes and quotes do not hide the shape", [
+  {
+    command: "git add \\-A",
+    expected: "block",
+    why: "an escaped dash still reaches -A",
+  },
+  {
+    command: "git add \\.",
+    expected: "block",
+    why: "an escaped dot still names the working directory",
+  },
+  {
+    command: "git add \\*",
+    expected: "block",
+    why: "an escaped glob is the spelling that asks git to expand it",
+  },
+  {
+    command: 'g""it add -A',
+    expected: "block",
+    why: "an empty quote pair inside the command name still runs git",
+  },
+]);
+
+// An allowed invocation names a path or selects hunks, so these three reach no
+// other refusal in the guard: their operands come from somewhere the command
+// text does not show.
+group("git add: an operand the command text does not show is refused", [
+  { command: "git add", expected: "block", why: "no operand at all" },
+  {
+    command: "git add -n",
+    expected: "block",
+    why: "a dry run still names no path",
+  },
+  {
+    command: "git add --pathspec-from-file=paths.txt",
+    expected: "block",
+    why: "the paths sit in a file the guard cannot read",
+  },
+  {
+    command: "git diff --name-only | xargs git add",
+    expected: "block",
+    why: "a pipe supplies the operands",
+  },
+]);
+
+// Guard 2's own comments record the shapes a reviewer used to defeat it: a
+// quoted operand, irregular spacing, a chained command and a body that only
+// describes the command. Each reaches this guard too, so each stays here.
+group("git add: the shapes that defeated earlier guards here", [
+  {
+    command: 'git add "."',
+    expected: "block",
+    why: "a quoted operand",
+  },
+  {
+    command: "git  add   -A",
+    expected: "block",
+    why: "irregular spacing",
+  },
+  {
+    command: "git status && git add -A",
+    expected: "block",
+    why: "chained behind another command",
+  },
+  {
+    command: "git status\ngit add -A",
+    expected: "block",
+    why: "on the second line of a multi-line command",
+  },
+  {
+    command: "GIT_DIR=x git add .",
+    expected: "block",
+    why: "a prefix assignment before git",
+  },
+  {
+    command: "sh -c 'git add -A'",
+    expected: "block",
+    why: "wrapped in a shell invocation",
+  },
+  {
+    command: "git -C sub add .",
+    expected: "block",
+    why: "behind a git global option",
+  },
+  {
+    command: "git --no-pager add .",
+    expected: "block",
+    why: "behind a git global option that takes no value",
+  },
+  {
+    command: ">/dev/null git add -A",
+    expected: "block",
+    why: "behind a leading redirect",
+  },
+  {
+    command: "timeout 5 git add -A",
+    expected: "block",
+    why: "behind a command that runs another command",
+  },
+  {
+    command: `${COMMIT} -m 'refuse git add -A in the hook'`,
+    expected: "allow",
+    why: "a message body describing the shape is prose",
+  },
+  {
+    command: `${COMMIT} -F - <<'MSG'\nrefuse git add . in the hook\nMSG`,
+    expected: "allow",
+    why: "a heredoc commit body describing the shape is prose",
+  },
+  {
+    command: "cat <<'EOF'\ngit add -A\nEOF",
+    expected: "allow",
+    why: "a heredoc body outside a git command is prose too",
+  },
+  {
+    command: `${COMMIT} -F - <<'MSG'\nbody\nMSG\ngit add -A`,
+    expected: "block",
+    why: "a real stage chained after the terminator",
+  },
+  {
+    command: `${COMMIT} -F - <<'MSG'\nrefuse git add -A in the hook\nMSG\ngit push`,
+    expected: "allow",
+    why: "a body describing the shape stays prose when a command follows the terminator",
+  },
+  {
+    command: "rg 'git add .' src",
+    expected: "allow",
+    why: "git does not open the segment, so searching for the text is not staging",
   },
 ]);
 

--- a/scripts/test-bash-guard.ts
+++ b/scripts/test-bash-guard.ts
@@ -231,6 +231,16 @@ group("find: text inside a heredoc is data, not a command", [
     expected: "allow",
     why: "heredoc body naming a dangerous find",
   },
+  {
+    command: "cat <<'EOF'\nbody\nEOF\nfind / -type f",
+    expected: "block",
+    why: "a real find chained after the terminator",
+  },
+  {
+    command: "cat <<'EOF'\nfind . -delete\nEOF\necho done",
+    expected: "allow",
+    why: "the body stays data when a command follows the terminator",
+  },
 ]);
 
 group("env protection still blocks", [


### PR DESCRIPTION
## 何が良くなるか

AGENTS.md の Commits & Pull Requests は「Never `git add -A` or `git add .`. Stage explicit paths」と書きます。その両方を `.claude/hooks/pre-bash-guard.sh` に食わせると出力は空で exit 0 になり、hook は何も止めていませんでした。読んだ session にしか効かないルールだったので、guard 3 を足して operand が explicit path でない `git add` を拒みます。

置き場所はこの file にしました。`.claude/settings.json` がこの hook を全ての `Bash` 呼び出しで走らせ、guard 1 と guard 2 が quote、連結、heredoc の扱いを既に持っています。

## 拒む形

git 2.50.1 の throwaway repository で叩いて確かめた挙動を添えます。

| operand | 何が起きるか |
| --- | --- |
| `-A` / `--all` / `--no-ignore-removal` | worktree の全変更を stage します。`-Av` のような短縮 option の cluster も文字単位で見ます |
| `-u` / `--update` | tracked な全変更を stage します。`sub/` から pathspec 無しで叩くと root の `a.txt` まで届きました |
| `.` / `./` / `..` / `/` / `~` / `*` / `?` | path segment を一つも名指ししていません |
| `:` で始まる operand | pathspec magic です。`:` は cwd、`:/` と `:(top)` は subdirectory から repository 全体を stage しました |
| operand も `-p` / `-i` / `-e` も無い invocation | stage する path がありません |
| 上と同じ形の `git stage` | 同じ builtin が走りました |

## 通す形

| 形 | 理由 |
| --- | --- |
| `git add src/foo.ts`、複数 path | 名指しした path そのものです |
| `git add -p` / `--patch` / `-i` / `-e` | hunk を選ぶので worktree を掃きません。AGENTS.md がこの形を指示しています |
| `git add src/components/ui/*.tsx` | shell が展開した後は名指しした path の列で、directory も名指しされています。全体を掃く token は裸の `*` の方で、そちらは拒みます |
| `git add -n src/foo.ts` | path を名指ししています |
| `rg 'git add .' src`、`echo 'git add -A' >> notes.md` | segment の先頭が `git` ではありません。text の検索や書き込みは staging ではありません |
| commit message、PR body、heredoc の中の記述 | guard 1 の scrub と heredoc の drop を通した text を見ます |

## 判断

**anchor をどこに置くか。** `git` が segment の先頭に来る形だけを見ます。代入と `env` / `sh -c` / `xargs` などの wrapper はその手前に許します。guard 2 のように位置を問わず `git` を探すと `rg 'git add .' src` まで拒むことになり、この file を触る worker が最初に踏みます。代わりに shell 関数や script file 経由は通ります。token walk から見えないので、この guard が縛るのは habit であって bypass ではありません。

**`-A` に path が付いていても拒みます。** `git add -A src/foo.ts` は `git add src/foo.ts` と同じものを stage します（名指しした path の削除も stage されることを `D  a.txt` で確認しました）。flag を落とすだけで通るので、拒んで失うものがありません。

**裸の `git add` も拒みます。** これ自体は何も stage しません。git 自身が `hint: Maybe you wanted to say 'git add .'?` を出すので、hint に従った次の一手が理由なしで拒まれます。先に正しい形を名指しする方を採りました。

**dash で始まる path は追いません。** `git add -- -A` は `-A` という名前の file を stage する形ですが、guard は `-A` を flag として拒みます。そういう file はこの repository になく、追えば `--` の位置を guard が持ち歩くことになります。

**`git commit -a` は範囲外です。** 同じく全体を stage しますが、ticket が指しているのは `git add` です。

**`-n` の dry run を特別扱いしません。** `git add -n -A` は何も stage しませんが、拒みます。path を名指しする route はこの形にも同じように効きます。

## guard 2 の穴も塞ぎました

heredoc 本文の除去を `drop_heredoc_body` として関数に出したところ、同じ処理が guard 2 に二つ目の実装として残りました。guard 2 の `${NORM%%<<*}` は最初の `<<` から後ろを全部落とすので、`cat <<EOF` / `x` / `EOF` / `find / -type f` が通っていました。terminator を読む関数に寄せて塞ぎ、test を一件足しました。関数を出した commit が生んだ不整合なので、この PR で直しています。

reuse の review が、寄せ方を間違えると guard 2 が三つの形（tab 区切りの `find`、`-m` body の中の記述、gh の `--body` の中の記述）で緩むことを測ってくれました。入力は `$CMD` のまま、空白の正規化も残したので、その三つは今も block します。

## 見送った findings

**guard 3 を function 群に分ける。** review の指摘は、guard 3 が読む `SCRUBBED` の prose 許容度を 200 行離れた guard 1 の `FIRST_WORD` switch が決めていて、guard 3 の位置にその印がないこと。求められた変更は、command text を受け取って理由を返す function を三本立て、短い main から呼ぶ形です。360 行の file の構造変更で、ticket が触らないコードを動かすため入れていません。guard 3 の冒頭 comment が依存先を名指ししています。

**`git commit -a` も拒む。** review が測ったところ、`git commit -am x` は今 allow で、`git add -u` は block します。同じ範囲を一手で stage する route が空いたままです。入れていない理由は、ticket が指すのが `git add` で、AGENTS.md も `git add -A` と `git add .` しか禁じていないため。deny message の後ろに規則がない refusal を増やすことになります。判断は user に渡します。

**guard 1 が heredoc を落としたことを flag で guard 3 に伝える。** awk fork 一回（git 系 command で約 7 ms）が浮きますが、guard 3 の入力が guard 1 の条件分岐の中で立つ flag に依存します。上の function 分割の指摘と逆向きなので取りませんでした。

## 前提

- 拒む operand の集合は ticket の指示どおりこちらで決めました。`?` を glob、`~` を home として拒む二件は ticket が挙げていない追加分です。
- `.claude/settings.json` の `statusMessage` は「.env protection + find gate」のままで、三本目を名指ししていません。scope がこの二 file なので触っていません。
- test の重複について、mutation で「単独で落ちる case が他にある」と測れた 4 件のうち、落としたのは `git add '.'` の一件だけです。`.`、`./`、`..`、`"."` は PR 本文が挙げる集合を pin するので残しました。

## 確認

- `bun run check` / `bun run test` 通過（462 tests、branches 100%）
- `bun scripts/test-bash-guard.ts` 123 件通過（既存 76 件 + 追加 48 件、`git add '.'` を除いた後）
- `ls -la` の payload で hook を 60 回ずつ二round 計測し、early-out ありで 173 ms と 184 ms、なしで 181 ms と 203 ms（並列 worker が走っている machine）

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the pre-bash-guard hook refuse `git add` (and `git stage`) calls that stage without naming explicit paths, and fixes heredoc handling so a command chained after a terminator reads as a command, not heredoc body.

- Blocks `-A`/`--all`/`--no-ignore-removal`/`-u`/`--update` (including short-option clusters like `-Av`), bare `.`/`./`/`..`/`/`/`~`/`*`/`?`, `:`-prefixed pathspec magic, globs in the first path component such as `*.ts`, and path-less invocations.
- Also blocks `-A` with a named path, since the path alone stages the same set; the flag can simply be dropped.
- Passes explicit paths, `-p`/`-i`/`-e` selection, globs under a named directory like `src/ui/*.tsx`, and text such as `rg 'git add .' src` where `git` doesn't open the segment.
- Heredoc bodies now drop only between the operator line and the terminator, closing the guard-2 hole where `cat <<EOF` / `x` / `EOF` / `find / -type f` passed.
- A heredoc prose body naming a protected file now passes when a command follows the terminator; it previously blocked the whole input.

<sup>Written for commit 3ce88d119d8280d3b715217c83aacd9b81d71918. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imaimai17468/imaimai-front-templete/pull/146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

