### PR TITLE
refactor: 述語の名前が判定している範囲どおりになる

### DIFF
--- a/tools/oxlint-plugins/arch-rules.js
+++ b/tools/oxlint-plugins/arch-rules.js
@@ -142,10 +142,10 @@ const tableChain = (callee) => {
 
 const isTestIdentifier = (name) => name === "it" || name === "test";
 
-// Whether this call declares a test case: the chain's root is `it` or `test`
-// and no member along it suppresses the case. Walking the chain rather than
-// matching a fixed depth is what lets `it.concurrent.only` through to the root.
-const isCaseDeclaration = (callee) => {
+// Whether this callee reaches `it` or `test` through a chain that suppresses no
+// case. Walking the chain rather than matching a fixed depth is what lets
+// `it.concurrent.only` through to the root.
+const isTestCallee = (callee) => {
   if (!callee) {
     return false;
   }
@@ -165,7 +165,7 @@ const testNamingFormat = {
   create(context) {
     return {
       CallExpression(node) {
-        if (!isCaseDeclaration(node.callee)) {
+        if (!isTestCallee(node.callee)) {
           return;
         }
         const [firstArg] = node.arguments;
@@ -212,7 +212,7 @@ const isExpectCall = (node) => {
 };
 
 const declaresCase = (node) => {
-  if (!isCaseDeclaration(node.callee)) {
+  if (!isTestCallee(node.callee)) {
     return false;
   }
   const [, secondArg] = node.arguments;


### PR DESCRIPTION
## 直した欠陥

`arch-rules` の `isCaseDeclaration` は callee の member chain しか見ていないのに、「この call がテストケースを宣言しているか」という名前とコメントを持っていた。`it.each(table)("row", fn)` では oxlint の visitor が内側の `it.each(table)` call も別ノードとして訪れ、その callee に対して `isCaseDeclaration` は true を返す。名前もコールバックも持たない call を「宣言」と呼んでいた。

`isTestCallee` に改名し、コメントを chain の判定として書き直した。引数の形を要求する述語は `declaresCase` の側にある。

## 誤報していないことと、それでも直す理由

呼び出し側 2 つは自分で引数の形を確かめているので今は誤報しない。`testNamingFormat` は第 1 引数が文字列リテラルであることを要求し、内側 call の唯一の引数はテーブル式なので抜ける。`declaresCase` は第 2 引数が関数であることを要求し、内側 call には第 2 引数が無いので false を返す。

名前が引数まで保証しているように読めるため、その確認を省く 3 つ目の呼び出し側が内側の call で誤報する。コメントで警告する代わりに名前を直した。

## 採らなかった案

レビューは `isCaseDeclaration` に node ごと渡して `arguments.length >= 2` を要求し、`declaresCase` の判定を共有述語に畳むことを提案した。採らなかった。`it("bad name")`（コールバック無し）を実際に lint に通すと `test-naming-format` が今これを報告する（`vitest(prefer-todo)` などと並んで出る）。引数の形を共有述語に入れるとこの報告が消える。

## 検証

`bun run check` / `bun run test`（497 pass、`tools/oxlint-plugins/arch-rules.js` の branch coverage 100%）。振る舞いは変わらないので、テストの追加も変更もしていない。


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames `isCaseDeclaration` to `isTestCallee` in `tools/oxlint-plugins/arch-rules.js` so the predicate's name matches what it actually checks: the callee's member chain, not whether the call declares a test case. Behavior is unchanged.

- The old name was misleading because in `it.each(table)("row", fn)` the inner `it.each(table)` call is visited as its own node, and the predicate returned true for its callee even though that call has no name or callback.
- The two call sites already verify argument shapes themselves, so nothing misfires today; keeping those checks in `declaresCase` prevents a future call site from skipping them.
- A shared `arguments.length >= 2` predicate was considered and rejected because it would drop the `test-naming-format` report for `it("bad name")`.
- No tests were added or changed; `bun run check` and `bun run test` pass with 100% branch coverage on the plugin.

<sup>Written for commit e36fab6bef51601b7672006fc7734410499e66aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imaimai17468/imaimai-front-templete/pull/150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

