### PR TITLE
feat: 新しいモジュールが既定でカバレッジのゲートに入る

### DIFF
--- a/scripts/check-cursor-rule-mirrors.ts
+++ b/scripts/check-cursor-rule-mirrors.ts
@@ -180,6 +180,9 @@ export const main = (argv: readonly string[]): number => {
 };
 
 const [, entry] = process.argv;
+// A test importing this module leaves the condition false, and taking the
+// true side would exit the test process, so coverage skips that side.
+/* v8 ignore if */
 if (entry !== undefined && path.resolve(entry) === import.meta.filename) {
   process.exit(main(process.argv.slice(2)));
 }

--- a/src/gateways/user/index.test.ts
+++ b/src/gateways/user/index.test.ts
@@ -200,6 +200,25 @@ describe("updateUserAvatar", () => {
     });
   });
 
+  it("should skip cleanup when the row holds no prior avatar", async () => {
+    const { deps, findAvatarUrl, remove } = makeFakes();
+    findAvatarUrl.mockResolvedValue({ avatarUrl: null });
+
+    const result = await createUserGateway(deps).updateUserAvatar(
+      "user-1",
+      validPng()
+    );
+
+    expect({ removeCalls: remove.mock.calls, result }).toStrictEqual({
+      removeCalls: [],
+      result: {
+        avatarUrl: NEW_URL,
+        cleanup: "complete",
+        success: true,
+      },
+    });
+  });
+
   it("should skip cleanup when the prior image is external", async () => {
     const { deps, findAvatarUrl, remove } = makeFakes();
     findAvatarUrl.mockResolvedValue({

--- a/src/routes/api/avatars.ts
+++ b/src/routes/api/avatars.ts
@@ -40,11 +40,15 @@ export const createGetAvatarResponse =
         });
       }
       // A new result kind fails to compile here rather than falling through to
-      // a response nobody chose, because it has no `never` to widen into.
+      // a response nobody chose, because it has no `never` to widen into. That
+      // same widening failure is what stops a test from reaching the arm, so
+      // coverage skips it instead of counting a branch nothing can enter.
+      /* v8 ignore start */
       default: {
         const unhandled: never = result;
         throw new Error(`Unhandled avatar read result: ${String(unhandled)}`);
       }
+      /* v8 ignore stop */
     }
   };
 

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -18,18 +18,33 @@ export default defineConfig({
     isolate: false,
     exclude: [...defaultExclude, ".claude/worktrees/**"],
     setupFiles: ["./src/test-setup.ts"],
-    // include が対象の全リスト。新しい純関数モジュールを
-    // テスト付きで追加したらここにも足す。
     coverage: {
-      include: [
-        "src/components/shared/mode-toggle/theme-cycle.ts",
-        "src/entities/**",
-        "src/lib/storage/avatar-validation.ts",
-        "src/lib/utils.ts",
-        "scripts/orchestrate-decisions.ts",
-        "tools/oxlint-plugins/arch-rules.js",
-        "tools/oxlint-plugins/style-rules.js",
-        "tools/vite-plugins/wrangler-types.ts",
+      // include のパターンに入るモジュールは既定でゲートされ、exclude が
+      // 例外をパスで挙げる。例外は生成物、テストハーネス、コンポーネント、
+      // そして依存を引数で受け取らず実バインディングの上でしか動かない
+      // アダプタと実行スクリプト。
+      include: ["src/**/*.ts", "tools/**/*.{ts,js}", "scripts/**/*.ts"],
+      exclude: [
+        "scripts/check-toolchain-pins.ts",
+        "scripts/orchestrate.ts",
+        "scripts/test-bash-guard.ts",
+        // include のパターンは picomatch の contains モードで照合されるので
+        // `*.ts` が `.tsx` にも当たる。コンポーネントはこの行で外れる。
+        "src/**/*.tsx",
+        "src/gateways/user/drizzle-store.ts",
+        "src/lib/auth/actions.ts",
+        "src/lib/auth/auth-client.ts",
+        "src/lib/auth/auth.ts",
+        "src/lib/auth/session.ts",
+        "src/lib/drizzle/db.ts",
+        "src/lib/drizzle/schema.ts",
+        "src/lib/storage/r2.ts",
+        "src/routeTree.gen.ts",
+        "src/routes/api/auth.$.ts",
+        "src/server/cloudflare.ts",
+        "src/server/fn/profile.ts",
+        "src/test/**",
+        "tools/vite-plugins/wrangler-types-plugin.ts",
       ],
       thresholds: {
         perFile: true,


### PR DESCRIPTION
`coverage.include` was an explicit list of eight modules, above a comment asking whoever adds a pure module to add it to the list too. Forgetting produced silence rather than a failure. `include` is now glob-based and a new `exclude` names the exceptions, so a module lands inside the gate by default and one that reaches I/O fails naming its own path.

```
include: ["src/**/*.ts", "tools/**/*.{ts,js}", "scripts/**/*.ts"]
```

## Proof

Four runs on this branch as it stands, each with a scratch file that reached no commit.

**An untested pure module fails and names itself.** `src/lib/covgate-probe.ts` (one ternary, no test) and `src/lib/covgate-io-probe.ts` (an `AVATARS_BUCKET.get` and a ternary, no test) together:

```
Branches     : 99.01% ( 403/407 )
ERROR: Coverage for branches (0%) does not meet global threshold (100%) for src/lib/covgate-probe.ts
ERROR: Coverage for branches (0%) does not meet global threshold (100%) for src/lib/covgate-io-probe.ts
```

The second line is the behavior change this ticket accepts: a module reaching I/O now stops the suite until its author either tests it behind injected deps or adds its path to `exclude`.

**A test that reaches the branch makes it pass.** Adding a two-row table test for `probeLabel` and deleting the I/O probe: `Tests 500 passed`, `Branches: 100% (405/405)`.

**The suite passes with no scratch file left.** `Test Files 21 passed`, `Tests 498 passed`, `Branches: 100% (403/403)`, `git status` clean.

## Counts

The gate holds 17 files, up from 8. Nine are new, and two of those declare only types and carry no branch (`src/env.d.ts`, `src/gateways/user/ports.ts`). The seven newly gated modules with executable code, with the branch arms now measured in each:

| module | arms | needed |
| --- | --- | --- |
| `scripts/check-cursor-rule-mirrors.ts` | 22 | the entrypoint guard skipped |
| `src/gateways/user/index.ts` | 20 | one test |
| `src/server/fn/avatar.ts` | 8 | already at 100% |
| `src/routes/api/avatars.ts` | 6 | the `never` arm skipped |
| `src/gateways/avatar/index.ts` | 4 | already at 100% |
| `src/lib/auth/required-secret.ts` | 4 | already at 100% |
| `src/server/fn/user.ts` | 2 | already at 100% |

One module needed a test. `src/gateways/user/index.ts` reached `previousKey === null` only through an external avatar URL, where `avatarKeyFromUrl` returns null, so the first-ever upload (the row holds `avatarUrl: null`) went untested. The new case asserts that `updateUserAvatar` calls no `remove` and returns `cleanup: "complete"`. No test here was written to reach a line without asserting anything.

## Decisions

**`include` takes `.ts`, and `exclude` carries `src/**/*.tsx`.** Keeping components out is not free by extension, which is what the ticket's sketch assumed. Vitest matches `coverage.include` through `isIncluded`, which calls `picomatch` with `{ contains: true }`, so the pattern may match any substring of the path and `*.ts` therefore matches `.tsx`:

```
$ bun -e 'console.log(require("picomatch").isMatch("src/components/x.tsx","src/**/*.ts",{contains:true,dot:true}))'
true
```

Measured, not reasoned: a scratch `src/components/covgate-probe.tsx` at 50% branches failed the gate under a `.tsx`-less exclude list, and passed once `src/**/*.tsx` was excluded. The same `contains` mode is why an entry like `scripts/orchestrate.ts` does not drag `scripts/orchestrate-decisions.ts` out with it (checked the same way).

**`exclude` is written path by path, except for two globs.** A directory glob would silently un-gate a future pure module dropped into that directory, which is the silence this PR removes. `src/lib/auth/` shows why the paths cannot collapse anyway: `auth.ts`, `session.ts`, `actions.ts` and `auth-client.ts` are excluded while `required-secret.ts` is gated beside them. The two globs are `src/**/*.tsx`, because every component is out, and `src/test/**`, the harness the suite runs through, which matches Vitest already excluding `src/test-setup.ts` on its own (it never appears in `coverage/coverage-final.json`). The one generated file, `src/routeTree.gen.ts`, is named as a path.

**The line between the two lists is where a module's dependencies come from.** A module whose logic takes its dependencies as parameters stays gated, even when the same file also wires the real instance: `src/gateways/user/index.ts` exports `createUserGateway(deps)` and `userGateway`, and it is the factory a test drives. A module whose logic can only run against a live binding is excluded, which is every adapter under `src/lib/drizzle/`, `src/lib/auth/` (except `required-secret.ts`), `src/lib/storage/r2.ts`, `src/server/cloudflare.ts`, `src/gateways/user/drizzle-store.ts` and `tools/vite-plugins/wrangler-types-plugin.ts`. `src/server/fn/profile.ts` and `src/routes/api/auth.$.ts` are excluded on the same test: their logic sits inside `createServerFn`/`createFileRoute` with no injected seam.

**`scripts/` is in the gate, by a rule rather than a list.** An executable entrypoint under `scripts/` is excluded, and a module it imports is gated. That excludes `orchestrate.ts`, `check-toolchain-pins.ts` and `test-bash-guard.ts` today, and keeps `orchestrate-decisions.ts` and `check-cursor-rule-mirrors.ts` in. A new script added under `scripts/` fails the gate until its author applies that rule, which is the loud direction.

**Two branches are skipped with a `v8 ignore` hint rather than tested or excluded.** Both are branches a test cannot enter, and in both cases the alternative was dropping a whole file with live branches out of the gate.

- `src/routes/api/avatars.ts`: the `default: { const unhandled: never = result }` arm. Reaching it needs a value outside `AvatarReadResult`, which the assignment to `never` rejects at compile time and which AGENTS.md forbids forcing with `as`. `/* v8 ignore start|stop */` around the arm drops that arm alone: the four live `case` arms stay measured, and deleting the `unauthorized` row from the test table drops the file to 83.33% and fails the suite (run, not assumed).
- `scripts/check-cursor-rule-mirrors.ts`: the `if (entry !== undefined && path.resolve(entry) === import.meta.filename)` entrypoint guard. A test importing the module leaves it false, and the true side calls `process.exit`. `/* v8 ignore if */` drops that side; the file's other 11 branch groups and 22 arms are still measured.

A reviewer who wants the hints gone should say which alternative to take, because excluding either file would un-gate its live branches, and reaching either branch from a test needs a cast.

## Left for whoever owns AGENTS.md

AGENTS.md's Testing section still describes the old mechanism: "`vitest.config.mts` enforces per file over an explicit module list. A new module whose exports are all pure joins that list when its test lands". After this merges that is false in both halves, and a component is now kept out by an `exclude` entry rather than by never being listed. This PR's scope excluded AGENTS.md because parallel pull requests own it, so the sentence needs a follow-up.

## Assumptions

- The threshold numbers stay as they are (`perFile: true`, `branches: 100`), per the ticket.
- Only `branches` is thresholded, so a file with uncovered statements or functions passes. `src/gateways/avatar/index.ts` at 87.5% statements is an example, and this PR does not change that.
