### PR TITLE
fix: merge 済み pull request の worktree が clean-worktrees で消える

### DIFF
--- a/scripts/orchestrate-decisions.test.ts
+++ b/scripts/orchestrate-decisions.test.ts
@@ -501,6 +501,7 @@ describe(worktreeVerdict, () => {
   it("should keep the worktree when its pull request is still open", () => {
     const verdict = worktreeVerdict({
       kind: "pull-request",
+      mainAncestry: { kind: "not-ancestor" },
       pullRequest: pullRequest("OPEN"),
       pullRequestAncestry: { kind: "ancestor" },
     });
@@ -511,22 +512,25 @@ describe(worktreeVerdict, () => {
     });
   });
 
-  it("should keep the worktree when its branch holds a commit the pull request does not", () => {
+  it("should keep the worktree naming both holders when neither the pull request nor main holds its branch commits", () => {
     const verdict = worktreeVerdict({
       kind: "pull-request",
+      mainAncestry: { kind: "not-ancestor" },
       pullRequest: pullRequest("MERGED", "UNKNOWN"),
       pullRequestAncestry: { kind: "not-ancestor" },
     });
 
     expect(verdict).toStrictEqual({
       kind: "keep",
-      reason: "commits the pull request does not hold",
+      reason:
+        "commits the pull request does not hold, and commits main does not hold",
     });
   });
 
-  it("should keep the worktree when the pull request's commit is not in this repository", () => {
+  it("should keep the worktree when the pull request's commit is not in this repository and main holds no branch commit", () => {
     const verdict = worktreeVerdict({
       kind: "pull-request",
+      mainAncestry: { kind: "not-ancestor" },
       pullRequest: pullRequest("MERGED", "UNKNOWN"),
       pullRequestAncestry: { commit: "4b486bc", kind: "absent" },
     });
@@ -534,13 +538,14 @@ describe(worktreeVerdict, () => {
     expect(verdict).toStrictEqual({
       kind: "keep",
       reason:
-        "the pull request is at commit 4b486bc, which this repository does not have",
+        "the pull request is at commit 4b486bc, which this repository does not have, and commits main does not hold",
     });
   });
 
-  it("should keep the worktree when git could not compare its branch with the pull request's commit", () => {
+  it("should keep the worktree when git could not compare its branch with either commit", () => {
     const verdict = worktreeVerdict({
       kind: "pull-request",
+      mainAncestry: { kind: "failed", reason: "fatal: bad revision" },
       pullRequest: pullRequest("MERGED", "UNKNOWN"),
       pullRequestAncestry: {
         kind: "failed",
@@ -551,13 +556,14 @@ describe(worktreeVerdict, () => {
     expect(verdict).toStrictEqual({
       kind: "keep",
       reason:
-        "git could not compare with the pull request: fatal: Not a valid commit name 4b486bc",
+        "git could not compare with the pull request: fatal: Not a valid commit name 4b486bc, and git could not compare with main: fatal: bad revision",
     });
   });
 
   it("should remove the worktree when its pull request is merged and holds its branch commits", () => {
     const verdict = worktreeVerdict({
       kind: "pull-request",
+      mainAncestry: { kind: "not-ancestor" },
       pullRequest: pullRequest("MERGED", "UNKNOWN"),
       pullRequestAncestry: { kind: "ancestor" },
     });
@@ -568,8 +574,31 @@ describe(worktreeVerdict, () => {
   it("should remove the worktree when its pull request is closed and holds its branch commits", () => {
     const verdict = worktreeVerdict({
       kind: "pull-request",
+      mainAncestry: { kind: "not-ancestor" },
       pullRequest: pullRequest("CLOSED", "UNKNOWN"),
       pullRequestAncestry: { kind: "ancestor" },
+    });
+
+    expect(verdict).toStrictEqual({ kind: "remove" });
+  });
+
+  it("should remove the worktree when main holds its branch commits and the pull request does not", () => {
+    const verdict = worktreeVerdict({
+      kind: "pull-request",
+      mainAncestry: { kind: "ancestor" },
+      pullRequest: pullRequest("MERGED", "UNKNOWN"),
+      pullRequestAncestry: { kind: "not-ancestor" },
+    });
+
+    expect(verdict).toStrictEqual({ kind: "remove" });
+  });
+
+  it("should remove the worktree when main holds its branch commits and the pull request's commit is not in this repository", () => {
+    const verdict = worktreeVerdict({
+      kind: "pull-request",
+      mainAncestry: { kind: "ancestor" },
+      pullRequest: pullRequest("MERGED", "UNKNOWN"),
+      pullRequestAncestry: { commit: "4b486bc", kind: "absent" },
     });
 
     expect(verdict).toStrictEqual({ kind: "remove" });

--- a/scripts/orchestrate-decisions.ts
+++ b/scripts/orchestrate-decisions.ts
@@ -293,14 +293,15 @@ export const ancestryKeepReason = (
 
 /**
  * What GitHub and git report about the worktree of a branch the run named. Each
- * shape names the commit whose history the branch was looked for in: main when
- * GitHub reports no pull request for the branch, and the commit GitHub holds
- * for it when there is one.
+ * shape names every commit whose history the branch was looked for in: main
+ * alone when GitHub reports no pull request for the branch, and main together
+ * with the commit GitHub holds for it when there is one.
  */
 export type WorktreeFacts =
   | { readonly kind: "no-pull-request"; readonly mainAncestry: Ancestry }
   | {
       readonly kind: "pull-request";
+      readonly mainAncestry: Ancestry;
       readonly pullRequest: PullRequest;
       readonly pullRequestAncestry: Ancestry;
     };
@@ -308,11 +309,16 @@ export type WorktreeFacts =
 /**
  * Whether the worktree of a branch this run named can go. Removing it deletes
  * the branch, so what decides is whether anything else holds the branch's
- * commits: main for a branch whose worker died before opening a pull request,
- * and otherwise the commit GitHub holds, because a squash merge leaves the
- * branch's commits outside main's ancestry. Ancestry rather than equality,
- * because the branch also differs from GitHub's commit when it sits behind one
- * a worker never pulled, and nothing of the branch's own is lost then.
+ * commits. Two commits are asked, and either one holding them clears the
+ * worktree: the commit GitHub holds for the pull request, and main. Which of
+ * them answers depends on the branch. A squash merge leaves the commits a
+ * branch carried outside main's ancestry, so the pull request's commit is what
+ * holds those, and main holds a branch that ended at a commit main already had.
+ * Main is the one of the two this repository can still resolve once
+ * `gh pr update-branch` has left the pull request at a merge nothing fetched.
+ * Ancestry rather than equality, because the branch also differs from GitHub's
+ * commit when it sits behind one a worker never pulled, and nothing of the
+ * branch's own is lost then.
  */
 export const worktreeVerdict = (facts: WorktreeFacts): WorktreeVerdict => {
   if (facts.kind === "no-pull-request") {
@@ -321,12 +327,18 @@ export const worktreeVerdict = (facts: WorktreeFacts): WorktreeVerdict => {
       ? { kind: "remove" }
       : { kind: "keep", reason: `no pull request, ${mainReason}` };
   }
-  const { pullRequest, pullRequestAncestry } = facts;
+  const { mainAncestry, pullRequest, pullRequestAncestry } = facts;
   if (pullRequest.state !== "MERGED" && pullRequest.state !== "CLOSED") {
     return { kind: "keep", reason: `pull request ${pullRequest.state}` };
   }
-  const reason = ancestryKeepReason(pullRequestAncestry, "the pull request");
-  return reason === undefined ? { kind: "remove" } : { kind: "keep", reason };
+  const pullRequestReason = ancestryKeepReason(
+    pullRequestAncestry,
+    "the pull request"
+  );
+  const mainReason = ancestryKeepReason(mainAncestry, "main");
+  return pullRequestReason === undefined || mainReason === undefined
+    ? { kind: "remove" }
+    : { kind: "keep", reason: `${pullRequestReason}, and ${mainReason}` };
 };
 
 /** The one line `clean-worktrees` prints for a worktree. */

--- a/scripts/orchestrate.ts
+++ b/scripts/orchestrate.ts
@@ -250,15 +250,19 @@ const ancestry = (commit: string, descendant: string): Ancestry => {
 };
 
 /**
- * What `worktreeVerdict` judges. The ancestry runs on the branch, which is the
- * commit the worktree has checked out and the ref `removeWorktree` deletes.
+ * What `worktreeVerdict` judges. Every ancestry runs on the branch, which is
+ * the commit the worktree has checked out and the ref `removeWorktree` deletes.
+ * Comparing main runs on every worktree that reaches this call, including one
+ * whose pull request settles the verdict on its own.
  */
 const worktreeFacts = (branch: string): WorktreeFacts => {
   const pullRequest = prOf(branch);
+  const mainAncestry = ancestry(branch, "main");
   return pullRequest === undefined
-    ? { kind: "no-pull-request", mainAncestry: ancestry(branch, "main") }
+    ? { kind: "no-pull-request", mainAncestry }
     : {
         kind: "pull-request",
+        mainAncestry,
         pullRequest,
         pullRequestAncestry: ancestry(branch, pullRequest.headRefOid),
       };


### PR DESCRIPTION
`clean-worktrees` が、merge 済み pull request の worktree を毎回残していた。観測された 2 行がこれで、1 つ目は branch の `git log origin/main..<branch>` が空、つまり main が branch の commit をすべて持っていた。

```
kept .../agent-X (commits the pull request does not hold)
kept .../agent-Y (the pull request is at commit <sha>, which this repository does not have)
```

`worktreeVerdict` は pull request の head 1 つにしか ancestry を聞いていなかった。`gh pr update-branch` は base を remote branch に merge するので、pull request の head はローカルが fetch していない commit になる。すると自分の commit を何も持たない worktree が pull request の側の答えだけで残り、次の run も同じ判定を出すので永久に残る。

`no pull request` の arm はもとから main に同じ質問をしていた。`WorktreeFacts` の `pull-request` arm に `mainAncestry` を足し、`worktreeVerdict` が pull request と main の 2 つに聞く形にした。unpush のローカル commit を守る ancestry test はそのまま残っている。

## 判定と理由

`state` が MERGED / CLOSED でない間は `kept (pull request <state>)` で、これは変わっていない。finished な pull request の worktree について今出る行は下の 5 通り。

| 条件 | 判定と理由 |
| --- | --- |
| pull request の commit が branch の commit を持つ | `removed` |
| pull request は持たないが main が持つ | `removed`（直した case 1） |
| pull request の commit がローカルに無く、main が持つ | `removed`（直した case 2） |
| どちらも持たない | `kept (commits the pull request does not hold, and commits main does not hold)` |
| 比較が走らなかった | `kept (git could not compare with the pull request: <stderr>, and git could not compare with main: <stderr>)` |

## 順序と、食い違ったときの判定

**どちらかが持てば `removed`。** worktree を消すと `removeWorktree` が `git branch -D` まで走るので、失われうるのは branch の commit だけ。pull request の head と main のどちらか 1 つがその commit をすべて持っているなら、消しても失われるものは無い。2 つの答えが食い違う（一方が持ち、一方が持たない）ときの判定は `removed` で、理由行は出ない。

**判定は pull request の答えを先に読む。** `ancestryKeepReason` は純粋な文字列生成なので、`worktreeVerdict` は 2 本とも呼んでから `||` で畳んでいる。つまりこの順序が決めるのは、両方が「持たない」と答えたときの理由行の並びだけ。pull request を先にしたのは、squash merge で普通に merge された branch は tip が pull request の head そのもので、この 1 本で答えが出る case だから。main はそれが空振りした branch に答える側で、理由行もその順に読める。git の呼び出し順はこれとは別で、`worktreeFacts` の中では `mainAncestry` の方が先に走る。2 本の `ancestry` は互いの答えに依存しないので、どちらが先でも判定と理由行は変わらない。

**どちらの holder が答えるかは branch による。** squash merge は branch が運んだ commit を main の ancestry の外に置くので、その commit を持つのは pull request の head の方。main が持つのは、branch が main がすでに持っていた commit で終わっている場合。`gh pr update-branch` が pull request を誰も fetch していない merge に置いたあとは、2 つのうちこの repository が解決できるのは main の方だけになる。逆に、自分の commit を持つ branch が squash merge され、pull request の head がローカルに無い worktree は今回も `kept` のまま残る。これを消すには `refs/pull/<n>/head` を fetch して pull request の commit を解決可能にするしかなく、cleanup path に network I/O を足す変更なので #142 が落としたまま、このチケットでも足していない。

**git の呼び出しは 2 本とも常に走る。** 判定側 (`orchestrate-decisions.ts`) を I/O から切り離したままにするため、`worktreeFacts` が facts を組む時点で両方の ancestry を測る。この機械で測った 1 回のコストは `git merge-base --is-ancestor` が 0.12 s、`git rev-parse --verify` が 0.06 s で、同じ worktree について先に走る `gh pr list` 1 本が 0.62 s。lazy にする形（`worktreeProbe` と同じ ask-then-answer union）と、`git for-each-ref --merged main` で全 branch を 1 回で聞く形の 2 つを検討して、どちらも取っていない。前者は関数と分岐が 1 つずつ増え、後者は main 側の `absent` と `failed` を潰すので理由行が減る。

## end-to-end の確認

`run("gh", ...)` は PATH から `gh` を引くので、scratch repository と PATH 先頭に置いた偽 `gh`（`--state open` に `[]`、`--state all` に MERGED の 1 件を返す）で `clean-worktrees` をそのまま走らせた。branch は main が commit を持つ位置に置き、pull request の `headRefOid` を 3 通り与えた。上が修正後、下が修正前（`git show origin/main:scripts/...` で取り出した同じ script）。

```
--- the pull request's commit does not hold the branch, main does
removed WK/repo/.claude/worktrees/agent-demo
--- the pull request's commit is not in this repository, main holds the branch
removed WK/repo/.claude/worktrees/agent-demo
--- neither the pull request's commit nor main holds the branch
kept WK/repo/.claude/worktrees/agent-demo (commits the pull request does not hold, and commits main does not hold)
```

```
--- the pull request's commit does not hold the branch, main does
kept WK/repo/.claude/worktrees/agent-demo (commits the pull request does not hold)
--- the pull request's commit is not in this repository, main holds the branch
kept WK/repo/.claude/worktrees/agent-demo (the pull request is at commit 4b486bca4c59f0f069af7e95fa3d961de6cfb9f1, which this repository does not have)
--- neither the pull request's commit nor main holds the branch
kept WK/repo/.claude/worktrees/agent-demo (commits the pull request does not hold)
```

修正後の `removed` 行に `branch kept:` が付いていないので、worktree の削除に続く `git branch -D` も通っている。3 つ目の case は自分の commit を持つ branch で、修正前も `kept` で、理由が 1 行から 2 つの holder を名指す形になった。

追加した 2 つの分岐は、`||` の main 側を落とすと `should remove the worktree when main holds its branch commits and the pull request does not` と `... and the pull request's commit is not in this repository` の 2 テストが落ちることを確認した（`bun run test` で 2 failed / 498 passed）。

## 取った review 指摘

- `worktreeFacts` の comment が「run の worktree すべてで main を比べる」と書いていたが、uncommitted changes を持つ worktree は `localVerdict` で返るのでこの call に来ない。到達した worktree だけを指す文に直した。
- `worktreeVerdict` の comment の「この repository が解決できる唯一の holder」を「2 つのうち解決できる方」に直した。関数が聞いているのは 2 つの holder だけで、`origin/main` でも tag でも解決はできる。
- `should name both holders when …` を `should keep the worktree naming both holders when …` にした。同じ `describe` の他の 10 本が verdict から始まっているのに、この 1 本だけ理由から始まっていた。
- `ancestryKeepReason` は純粋な文字列生成なので、pull request 側の答えで early return せず 2 本呼んでから `||` で畳む形にした。

## 取らなかった review 指摘

- **`WorktreeFacts` を holder の list にする。** `readonly Holder[]` なら holder を足すのが additive になるが、`pullRequestAncestry` が `pullRequest` 無しでは存在できないという今の型の縛りが消え、GitHub が pull request を返していないのに `the pull request` という名前の holder を持てる形になる。holder は 2 つで固定なので union のまま。
- **`main` ではなく `origin/main` を聞く、または先に `git fetch origin main` する（review の major 指摘）。** `clean-worktrees` は fetch も pull も 1 本も走らせないので、ローカル main が remote より遅れた checkout ではこの判定が空振りして `kept (…, and commits main does not hold)` を出す、という指摘。求められた変更は `cleanWorktrees` の先頭で `git fetch origin main` を走らせ、`worktreeFacts` と `deleteMergedBranch` の両方を `origin/main` に向けること。取らなかった理由は 2 つ。squash merge は branch の commit を main の ancestry に入れないので、main が branch の commit を持つのは branch がもっと古い main の commit で終わっている場合で、run 自身の merge 分だけ遅れた main でもその commit は持っている。もう 1 つは、この変更が all-local な cleanup path に network I/O を入れ、fetch の失敗に固有の理由行を要求し、`main` を名指している既存の 2 か所（`no pull request` の arm と `deleteMergedBranch`）の挙動も変えるところ。ローカル main が遅れているときの判定は保守側（消さない側）に寄る。判断は user 待ちで、取るなら 3 か所そろえて別チケット。指摘が付けてきた acceptance は「finished な pull request の branch を `git log origin/main..<branch>` が空の状態にし、ローカル main をその手前に置いて `clean-worktrees` を走らせると `removed` になる」。
- **`Ancestry` の `absent` が sha と ref 名を区別していない。** `ancestry(branch, "main")` の `absent` は渡された ref 名をそのまま持つので、ローカルに `main` が無い repository では `main is at commit main, which this repository does not have` が出る。この文言は #142 が `no pull request` の arm について「不格好だが真」として受け入れたもので、今回 finished な pull request の arm からも到達可能になった。`absent` に「sha か ref 名か」を持たせて文を分けるのが指摘された形で、`no pull request` 側の文言まで変わるので別チケット。
- **`keep` に `reasons: readonly string[]` を持たせて `formatVerdict` で join する。** 理由文の組み立てが判定関数の中に 2 か所（`no pull request, …` と `…, and …`）ある。`WorktreeVerdict` の形が変わり、keep を作る 8 か所と keep 側のテスト全部に波及するので、この 1 本の fix には見合わない。
- **新しい remove 2 テストを table にする。** 差分は `pullRequestAncestry` の 1 literal だけ。この test file は `it` が 69 個あって `it.each` を 1 つも使っておらず、#142 も同じ理由で並べたままにしている。

## 触っていないもの

documentation は 1 行も変えていない。`clean-worktrees` の判定基準を書いている instruction document は無く（`.claude/skills/dispatch-run/SKILL.md` はコマンドを名指すだけ、`AGENTS.md` はその skill を指すだけ）、理由行の文言を引用している `.md` も無い。

## Gates

worktree で `bun run check`、`bun run test`（21 files、500 tests、`Branches: 100% (403/403)`）、`bun run knip`（`knip.json` の `oxlint-plugin-react-doctor` についての configuration hint 1 件はこの branch の前からある）を通した。`similarity-ts` は pre-push が `./src` に対して走らせるもので、この branch は `scripts/` しか触っていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TW5S9YkMGqwgN3g4sScv9D
