### PR TITLE
fix: settings.json と env-check が bun run setup と 3 つの Bash ゲートを実態どおりに書く

### DIFF
--- a/.claude/hooks/session-start-env-check.sh
+++ b/.claude/hooks/session-start-env-check.sh
@@ -32,15 +32,16 @@ command -v similarity-ts >/dev/null 2>&1 || MISSING+=("similarity-ts not on PATH
 # actionlint` and skips on a missing mise, so mise is the condition that decides
 # whether the check runs. mise.toml pins the version it resolves.
 command -v mise >/dev/null 2>&1 || MISSING+=("mise not on PATH (lefthook pre-push skips the GitHub Actions workflow check; install: https://mise.jdx.dev/, then mise install)")
-# The installed hooks, not the binary: `bun run prepare` writes them, and a tree
-# whose hooks are absent runs no pre-commit check while every binary above is
-# present. Resolved through git because in a linked worktree `.git` is a file
-# and the hooks live in the main checkout's .git/hooks. `--git-path` answers
-# relative to the checkout when the hooks are inside it, so the test runs there.
-( cd "$TREE" 2>/dev/null && [ -f "$(git rev-parse --git-path hooks/pre-commit 2>/dev/null)" ] ) || MISSING+=("lefthook hooks not installed — pre-commit/pre-push run nothing (fix: bun run prepare)")
+# The installed hooks, not the binary: `bun run setup` writes them through
+# `lefthook install`, and a tree whose hooks are absent runs no pre-commit check
+# while every binary above is present. Resolved through git because in a linked
+# worktree `.git` is a file and the hooks live in the main checkout's
+# .git/hooks. `--git-path` answers relative to the checkout when the hooks are
+# inside it, so the test runs there.
+( cd "$TREE" 2>/dev/null && [ -f "$(git rev-parse --git-path hooks/pre-commit 2>/dev/null)" ] ) || MISSING+=("lefthook hooks not installed — pre-commit/pre-push run nothing (fix: bun run setup)")
 # A fresh worktree has no node_modules until someone installs; the Stop gate,
 # the link check and lefthook all fail without it.
-[ -d "$TREE/node_modules" ] || MISSING+=("node_modules absent — fresh checkout or worktree (fix: bun install, then bun run generate-routes && bun run cf-typegen)")
+[ -d "$TREE/node_modules" ] || MISSING+=("node_modules absent — fresh checkout or worktree (fix: bun run setup)")
 # A capability probe, not a version compare: what old node lacks is
 # `module.registerHooks`, which @cloudflare/vite-plugin imports at module top
 # level, so loading vite.config.ts fails wherever it is loaded. Observed on

--- a/.claude/hooks/session-start-env-check.sh
+++ b/.claude/hooks/session-start-env-check.sh
@@ -53,7 +53,7 @@ node -e 'if (typeof require("node:module").registerHooks !== "function") process
 if [ "${#MISSING[@]}" -gt 0 ]; then
   echo "[env-check] This session runs DEGRADED — missing gate dependencies:"
   printf '  - %s\n' "${MISSING[@]}"
-  echo "[env-check] Per AGENTS.md 'Degraded environments': state the degrade to the user once, and do not treat skipped checks as passed."
+  echo "[env-check] Per AGENTS.md 'Degraded Environments': state the degrade to the user once, and do not treat skipped checks as passed."
 else
   echo "[env-check] Gate dependencies present (jq, bun, similarity-ts, mise, node with module.registerHooks, lefthook hooks installed, node_modules)."
 fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -73,7 +73,7 @@
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/pre-bash-guard.sh",
             "timeout": 30,
-            "statusMessage": "Bash guard: .env protection + find gate..."
+            "statusMessage": "Bash guard: env-file protection + find gate + git add gate..."
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,6 +6,7 @@
       "WebSearch",
       "WebFetch",
       "Bash(bun scripts/orchestrate.ts *)",
+      "Bash(bun run setup)",
       "Bash(bun run check)",
       "Bash(bun run typecheck)",
       "Bash(bun run test)",

--- a/.cursor/permissions.json
+++ b/.cursor/permissions.json
@@ -55,6 +55,7 @@
     "bun pm",
     // bun scripts, enumerated one by one (never `bun run` as a bare prefix);
     // `cmd:args` form so script names containing `:` stay literal
+    "bun:run setup",
     "bun:run lint",
     "bun:run lint:fix",
     "bun:run format",


### PR DESCRIPTION
`bun run setup` (#147)、Stop gate の一括報告 (#144)、`git add` ゲート (#146) が入ったあとの `.claude/settings.json` と `.claude/hooks/session-start-env-check.sh` を、実際に動いているものに合わせる。

## 1. `bun run setup` を allow に入れた

`scripts/setup.sh` は fresh worktree で worker が最初に実行するコマンドで、`.claude/settings.json` の `permissions.allow` にはなかった。`.claude/settings.local.json` は `~/.config/git/ignore` の `**/.claude/settings.local.json` で無視される個人ファイルで、`.worktreeinclude` にも載っていないため、この worktree には存在しない（`git check-ignore -v` で確認）。つまり worker の worktree には届かず、project の allow だけが効く。

`Bash(bun run setup)` は引数なしの完全一致で、既存の `Bash(bun run check)` などと同じ形。`Bash(bun run *)` にはしていない。

広がるものを書き出す。`scripts/setup.sh` は `mise trust mise.toml`、`bun install --frozen-lockfile`、`bun run prepare`（`lefthook install`。main checkout と共有する `.git/hooks` に書く）、`bun run generate-routes`、`bun run cf-typegen` を実行する。`--frozen-lockfile` なので入る package は commit 済み lockfile が固定したものだけで、worker が選んだものは入らない。`package.json` に `trustedDependencies` はない（`jq` で確認）。残りは生成物（`src/routeTree.gen.ts`、`worker-configuration.d.ts`。どちらも `.gitignore` 済み）と、`mise.toml` / `lefthook.yml` という commit 済み設定にもとづく trust と hook の再インストールで、どれも冪等。これを allow に置かないと、worker は最初のコマンドで承認待ちになる。

同じ判断を Cursor 側にも入れた。`.cursor/permissions.json` は `.claude/settings.json` の `permissions` から導いたもので `bun run` script を 1 つずつ並べており、`bun:run setup` が抜けていた（code-reviewer の指摘）。`bun install` と `bun:run generate-routes` と `bun:run cf-typegen` はすでに載っているので、追加で無人化されるのは `mise trust mise.toml` と `lefthook install` の 2 手だけ。`autoRun.block_instructions` が挙げる破壊的操作にもデプロイにも当たらないので載せた。

## 2. statusMessage

`pre-bash-guard.sh` のゲートは 3 つ（保護対象の env ファイル、`find` ゲート、明示パスでない `git add` の拒否）で、statusMessage は 2 つしか名前を挙げていなかった。3 つ目を加えた。あわせて `.env protection` を `env-file protection` にした。ゲートが守るのは `.env` / `.env.local` / `.env.development` / `.env.production` の 4 ファイルで、`env-file` のほうが範囲どおり書ける。副産物として、Guard 1 は `.env` リテラルを含む Bash コマンドを拒むので、この行をシェル経由で書き換えようとすると自分自身に拒否される（実際に拒否された）。

**Stop hook の statusMessage は変えていない。** stop-gate.sh を読み、`git log -p` で履歴も見た結果、`Stop gate: typecheck / lint / format + tests + markdown links...` は #140 (324cc04) で `tests` が入っており、スクリプトが走らせる 3 ステップ（`bun run check`、`bun run test`、markdown link check）をすべて名前で挙げている。#144 が変えたのは失敗の報告方法で、statusMessage は hook 実行中に何が動いているかを示すラベルなので、そこに入れるものではない。実際に payload を流した出力も `✅ Stop gate: typecheck / lint / format and the test suite pass (md links: clean)` で、statusMessage と一致していた。stale ではなかったので触っていない。

## 3. env-check の修復手順

コマンドを名前で挙げている行を全部見て、次のように判断した。

**変えた行**

- lefthook hooks の行（`fix: bun run prepare` → `fix: bun run setup`）。`bun run prepare` は今も存在するスクリプトだが、`lefthook` バイナリを使うので node_modules が必要で、fresh worktree では失敗する。`bun run setup` は `bun install` を `bun run prepare` の前に置くので、2 つの条件がどちらの順で現れても 1 コマンドで解消する。上のコメントも `bun run setup` が `lefthook install` 経由で hook を書くという書き方に直した（package.json の `"prepare": "lefthook install"` と `scripts/setup.sh` が `bun run prepare` を走らせることを確認済み）。
- node_modules の行（`fix: bun install, then bun run generate-routes && bun run cf-typegen` → `fix: bun run setup`）。これが #147 で置き換えられた手順そのもの。しかも旧手順は `bun install` だけでは hook が入らない（`scripts/setup.sh` のコメントどおり bun 1.3.1 の `bun install` は root package の `prepare` を走らせない）ため、上の lefthook 行の条件が残る。
- AGENTS.md の節名の引用（`'Degraded environments'` → `'Degraded Environments'`）。AGENTS.md 17 行目の見出しは `## Degraded Environments`。

**残した行**

- similarity-ts の `cargo install similarity-ts` と PATH の案内。machine 側のインストールで、worktree の初期化とは無関係。
- mise の `https://mise.jdx.dev/, then mise install`。同じくインストール手順。`scripts/setup.sh` は `mise trust mise.toml` も走らせるが、この検査が見ているのは `command -v mise` だけで、trust されているかは見ていない。検査していない条件の修復手順を書くことになるので加えなかった（新しい依存チェックの追加はこのチケットの範囲外）。
- node の `see engines in package.json`。コマンドではない。
- `--git-path` についてのコメント。コマンドではないが、主張を確認した。linked worktree では絶対パス（`/Users/.../imaimai-front-templete/.git/hooks/pre-commit`）を返し、scratchpad に `git init` した普通の checkout では相対パス（`.git/hooks/pre-commit`）を返した。つまり「hooks が checkout の中にあるときは相対で答える」は成り立ち、`cd "$TREE"` が効いている。そのまま残した。

## env-check の主張の検証

この機械上で報告対象の依存を 1 つずつ確認した。

| 依存 | 結果 |
| --- | --- |
| jq | `/usr/bin/jq`。`pre-bash-guard.sh` と `stop-gate.sh` はどちらも jq で入力を parse する |
| bun | `~/.local/share/mise/installs/bun/1.3.1/bin/bun` |
| similarity-ts | `~/.cargo/bin/similarity-ts`。`lefthook.yml` の similarity ステップは `! command -v similarity-ts` で skip する |
| mise | PATH 上にある。`lefthook.yml` の actionlint は `mise exec -- actionlint` で、`! command -v mise` で skip する |
| node の `module.registerHooks` | node v26.7.0 で probe が PASS |
| lefthook hooks | `/Users/.../imaimai-front-templete/.git/hooks/pre-commit` が存在 |
| node_modules | 存在 |

再現できなかった主張はない。

## hook を payload で走らせた結果

- `session-start-env-check.sh`、cwd がこの worktree: `[env-check] Gate dependencies present (jq, bun, similarity-ts, mise, node with module.registerHooks, lefthook hooks installed, node_modules).` / `[env-check] Session model: claude-opus-5[1m]`、exit 0。
- 同じ hook、cwd が `git init` しただけの空ツリー: `lefthook hooks not installed — pre-commit/pre-push run nothing (fix: bun run setup)` と `node_modules absent — fresh checkout or worktree (fix: bun run setup)` の 2 行を出して exit 0。書き換えた 2 つの文字列が実際に出ることを確認した。
- `stop-gate.sh`（statusMessage だけ確認、スクリプトは未変更）: `{"systemMessage":"✅ Stop gate: typecheck / lint / format and the test suite pass (md links: clean)"}`、exit 0、`jq -e` で parse できる。
- `pre-bash-guard.sh`（statusMessage だけ変更、スクリプトは未変更）: `cat .env.local` / `find . -type f -exec cat {} ;` / `git add -A` の 3 payload がいずれも `decision: "block"` と `hookSpecificOutput.permissionDecision: "deny"` を持つ JSON を返し、`git add src/main.tsx` は無出力で exit 0。statusMessage の変更は hook が出す JSON に影響しない（statusMessage は settings.json から harness が読むもので、hook の stdout ではない）。
- `jq -e . .claude/settings.json` が通る。

## レビュー

`code-reviewer` は 11 件挙げて 1 件を confirmed で返し、10 件を自分で refute した。confirmed は上の `.cursor/permissions.json` の drift で、提示された 2 案のうち「entry を足す」を採った。もう 1 案は「載せない理由をコメントで書く」だが、Claude 側で allow にしたコマンドを Cursor で外しておく理由がなく、`bun install` がすでに載っている以上 risky 判定も立たない。

refute された中で 1 点だけ外部ツールの挙動が未確認のまま残った。bun 1.3.1 の `install --frozen-lockfile` が依存の lifecycle script を既定で走らせるかどうかは、この worktree からは確認できていない。`package.json` に `trustedDependencies` がないことは確認したので、上の記述はそこまでに留めてある。

## 走らせていない検査

`shellcheck` はこの機械の PATH にないので、シェルの静的 lint はしていない。

## ゲート

`bun run check` pass、`bun run test` pass（21 files / 498 tests、branch coverage 100%）、`bun .claude/hooks/check-md-links.ts` pass（21 files）、`bun run knip` exit 0、`bun scripts/check-cursor-rule-mirrors.ts` pass。
