### PR TITLE
refactor: カバレッジのゲートのコメントとテストの重複が減る

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ The next rule has no path scope, and applies whenever you write any instruction 
 
 ## Testing
 
-Tests are written against the implementation, and test-first is not required. What is required is that every branch you added is reached by a test that fails when that branch breaks. White-box: tests cover internal logic paths and branches as well as inputs and outputs. Pure functions require 100% branch coverage, which `vitest.config.mts` enforces per file over an explicit module list. A new module whose exports are all pure joins that list when its test lands, or nothing gates its coverage and no one notices. A module that reaches I/O stays out of it, and so does a component.
+Tests are written against the implementation, and test-first is not required. What is required is that every branch you added is reached by a test that fails when that branch breaks. White-box: tests cover internal logic paths and branches as well as inputs and outputs. Pure functions require 100% branch coverage, which `vitest.config.mts` enforces per file, and a module is inside that gate with no config edit. A module whose logic only runs against a live binding, and a component, are named in that file's `coverage.exclude`. A new one of either fails the suite naming its own path until its author adds it there.
 
 - **A test name states a condition and its result.** The name alone says what broke, without opening the body. Follow the phrasing of the tests around it.
 - **One test, one `expect`, arranged as Arrange / Act / Assert.** A table-driven case is one test per row and obeys the same rule.

--- a/src/gateways/user/index.test.ts
+++ b/src/gateways/user/index.test.ts
@@ -200,30 +200,12 @@ describe("updateUserAvatar", () => {
     });
   });
 
-  it("should skip cleanup when the row holds no prior avatar", async () => {
+  it.each([
+    ["the row holds no prior avatar", null],
+    ["the prior image is external", "https://images.example.com/avatar.png"],
+  ])("should skip cleanup when %s", async (_label, avatarUrl) => {
     const { deps, findAvatarUrl, remove } = makeFakes();
-    findAvatarUrl.mockResolvedValue({ avatarUrl: null });
-
-    const result = await createUserGateway(deps).updateUserAvatar(
-      "user-1",
-      validPng()
-    );
-
-    expect({ removeCalls: remove.mock.calls, result }).toStrictEqual({
-      removeCalls: [],
-      result: {
-        avatarUrl: NEW_URL,
-        cleanup: "complete",
-        success: true,
-      },
-    });
-  });
-
-  it("should skip cleanup when the prior image is external", async () => {
-    const { deps, findAvatarUrl, remove } = makeFakes();
-    findAvatarUrl.mockResolvedValue({
-      avatarUrl: "https://images.example.com/avatar.png",
-    });
+    findAvatarUrl.mockResolvedValue({ avatarUrl });
 
     const result = await createUserGateway(deps).updateUserAvatar(
       "user-1",

--- a/src/routes/api/avatars.ts
+++ b/src/routes/api/avatars.ts
@@ -40,15 +40,13 @@ export const createGetAvatarResponse =
         });
       }
       // A new result kind fails to compile here rather than falling through to
-      // a response nobody chose, because it has no `never` to widen into. That
-      // same widening failure is what stops a test from reaching the arm, so
-      // coverage skips it instead of counting a branch nothing can enter.
-      /* v8 ignore start */
+      // a response nobody chose, because it has no `never` to widen into. The
+      // same widening failure keeps a test out of this arm.
+      /* v8 ignore next */
       default: {
         const unhandled: never = result;
         throw new Error(`Unhandled avatar read result: ${String(unhandled)}`);
       }
-      /* v8 ignore stop */
     }
   };
 

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -19,8 +19,7 @@ export default defineConfig({
     exclude: [...defaultExclude, ".claude/worktrees/**"],
     setupFiles: ["./src/test-setup.ts"],
     coverage: {
-      // include のパターンに入るモジュールは既定でゲートされ、exclude が
-      // 例外をパスで挙げる。例外は生成物、テストハーネス、コンポーネント、
+      // exclude に並ぶ例外は、生成物、テストハーネス、コンポーネント、
       // そして依存を引数で受け取らず実バインディングの上でしか動かない
       // アダプタと実行スクリプト。
       include: ["src/**/*.ts", "tools/**/*.{ts,js}", "scripts/**/*.ts"],


### PR DESCRIPTION
Cleanup on #149, whose own review pass died on a rate limit and reported after that PR had merged. Three of its findings were real, and the fourth item here is the AGENTS.md sentence #149 could not touch because parallel pull requests owned that file at the time. None are open now.

## Findings taken

**One `v8 ignore` directive instead of a pair.** `src/routes/api/avatars.ts` wrapped its `default: never` arm in `/* v8 ignore start */` and `/* v8 ignore stop */`, two lines to keep paired around four. `/* v8 ignore next */` alone does the same job: `avatars.ts` still reports `91.66 | 100 | 66.66 | 91.66`, the suite still passes at `Branches: 100% (403/403)`, and deleting the `unauthorized` row from the test table still drops the file to 83.33% and fails, so the four live arms are still measured. Ran, not assumed.

**The comment above it lost the clause that restated the directive.** The sentence already said the arm "has no `never` to widen into", and what followed said the same thing twice more. One clause survives, naming why a test cannot enter the arm.

**`vitest.config.mts`'s comment opens at the exceptions.** Its first sentence described what `include` and `exclude` mean, which holds for any vitest config. What a reader cannot recover from the code is which four kinds of module are exceptions, so the comment starts there.

**The two "skip cleanup" cases in `src/gateways/user/index.test.ts` are one `it.each`.** They differed only in the `avatarUrl` handed to `mockResolvedValue`, with identical Act and identical expected object, so which case drove which branch was visible only by diffing one against its neighbour. #148 made the naming and single-expect gates read table rows, so the table is checked the same way the two separate `it`s were.

**AGENTS.md's Testing section described the old mechanism.** It said the threshold applies "over an explicit module list" and that a new pure module "joins that list when its test lands". Both halves became false when #149 merged. It now says a module is inside the gate with no config edit, that a module which only runs against a live binding and a component are named in `coverage.exclude`, and that a new one of either fails the suite naming its own path.

## Finding not taken

**Collapsing six `exclude` paths into `src/lib/auth/{actions,auth,auth-client,session}.ts` and `src/lib/drizzle/{db,schema}.ts`.** The review verified the two patterns match exactly those six files and hide no future module, and offered it as take-or-leave. Left as one path per line: adding or dropping an exception then reads as one line in a diff, and a reader sees which files are out without expanding a pattern. Four lines of config is the whole saving.

## Verification

`bun run check` and `bun run test` pass (`Test Files 21`, `Tests 498`, `Branches: 100% (403/403)`), and `bun run knip` exits 0.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies the review findings from a merged PR's late pass, cutting duplication in coverage comments and tests without changing behavior.

- Replaces the paired `v8 ignore start`/`stop` in `src/routes/api/avatars.ts` with one `v8 ignore next` and shortens the comment above it; branch coverage and the suite still sit at 100%.
- Rewrites the `vitest.config.mts` comment to start at the four excluded module kinds instead of restating what `include` and `exclude` mean.
- Merges the two skip-cleanup tests in `src/gateways/user/index.test.ts` into one `it.each`, identical except for the mocked `avatarUrl`.
- Updates AGENTS.md's Testing section to the current gate: modules are covered with no config edit, and new live-binding or component modules fail the suite until named in `coverage.exclude`.
- Leaves the six `coverage.exclude` paths as one line each, keeping add/remove as a single-line diff.

<sup>Written for commit d31fa58dd1bac0b68a33861ddcc62f51feefc7e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imaimai17468/imaimai-front-templete/pull/151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

