### PR TITLE
fix: 表駆動テストの行も命名と expect 数のゲートが判定する

### DIFF
--- a/src/components/shared/mode-toggle/theme-cycle.test.ts
+++ b/src/components/shared/mode-toggle/theme-cycle.test.ts
@@ -46,7 +46,7 @@ describe(needsThemeNormalization, () => {
     { label: "undefined", theme: undefined },
     { label: "light", theme: "light" },
     { label: "dark", theme: "dark" },
-  ])("should return false for supported theme $label", ({ theme }) => {
+  ])("should return false when the supported theme is $label", ({ theme }) => {
     expect(needsThemeNormalization(theme)).toBeFalsy();
   });
 
@@ -54,7 +54,10 @@ describe(needsThemeNormalization, () => {
     { label: "legacy system", theme: "system" },
     { label: "unrecognized", theme: "high-contrast" },
     { label: "empty string", theme: "" },
-  ])("should return true for out-of-cycle theme $label", ({ theme }) => {
-    expect(needsThemeNormalization(theme)).toBeTruthy();
-  });
+  ])(
+    "should return true when the out-of-cycle theme is $label",
+    ({ theme }) => {
+      expect(needsThemeNormalization(theme)).toBeTruthy();
+    }
+  );
 });

--- a/src/lib/storage/avatar-validation.test.ts
+++ b/src/lib/storage/avatar-validation.test.ts
@@ -15,9 +15,12 @@ describe(avatarExtensionForMime, () => {
     ["image/jpeg", "jpg"],
     ["image/webp", "webp"],
     ["image/gif", "gif"],
-  ])("maps allowed type %s to extension %s", (mime, ext) => {
-    expect(avatarExtensionForMime(mime)).toBe(ext);
-  });
+  ])(
+    "should return an extension when the allowed type %s maps to %s",
+    (mime, ext) => {
+      expect(avatarExtensionForMime(mime)).toBe(ext);
+    }
+  );
 
   it.each([
     "text/html",
@@ -31,9 +34,12 @@ describe(avatarExtensionForMime, () => {
     "toString",
     "hasOwnProperty",
     "valueOf",
-  ])("rejects disallowed or malformed type %j", (mime) => {
-    expect(avatarExtensionForMime(mime)).toBeNull();
-  });
+  ])(
+    "should return null when the type %j is disallowed or malformed",
+    (mime) => {
+      expect(avatarExtensionForMime(mime)).toBeNull();
+    }
+  );
 });
 
 describe(isValidAvatarKey, () => {
@@ -49,7 +55,7 @@ describe(isValidAvatarKey, () => {
     "user-123/avatar.JPG",
     // uppercase + jpeg together (both tolerances at once)
     "user-123/avatar.JPEG",
-  ])("accepts well-formed key %s", (key) => {
+  ])("should return true when the key %s is well-formed", (key) => {
     expect(isValidAvatarKey(key)).toBeTruthy();
   });
 
@@ -66,7 +72,7 @@ describe(isValidAvatarKey, () => {
     ["prefix with dot", "user.123/avatar.png"],
     ["no extension", "user-123/avatar"],
     ["versioned key with malformed UUID", "user-123/avatars/not-a-uuid.png"],
-  ])("rejects %s: %j", (_label, key) => {
+  ])("should return false when the key is %s (%j)", (_label, key) => {
     expect(isValidAvatarKey(key)).toBeFalsy();
   });
 });
@@ -75,21 +81,21 @@ describe(avatarSizeRejection, () => {
   it.each([
     ["zero bytes", 0],
     ["negative size", -1],
-  ])("rejects %s as empty", (_label, size) => {
+  ])("should return empty when the size is %s", (_label, size) => {
     expect(avatarSizeRejection(size)).toBe("empty");
   });
 
   it.each([
     ["one byte over the ceiling", MAX_AVATAR_BYTES + 1],
     ["far over the ceiling", MAX_AVATAR_BYTES * 10],
-  ])("rejects %s as too-large", (_label, size) => {
+  ])("should return too-large when the size is %s", (_label, size) => {
     expect(avatarSizeRejection(size)).toBe("too-large");
   });
 
   it.each([
     ["the smallest non-empty size", 1],
     ["exactly the ceiling", MAX_AVATAR_BYTES],
-  ])("accepts %s", (_label, size) => {
+  ])("should return null when the size is %s", (_label, size) => {
     expect(avatarSizeRejection(size)).toBeNull();
   });
 });

--- a/tools/oxlint-plugins/arch-rules.js
+++ b/tools/oxlint-plugins/arch-rules.js
@@ -106,27 +106,66 @@ const oneComponentPerFile = {
 
 const TEST_NAME_RE = /^should\s+.+\s+when\s+/iu;
 
-const SKIP_METHODS = new Set(["each", "skip", "todo"]);
+// A row name opening with a `%s` or `$field` placeholder gets its opening words
+// from the table row, so no row value can make it match TEST_NAME_RE and this
+// rule cannot read what the composed name says.
+const ROW_PLACEHOLDER_LEAD_RE = /^[$%]/u;
+
+const SKIP_METHODS = new Set(["skip", "todo"]);
+
+const TABLE_METHODS = new Set(["each", "for"]);
+
+// `it.each(table)(name, fn)` and `` it.each`table`(name, fn) `` hang the row's
+// name and callback off an outer call, so the chain naming the case is inside
+// that outer call's own callee.
+const tableCallee = (callee) => {
+  if (callee.type === "CallExpression") {
+    return callee.callee;
+  }
+  if (callee.type === "TaggedTemplateExpression") {
+    return callee.tag;
+  }
+  return null;
+};
+
+const tableChain = (callee) => {
+  const inner = tableCallee(callee);
+  if (
+    inner !== null &&
+    inner.type === "MemberExpression" &&
+    TABLE_METHODS.has(inner.property.name)
+  ) {
+    return inner;
+  }
+  return null;
+};
+
+const isTestIdentifier = (name) => name === "it" || name === "test";
+
+// Whether this call declares a test case: the chain's root is `it` or `test`
+// and no member along it suppresses the case. Walking the chain rather than
+// matching a fixed depth is what lets `it.concurrent.only` through to the root.
+const isCaseDeclaration = (callee) => {
+  if (!callee) {
+    return false;
+  }
+  let node = tableChain(callee) ?? callee;
+  while (node !== null && node.type === "MemberExpression") {
+    if (node.property && SKIP_METHODS.has(node.property.name)) {
+      return false;
+    }
+    node = node.object;
+  }
+  return (
+    node !== null && node.type === "Identifier" && isTestIdentifier(node.name)
+  );
+};
 
 const testNamingFormat = {
   create(context) {
     return {
       CallExpression(node) {
-        const { callee } = node;
-        let calleeName = null;
-        if (callee.type === "Identifier") {
-          calleeName = callee.name;
-        } else if (
-          callee.type === "MemberExpression" &&
-          callee.object?.type === "Identifier" &&
-          (callee.object.name === "it" || callee.object.name === "test")
-        ) {
-          if (callee.property && SKIP_METHODS.has(callee.property.name)) {
-            return;
-          }
-          calleeName = callee.object.name;
-        }
-        if (calleeName !== "it" && calleeName !== "test") {
+        if (!isCaseDeclaration(node.callee)) {
           return;
         }
         const [firstArg] = node.arguments;
@@ -140,12 +179,19 @@ const testNamingFormat = {
         if (typeof testName !== "string") {
           return;
         }
-        if (!TEST_NAME_RE.test(testName)) {
-          context.report({
-            message: `Test name must follow the format: 'should [expected behavior] when [condition]'. Got: '${testName}'`,
-            node,
-          });
+        if (TEST_NAME_RE.test(testName)) {
+          return;
         }
+        if (
+          ROW_PLACEHOLDER_LEAD_RE.test(testName) &&
+          tableChain(node.callee) !== null
+        ) {
+          return;
+        }
+        context.report({
+          message: `Test name must follow the format: 'should [expected behavior] when [condition]'. Got: '${testName}'`,
+          node,
+        });
       },
     };
   },
@@ -165,20 +211,16 @@ const isExpectCall = (node) => {
   return false;
 };
 
-const isEachCall = (node) => {
-  const { callee } = node;
-  if (!callee) {
+const declaresCase = (node) => {
+  if (!isCaseDeclaration(node.callee)) {
     return false;
   }
-  if (
-    callee.type === "MemberExpression" &&
-    callee.object &&
-    (callee.object.name === "it" || callee.object.name === "test") &&
-    callee.property?.name === "each"
-  ) {
-    return true;
-  }
-  return false;
+  const [, secondArg] = node.arguments;
+  return (
+    secondArg !== undefined &&
+    (secondArg.type === "ArrowFunctionExpression" ||
+      secondArg.type === "FunctionExpression")
+  );
 };
 
 const singleExpect = {
@@ -187,31 +229,8 @@ const singleExpect = {
 
     return {
       CallExpression(node) {
-        if (isEachCall(node)) {
-          return;
-        }
-        const { callee } = node;
-        let calleeName = callee?.type === "Identifier" ? callee.name : null;
-        if (
-          calleeName === null &&
-          callee?.type === "MemberExpression" &&
-          callee.object?.type === "Identifier" &&
-          (callee.object.name === "it" || callee.object.name === "test")
-        ) {
-          if (callee.property && SKIP_METHODS.has(callee.property.name)) {
-            return;
-          }
-          calleeName = callee.object.name;
-        }
-        if (calleeName === "it" || calleeName === "test") {
-          const [, secondArg] = node.arguments;
-          if (
-            secondArg &&
-            (secondArg.type === "ArrowFunctionExpression" ||
-              secondArg.type === "FunctionExpression")
-          ) {
-            scopeStack.push({ count: 0, testNode: node });
-          }
+        if (declaresCase(node)) {
+          scopeStack.push({ count: 0, testNode: node });
           return;
         }
         if (scopeStack.length > 0 && isExpectCall(node)) {
@@ -220,37 +239,11 @@ const singleExpect = {
         }
       },
       "CallExpression:exit"(node) {
-        if (isEachCall(node)) {
+        const scope = scopeStack.at(-1);
+        if (scope?.testNode !== node) {
           return;
         }
-        const { callee } = node;
-        let calleeName = callee?.type === "Identifier" ? callee.name : null;
-        if (
-          calleeName === null &&
-          callee?.type === "MemberExpression" &&
-          callee.object?.type === "Identifier" &&
-          (callee.object.name === "it" || callee.object.name === "test")
-        ) {
-          if (callee.property && SKIP_METHODS.has(callee.property.name)) {
-            return;
-          }
-          calleeName = callee.object.name;
-        }
-        if (calleeName !== "it" && calleeName !== "test") {
-          return;
-        }
-        const [, secondArg] = node.arguments;
-        if (
-          !secondArg ||
-          (secondArg.type !== "ArrowFunctionExpression" &&
-            secondArg.type !== "FunctionExpression")
-        ) {
-          return;
-        }
-        if (scopeStack.length === 0) {
-          return;
-        }
-        const scope = scopeStack.pop();
+        scopeStack.pop();
         if (scope.count > 1) {
           context.report({
             message: `Each test case should have exactly one expect(). Found ${scope.count} expect() calls.`,

--- a/tools/oxlint-plugins/arch-rules.test.ts
+++ b/tools/oxlint-plugins/arch-rules.test.ts
@@ -22,6 +22,12 @@ const importNode = (specifier: ImportSource, importedNames: string[] = []) => ({
   })),
 });
 
+const expectCall = {
+  arguments: [],
+  callee: { name: "expect", type: "Identifier" },
+  type: "CallExpression",
+};
+
 describe("no-size-props", () => {
   const rule = plugin.rules["no-size-props"];
 
@@ -624,15 +630,10 @@ describe("single-expect", () => {
       callee: { name: "it", type: "Identifier" },
       type: "CallExpression",
     };
-    const expectNode = {
-      arguments: [],
-      callee: { name: "expect", type: "Identifier" },
-      type: "CallExpression",
-    };
 
     // Act
     visitors.CallExpression(itNode);
-    visitors.CallExpression(expectNode);
+    visitors.CallExpression(expectCall);
     visitors["CallExpression:exit"](itNode);
 
     // Assert
@@ -651,16 +652,11 @@ describe("single-expect", () => {
       callee: { name: "it", type: "Identifier" },
       type: "CallExpression",
     };
-    const expectNode = {
-      arguments: [],
-      callee: { name: "expect", type: "Identifier" },
-      type: "CallExpression",
-    };
 
     // Act
     visitors.CallExpression(itNode);
-    visitors.CallExpression(expectNode);
-    visitors.CallExpression(expectNode);
+    visitors.CallExpression(expectCall);
+    visitors.CallExpression(expectCall);
     visitors["CallExpression:exit"](itNode);
 
     // Assert
@@ -679,16 +675,11 @@ describe("single-expect", () => {
       callee: { name: "test", type: "Identifier" },
       type: "CallExpression",
     };
-    const expectNode = {
-      arguments: [],
-      callee: { name: "expect", type: "Identifier" },
-      type: "CallExpression",
-    };
 
     // Act
     visitors.CallExpression(testNode);
-    visitors.CallExpression(expectNode);
-    visitors.CallExpression(expectNode);
+    visitors.CallExpression(expectCall);
+    visitors.CallExpression(expectCall);
     visitors["CallExpression:exit"](testNode);
 
     // Assert
@@ -736,16 +727,11 @@ describe("single-expect", () => {
       },
       type: "CallExpression",
     };
-    const expectNode = {
-      arguments: [],
-      callee: { name: "expect", type: "Identifier" },
-      type: "CallExpression",
-    };
 
     // Act
     visitors.CallExpression(onlyNode);
-    visitors.CallExpression(expectNode);
-    visitors.CallExpression(expectNode);
+    visitors.CallExpression(expectCall);
+    visitors.CallExpression(expectCall);
     visitors["CallExpression:exit"](onlyNode);
 
     // Assert
@@ -768,16 +754,11 @@ describe("single-expect", () => {
       },
       type: "CallExpression",
     };
-    const expectNode = {
-      arguments: [],
-      callee: { name: "expect", type: "Identifier" },
-      type: "CallExpression",
-    };
 
     // Act
     visitors.CallExpression(skipNode);
-    visitors.CallExpression(expectNode);
-    visitors.CallExpression(expectNode);
+    visitors.CallExpression(expectCall);
+    visitors.CallExpression(expectCall);
     visitors["CallExpression:exit"](skipNode);
 
     // Assert
@@ -800,15 +781,10 @@ describe("single-expect", () => {
       },
       type: "CallExpression",
     };
-    const expectNode = {
-      arguments: [],
-      callee: { name: "expect", type: "Identifier" },
-      type: "CallExpression",
-    };
 
     // Act
     visitors.CallExpression(todoNode);
-    visitors.CallExpression(expectNode);
+    visitors.CallExpression(expectCall);
     visitors["CallExpression:exit"](todoNode);
 
     // Assert
@@ -1547,16 +1523,11 @@ describe("single-expect (defensive branches)", () => {
     // Arrange
     const context = makeContext();
     const visitors = rule.create(context);
-    const expectNode = {
-      arguments: [],
-      callee: { name: "expect", type: "Identifier" },
-      type: "CallExpression",
-    };
 
     // Act
     visitors.CallExpression(testNode);
     visitors.CallExpression({ callee: null, type: "CallExpression" });
-    visitors.CallExpression(expectNode);
+    visitors.CallExpression(expectCall);
     visitors["CallExpression:exit"](testNode);
 
     // Assert

--- a/tools/oxlint-plugins/arch-rules.test.ts
+++ b/tools/oxlint-plugins/arch-rules.test.ts
@@ -417,7 +417,7 @@ describe("test-naming-format", () => {
     const node = {
       arguments: [{ type: "Literal", value: "bad name" }],
       callee: {
-        object: { name: "it" },
+        object: { name: "it", type: "Identifier" },
         property: { name: "skip" },
         type: "MemberExpression",
       },
@@ -437,7 +437,7 @@ describe("test-naming-format", () => {
     const node = {
       arguments: [{ type: "Literal", value: "bad name" }],
       callee: {
-        object: { name: "it" },
+        object: { name: "it", type: "Identifier" },
         property: { name: "todo" },
         type: "MemberExpression",
       },

--- a/tools/oxlint-plugins/arch-rules.test.ts
+++ b/tools/oxlint-plugins/arch-rules.test.ts
@@ -22,11 +22,61 @@ const importNode = (specifier: ImportSource, importedNames: string[] = []) => ({
   })),
 });
 
+// The callee fixtures reach only as deep as the rules under test read, so an
+// `it.skip.each` chain is a MemberExpression whose object is another one.
+interface CalleeNode {
+  type: string;
+  name?: string;
+  object?: CalleeNode;
+  property?: { name: string };
+  callee?: CalleeNode;
+  tag?: CalleeNode;
+}
+
+const memberCallee = (
+  object: CalleeNode,
+  propertyName: string
+): CalleeNode => ({
+  object,
+  property: { name: propertyName },
+  type: "MemberExpression",
+});
+
+const identifier = (name: string): CalleeNode => ({
+  name,
+  type: "Identifier",
+});
+
+const arrowBody = { type: "ArrowFunctionExpression" };
+
 const expectCall = {
   arguments: [],
-  callee: { name: "expect", type: "Identifier" },
+  callee: identifier("expect"),
   type: "CallExpression",
 };
+
+const caseCall = (name: string, callee: CalleeNode) => ({
+  arguments: [{ type: "Literal", value: name }, arrowBody],
+  callee,
+  type: "CallExpression",
+});
+
+// `it.each(table)(name, fn)` and `` it.each`table`(name, fn) `` hang the row's
+// name and callback off an outer call, so the chain sits inside that call.
+const callWrapper = (chain: CalleeNode): CalleeNode => ({
+  callee: chain,
+  type: "CallExpression",
+});
+
+const taggedWrapper = (chain: CalleeNode): CalleeNode => ({
+  tag: chain,
+  type: "TaggedTemplateExpression",
+});
+
+const eachChain = (base: string) => memberCallee(identifier(base), "each");
+
+const eachRowCall = (name: string) =>
+  caseCall(name, callWrapper(eachChain("it")));
 
 describe("no-size-props", () => {
   const rule = plugin.rules["no-size-props"];
@@ -390,18 +440,24 @@ describe("test-naming-format", () => {
     expect(context.report).not.toHaveBeenCalled();
   });
 
-  it("should not report when callee is it.each", () => {
+  it("should report when an it.each row name does not follow should...when... format", () => {
     // Arrange
     const context = makeContext();
     const visitors = rule.create(context);
-    const node = {
-      arguments: [{ type: "Literal", value: "bad name" }],
-      callee: {
-        object: { name: "it" },
-        property: { name: "each" },
-        type: "MemberExpression",
-      },
-    };
+    const node = eachRowCall("bad name");
+
+    // Act
+    visitors.CallExpression(node);
+
+    // Assert
+    expect(context.report).toHaveBeenCalledOnce();
+  });
+
+  it("should not report when an it.each row name follows the should...when... format", () => {
+    // Arrange
+    const context = makeContext();
+    const visitors = rule.create(context);
+    const node = eachRowCall("should reject the key when %s");
 
     // Act
     visitors.CallExpression(node);
@@ -410,18 +466,104 @@ describe("test-naming-format", () => {
     expect(context.report).not.toHaveBeenCalled();
   });
 
+  it("should not report when an it.each row name opens with a placeholder", () => {
+    // Arrange
+    const context = makeContext();
+    const visitors = rule.create(context);
+    const node = eachRowCall("$label");
+
+    // Act
+    visitors.CallExpression(node);
+
+    // Assert
+    expect(context.report).not.toHaveBeenCalled();
+  });
+
+  it("should report when a plain it() name opens with a placeholder", () => {
+    // Arrange
+    const context = makeContext();
+    const visitors = rule.create(context);
+    const node = caseCall("$label", identifier("it"));
+
+    // Act
+    visitors.CallExpression(node);
+
+    // Assert
+    expect(context.report).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ["test.each(table)(...)", callWrapper(eachChain("test"))],
+    ["it.for(table)(...)", callWrapper(memberCallee(identifier("it"), "for"))],
+    ["it.each`table`(...)", taggedWrapper(eachChain("it"))],
+    [
+      "it.only.each(table)(...)",
+      callWrapper(memberCallee(memberCallee(identifier("it"), "only"), "each")),
+    ],
+  ])(
+    "should report when a bad row name is declared under %s",
+    (_label, callee) => {
+      // Arrange
+      const context = makeContext();
+      const visitors = rule.create(context);
+      const node = caseCall("bad name", callee);
+
+      // Act
+      visitors.CallExpression(node);
+
+      // Assert
+      expect(context.report).toHaveBeenCalledOnce();
+    }
+  );
+
+  it.each([
+    [
+      "it.skip.each(table)(...)",
+      callWrapper(memberCallee(memberCallee(identifier("it"), "skip"), "each")),
+    ],
+    ["describe.each(table)(...)", callWrapper(eachChain("describe"))],
+    ["a factory call result", callWrapper(identifier("makeIt"))],
+    [
+      "a non-table it.only(table) result",
+      callWrapper(memberCallee(identifier("it"), "only")),
+    ],
+  ])(
+    "should not report when a bad row name is declared under %s",
+    (_label, callee) => {
+      // Arrange
+      const context = makeContext();
+      const visitors = rule.create(context);
+      const node = caseCall("bad name", callee);
+
+      // Act
+      visitors.CallExpression(node);
+
+      // Assert
+      expect(context.report).not.toHaveBeenCalled();
+    }
+  );
+
+  it("should report when a chained it.concurrent.only name does not follow should...when... format", () => {
+    // Arrange
+    const context = makeContext();
+    const visitors = rule.create(context);
+    const node = caseCall(
+      "bad name",
+      memberCallee(memberCallee(identifier("it"), "concurrent"), "only")
+    );
+
+    // Act
+    visitors.CallExpression(node);
+
+    // Assert
+    expect(context.report).toHaveBeenCalledOnce();
+  });
+
   it("should not report when callee is it.skip", () => {
     // Arrange
     const context = makeContext();
     const visitors = rule.create(context);
-    const node = {
-      arguments: [{ type: "Literal", value: "bad name" }],
-      callee: {
-        object: { name: "it", type: "Identifier" },
-        property: { name: "skip" },
-        type: "MemberExpression",
-      },
-    };
+    const node = caseCall("bad name", memberCallee(identifier("it"), "skip"));
 
     // Act
     visitors.CallExpression(node);
@@ -434,14 +576,7 @@ describe("test-naming-format", () => {
     // Arrange
     const context = makeContext();
     const visitors = rule.create(context);
-    const node = {
-      arguments: [{ type: "Literal", value: "bad name" }],
-      callee: {
-        object: { name: "it", type: "Identifier" },
-        property: { name: "todo" },
-        type: "MemberExpression",
-      },
-    };
+    const node = caseCall("bad name", memberCallee(identifier("it"), "todo"));
 
     // Act
     visitors.CallExpression(node);
@@ -686,26 +821,76 @@ describe("single-expect", () => {
     expect(context.report).toHaveBeenCalledOnce();
   });
 
-  it("should not report when it.each() is used", () => {
+  it("should report when an it.each row has more than one expect", () => {
     // Arrange
     const context = makeContext();
     const visitors = rule.create(context);
-    const eachNode = {
-      arguments: [
-        { type: "Literal", value: "should do X when Y" },
-        { type: "ArrowFunctionExpression" },
-      ],
-      callee: {
-        object: { name: "it" },
-        property: { name: "each" },
-        type: "MemberExpression",
-      },
+    const rowNode = eachRowCall("should do X when Y");
+    const tableNode = {
+      arguments: [{ type: "ArrayExpression" }],
+      callee: rowNode.callee.callee,
       type: "CallExpression",
     };
 
     // Act
-    visitors.CallExpression(eachNode);
-    visitors["CallExpression:exit"](eachNode);
+    visitors.CallExpression(rowNode);
+    visitors.CallExpression(tableNode);
+    visitors["CallExpression:exit"](tableNode);
+    visitors.CallExpression(expectCall);
+    visitors.CallExpression(expectCall);
+    visitors["CallExpression:exit"](rowNode);
+
+    // Assert
+    expect(context.report).toHaveBeenCalledOnce();
+  });
+
+  it("should not report when an it.each row has exactly one expect", () => {
+    // Arrange
+    const context = makeContext();
+    const visitors = rule.create(context);
+    const rowNode = eachRowCall("should do X when Y");
+
+    // Act
+    visitors.CallExpression(rowNode);
+    visitors.CallExpression(expectCall);
+    visitors["CallExpression:exit"](rowNode);
+
+    // Assert
+    expect(context.report).not.toHaveBeenCalled();
+  });
+
+  it("should still report when the expect calls exit before the test does", () => {
+    // Arrange
+    const context = makeContext();
+    const visitors = rule.create(context);
+    const rowNode = eachRowCall("should do X when Y");
+
+    // Act
+    visitors.CallExpression(rowNode);
+    visitors.CallExpression(expectCall);
+    visitors["CallExpression:exit"](expectCall);
+    visitors.CallExpression(expectCall);
+    visitors["CallExpression:exit"](expectCall);
+    visitors["CallExpression:exit"](rowNode);
+
+    // Assert
+    expect(context.report).toHaveBeenCalledOnce();
+  });
+
+  it("should not report when it.skip.each is used", () => {
+    // Arrange
+    const context = makeContext();
+    const visitors = rule.create(context);
+    const rowNode = caseCall(
+      "should do X when Y",
+      callWrapper(memberCallee(memberCallee(identifier("it"), "skip"), "each"))
+    );
+
+    // Act
+    visitors.CallExpression(rowNode);
+    visitors.CallExpression(expectCall);
+    visitors.CallExpression(expectCall);
+    visitors["CallExpression:exit"](rowNode);
 
     // Assert
     expect(context.report).not.toHaveBeenCalled();


### PR DESCRIPTION
## 直した欠陥

`arch-rules/test-naming-format` と `arch-rules/single-expect` は `vite.config.ts` で `"error"` なのに、`it.each(table)("row %s", ...)` の行を一切見ていなかった。`SKIP_METHODS` に `each` が入って命名判定を抜け、`isEachCall` が expect の数え上げを抜けていた。AGENTS.md の Testing は「A table-driven case is one test per row and obeys the same rule」と書いているので、ゲートが守るべき規則に反していた。

原因は AST の形。`it.each(table)(name, fn)` では行名とコールバックが外側の call に付き、その callee が `CallExpression` なので、`it.only` / `it.skip` を読む member walk がそこを見通せない。

両ルールが共有する `isCaseDeclaration(callee)` を入れた。テーブル呼び出しを外してから member chain を根の識別子まで辿り、途中の member が `SKIP_METHODS` にあれば false を返す。固定の深さで照合するのをやめたので、これまで両ルールが黙っていた `it.concurrent.only(...)` も判定対象に入る（実際のオックスリント AST で報告されることを確認した）。`singleExpect` の exit visitor は述語を再計算せず、スコープをノード同一性で pop する。

## カバーした綴り

- `it.each(table)(name, fn)` / `test.each(table)(name, fn)`
- タグ付きテンプレート `` it.each`table`(name, fn) ``
- `it.for(table)(name, fn)`（vitest 4.1.11 の `test.for`。`@vitest/runner` の型に `for: TestForFunction` がある）
- `it.only.each(...)` は報告し、`it.skip.each(...)` は `it.skip` と同じく黙る
- chain の途中に何が挟まっても根まで辿るので `it.concurrent.each` は自動的に通る

## 外した綴り

- `describe.each` / `describe.for`: 両ルールは素の `describe` も見ていない（suite 名はテスト名ではなく、expect を直接持たない）。同じ理由で外し、黙ることをテストで固定した。
- `it.each(...)` の後ろにさらにメソッドが続く形: vitest の API に無い。

## 行名に要求する形

素の `it` と同じ `should ... when ...` を要求し、プレースホルダは普通の文字として扱う。適合する行名は `"should reject the key when %s"`、`"should default to light when not mounted and theme is $label"`。

適応を 1 つ入れた。**行名が `%` か `$` で始まるときは報告しない。** 判定される先頭の語をテーブルの行データが供給しているので、どの行の値でも `^should` にはならず、ルールは合成後の名前が何を言っているか読めない。素の `it("$label", ...)` にはデータ源が無いので報告する（両方テストで固定してある）。

`.claude/hooks/check-md-links.test.ts` は `"$label"` と `"$label resolves to a live file"` の形の行名を 12 個持っていて、この免除がそれを黙らせている。免除を落とすとこの PR は単独マージで main を赤にし、そのファイルは並列 PR の担当なので触れない。

## レビュー指摘のうち判断が必要だったもの

altitude 角度のレビューが `ROW_PLACEHOLDER_LEAD_RE` の削除を求めた。理由は「`src` の行名 22 本はすべて `should` で始まるので免除に消費者が無く、`it.each([...])("%s rejects malformed input", …)` を黙って通す穴になる」。より狭い代案として「名前全体がプレースホルダ 1 個のとき（`/^[$%]\w*$/`）だけ免除」も示された。

採らなかった。レビューは `src` だけを見ていて `.claude/hooks/` の 12 件を数えていない（`bun run lint` で実測した）。狭い代案でも `"$label resolves to a live file"` が残り、そのファイルは触れない。指摘の実体である「`"%s rejects malformed input"` が通る」は残るので、行名の先頭がデータ由来なら合成後の名前を読めないという条件をコメントに書いた。より狭くするなら `.claude/hooks/` を触れる PR と一緒でなければならない。

同じレビューが指摘した他の点は採った。`testCalleeName` が誰も読まない識別子を返していたのを `isCaseDeclaration` の boolean にし、深さ固定の照合を chain walk に置き換え、exit visitor の述語再計算をノード同一性の比較にした。efficiency 角度が指摘した「命名ルールが `tableSubject` を 2 回計算する」も、形式チェックに落ちた名前だけが 2 回目に到達する順序に直した。

採らなかったもう 1 点は `hasCaseBody` の「arrow か function expression か」という判定が `oneComponentPerFile` と `componentFileNaming` にも別々に書かれている件。共有ヘルパの抽出は無関係な 2 ルールを触るので別チケット。

## 抜けを固定していたテストの扱い

反転した。`test-naming-format` の "should not report when callee is it.each" と `single-expect` の "should not report when it.each() is used" は、どちらも実際には書かれない形（`it.each("bad name")`）を fixture にしていた。本物の外側 call 形に置き換えて「報告する」を assert する。綴りごとの個別テストは 2 つの `it.each` 表（報告する chain と黙る chain）にまとめた。

## 既存テストへの影響

新しい診断は 9 件。すべて `test-naming-format` で、`single-expect` は 0 件（2 つ expect を持つ行は無かった）。

- `src/lib/storage/avatar-validation.test.ts` 7 件（`"rejects %s as empty"` など、`should` で始まっていなかった）
- `src/components/shared/mode-toggle/theme-cycle.test.ts` 2 件（`when` 節が無かった）

どれも行名を規則に合わせて直した。ルールを緩める修正はしていない。lint-disable も入れていない。

## プローブ

各ルールについて、違反する形を一時ファイル（`src/lib/storage/zz-probe-a9ad.test.ts`）に書いて `bun run check` を回し、直して黙ることを確認した。4 観測、プローブは削除済み。

1. `it.each([1, 2])("row %s", ...)` → `arch-rules(test-naming-format): Test name must follow the format: 'should [expected behavior] when [condition]'. Got: 'row %s'`
2. 行名を `"should exceed zero when the value is %s"` に直す → 0 error
3. その行に `expect` を 2 つ → `arch-rules(single-expect): Each test case should have exactly one expect(). Found 2 expect() calls.`
4. `expect` を 1 つに戻す → 0 error

追加した分岐は 1 つずつ壊して、対応するテストが落ちることを確認した。tagged-template 分岐、テーブル外し、chain walk の 2 段目、プレースホルダ免除の両側、`TABLE_METHODS` の `for`、`singleExpect` の同一性 pop。`SKIP_METHODS` から抜いた `each` はどのテストも落とさない。`tableChain` が `it.each` を外した後は walk が `each` を SKIP_METHODS と照合しても no-op なので、あのエントリは到達しない設定であり、消したのはそのためである。

## 検証

`bun run check` / `bun run test`（497 pass、`tools/oxlint-plugins/arch-rules.js` の branch coverage 100%）/ `bun run knip` すべて通る。`origin/main` 95b2c9b にリベース済み。


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Table-driven test rows were previously skipped by `arch-rules/test-naming-format` and `arch-rules/single-expect`; they are now checked like individual tests, so invalid row names and multiple `expect()` calls fail the gate. The rules support `.each`, `.for`, and tagged-template forms while preserving `skip`/`todo` behavior and allowing row names that begin with `%` or `$`.

- Updated nine existing table-driven test names to satisfy the enforced format.
- Added coverage for nested chains, skipped cases, placeholder-led row names, and row-level `expect()` counts.
- `bun run check`, `bun run test`, and `bun run knip` pass.

<sup>Written for commit 24e224e7c94e2d25d802ec6dcb49f70a49ae855f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imaimai17468/imaimai-front-templete/pull/148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

