### PR TITLE
test: coverage の exclude に消えたモジュールのエントリが残らなくなる

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -49,6 +49,7 @@
         "react-doctor": "0.9.12",
         "react-grab": "0.2.0",
         "tailwindcss": "4.3.2",
+        "tinyglobby": "0.2.17",
         "tw-animate-css": "1.4.0",
         "typescript": "7.0.2",
         "ultracite": "7.10.6",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "react-doctor": "0.9.12",
     "react-grab": "0.2.0",
     "tailwindcss": "4.3.2",
+    "tinyglobby": "0.2.17",
     "tw-animate-css": "1.4.0",
     "typescript": "7.0.2",
     "ultracite": "7.10.6",

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -2,6 +2,12 @@ import path from "node:path";
 import react from "@vitejs/plugin-react";
 import { defaultExclude, defineConfig } from "vite-plus";
 
+export const coverageInclude = [
+  "src/**/*.ts",
+  "tools/**/*.{ts,js}",
+  "scripts/**/*.ts",
+];
+
 // coverage の gate から外す例外は、生成物、テストハーネス、コンポーネント、
 // そして依存を引数で受け取らず実バインディングの上でしか動かないアダプタと
 // 実行スクリプト。
@@ -46,7 +52,7 @@ export default defineConfig({
     exclude: [...defaultExclude, ".claude/worktrees/**"],
     setupFiles: ["./src/test-setup.ts"],
     coverage: {
-      include: ["src/**/*.ts", "tools/**/*.{ts,js}", "scripts/**/*.ts"],
+      include: coverageInclude,
       exclude: coverageExclude,
       thresholds: {
         perFile: true,

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -2,6 +2,33 @@ import path from "node:path";
 import react from "@vitejs/plugin-react";
 import { defaultExclude, defineConfig } from "vite-plus";
 
+// coverage の gate から外す例外は、生成物、テストハーネス、コンポーネント、
+// そして依存を引数で受け取らず実バインディングの上でしか動かないアダプタと
+// 実行スクリプト。
+export const coverageExclude = [
+  "scripts/check-cursor-rule-mirrors.ts",
+  "scripts/check-toolchain-pins.ts",
+  "scripts/orchestrate.ts",
+  "scripts/test-bash-guard.ts",
+  // include のパターンは picomatch の contains モードで照合されるので
+  // `*.ts` が `.tsx` にも当たる。コンポーネントはこの行で外れる。
+  "src/**/*.tsx",
+  "src/gateways/user/drizzle-store.ts",
+  "src/lib/auth/actions.ts",
+  "src/lib/auth/auth-client.ts",
+  "src/lib/auth/auth.ts",
+  "src/lib/auth/session.ts",
+  "src/lib/drizzle/db.ts",
+  "src/lib/drizzle/schema.ts",
+  "src/lib/storage/r2.ts",
+  "src/routeTree.gen.ts",
+  "src/routes/api/auth.$.ts",
+  "src/server/cloudflare.ts",
+  "src/server/fn/profile.ts",
+  "src/test/**",
+  "tools/vite-plugins/wrangler-types-plugin.ts",
+];
+
 export default defineConfig({
   resolve: {
     tsconfigPaths: true,
@@ -19,33 +46,8 @@ export default defineConfig({
     exclude: [...defaultExclude, ".claude/worktrees/**"],
     setupFiles: ["./src/test-setup.ts"],
     coverage: {
-      // exclude に並ぶ例外は、生成物、テストハーネス、コンポーネント、
-      // そして依存を引数で受け取らず実バインディングの上でしか動かない
-      // アダプタと実行スクリプト。
       include: ["src/**/*.ts", "tools/**/*.{ts,js}", "scripts/**/*.ts"],
-      exclude: [
-        "scripts/check-cursor-rule-mirrors.ts",
-        "scripts/check-toolchain-pins.ts",
-        "scripts/orchestrate.ts",
-        "scripts/test-bash-guard.ts",
-        // include のパターンは picomatch の contains モードで照合されるので
-        // `*.ts` が `.tsx` にも当たる。コンポーネントはこの行で外れる。
-        "src/**/*.tsx",
-        "src/gateways/user/drizzle-store.ts",
-        "src/lib/auth/actions.ts",
-        "src/lib/auth/auth-client.ts",
-        "src/lib/auth/auth.ts",
-        "src/lib/auth/session.ts",
-        "src/lib/drizzle/db.ts",
-        "src/lib/drizzle/schema.ts",
-        "src/lib/storage/r2.ts",
-        "src/routeTree.gen.ts",
-        "src/routes/api/auth.$.ts",
-        "src/server/cloudflare.ts",
-        "src/server/fn/profile.ts",
-        "src/test/**",
-        "tools/vite-plugins/wrangler-types-plugin.ts",
-      ],
+      exclude: coverageExclude,
       thresholds: {
         perFile: true,
         branches: 100,

--- a/vitest.config.test.ts
+++ b/vitest.config.test.ts
@@ -32,8 +32,6 @@ const treeWithOneModule = (): string => {
 };
 
 describe("coverage.exclude", () => {
-  // One entry, `src/routeTree.gen.ts`, is generated and gitignored, so this
-  // reports it in a checkout where `bun run generate-routes` has not run.
   it("should report no stale entry when every entry selects a file in the working tree", () => {
     expect(stalePatterns(coverageExclude, ROOT)).toStrictEqual([]);
   });

--- a/vitest.config.test.ts
+++ b/vitest.config.test.ts
@@ -3,11 +3,10 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, describe, expect, it } from "vite-plus/test";
+import { describe, expect, it, onTestFinished } from "vite-plus/test";
 import { coverageExclude } from "./vitest.config.mts";
 
 const ROOT = import.meta.dirname;
-const WORK = fs.mkdtempSync(path.join(os.tmpdir(), "coverage-exclude-"));
 
 // `globSync` takes a literal path and a wildcard pattern alike, and it reads
 // the working tree, so a module written but not yet committed counts as
@@ -23,17 +22,16 @@ const stalePatterns = (patterns: readonly string[], root: string): string[] =>
  * empty.
  */
 const treeWithOneModule = (): string => {
-  const root = fs.mkdtempSync(path.join(WORK, "case-"));
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "coverage-exclude-"));
+  onTestFinished(() => {
+    fs.rmSync(root, { force: true, recursive: true });
+  });
   fs.mkdirSync(path.join(root, "src/lib"), { recursive: true });
   fs.writeFileSync(path.join(root, "src/lib/live.ts"), "export const x = 1;\n");
   return root;
 };
 
 describe("coverage.exclude", () => {
-  afterAll(() => {
-    fs.rmSync(WORK, { force: true, recursive: true });
-  });
-
   // One entry, `src/routeTree.gen.ts`, is generated and gitignored, so this
   // reports it in a checkout where `bun run generate-routes` has not run.
   it("should report no stale entry when every entry selects a file in the working tree", () => {

--- a/vitest.config.test.ts
+++ b/vitest.config.test.ts
@@ -3,17 +3,19 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { globSync } from "tinyglobby";
 import { describe, expect, it, onTestFinished } from "vite-plus/test";
 import { coverageExclude } from "./vitest.config.mts";
 
 const ROOT = import.meta.dirname;
 
-// `globSync` takes a literal path and a wildcard pattern alike, and it reads
-// the working tree, so a module written but not yet committed counts as
-// present.
+// tinyglobby with `dot` and `onlyFiles` is what vitest expands these patterns
+// with, so a pattern that selects only a directory, and one that selects only
+// a dotted path, are counted here the way the coverage gate counts them.
 const stalePatterns = (patterns: readonly string[], root: string): string[] =>
   patterns.filter(
-    (pattern) => fs.globSync(pattern, { cwd: root }).length === 0
+    (pattern) =>
+      globSync(pattern, { cwd: root, dot: true, onlyFiles: true }).length === 0
   );
 
 /**
@@ -44,4 +46,13 @@ describe("coverage.exclude", () => {
       expect(stalePatterns([pattern], root)).toStrictEqual([pattern]);
     }
   );
+
+  it("should report a pattern as stale when the directory it selects holds no file", () => {
+    const root = treeWithOneModule();
+    fs.mkdirSync(path.join(root, "src/empty"));
+
+    expect(stalePatterns(["src/empty/**"], root)).toStrictEqual([
+      "src/empty/**",
+    ]);
+  });
 });

--- a/vitest.config.test.ts
+++ b/vitest.config.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment node
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+import { coverageExclude } from "./vitest.config.mts";
+
+const ROOT = import.meta.dirname;
+const WORK = fs.mkdtempSync(path.join(os.tmpdir(), "coverage-exclude-"));
+
+// `globSync` takes a literal path and a wildcard pattern alike, and it reads
+// the working tree, so a module written but not yet committed counts as
+// present.
+const stalePatterns = (patterns: readonly string[], root: string): string[] =>
+  patterns.filter(
+    (pattern) => fs.globSync(pattern, { cwd: root }).length === 0
+  );
+
+/**
+ * A tree holding one module, so a pattern that selects nothing here selects
+ * nothing because its own target is absent rather than because the tree is
+ * empty.
+ */
+const treeWithOneModule = (): string => {
+  const root = fs.mkdtempSync(path.join(WORK, "case-"));
+  fs.mkdirSync(path.join(root, "src/lib"), { recursive: true });
+  fs.writeFileSync(path.join(root, "src/lib/live.ts"), "export const x = 1;\n");
+  return root;
+};
+
+describe("coverage.exclude", () => {
+  afterAll(() => {
+    fs.rmSync(WORK, { force: true, recursive: true });
+  });
+
+  // One entry, `src/routeTree.gen.ts`, is generated and gitignored, so this
+  // reports it in a checkout where `bun run generate-routes` has not run.
+  it("should report no stale entry when every entry selects a file in the working tree", () => {
+    expect(stalePatterns(coverageExclude, ROOT)).toStrictEqual([]);
+  });
+
+  it.each(["src/lib/moved.ts", "src/moved/**"])(
+    "should report %s as stale when it selects no file in the tree",
+    (pattern) => {
+      const root = treeWithOneModule();
+
+      expect(stalePatterns([pattern], root)).toStrictEqual([pattern]);
+    }
+  );
+});

--- a/vitest.config.test.ts
+++ b/vitest.config.test.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { globSync } from "tinyglobby";
 import { describe, expect, it, onTestFinished } from "vite-plus/test";
-import { coverageExclude } from "./vitest.config.mts";
+import { coverageExclude, coverageInclude } from "./vitest.config.mts";
 
 const ROOT = import.meta.dirname;
 
@@ -24,7 +24,7 @@ const stalePatterns = (patterns: readonly string[], root: string): string[] =>
  * empty.
  */
 const treeWithOneModule = (): string => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "coverage-exclude-"));
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "coverage-patterns-"));
   onTestFinished(() => {
     fs.rmSync(root, { force: true, recursive: true });
   });
@@ -33,9 +33,12 @@ const treeWithOneModule = (): string => {
   return root;
 };
 
-describe("coverage.exclude", () => {
-  it("should report no stale entry when every entry selects a file in the working tree", () => {
-    expect(stalePatterns(coverageExclude, ROOT)).toStrictEqual([]);
+describe("coverage.include and coverage.exclude", () => {
+  it("should report no stale pattern when every pattern selects a file in the working tree", () => {
+    expect({
+      exclude: stalePatterns(coverageExclude, ROOT),
+      include: stalePatterns(coverageInclude, ROOT),
+    }).toStrictEqual({ exclude: [], include: [] });
   });
 
   it.each(["src/lib/moved.ts", "src/moved/**"])(


### PR DESCRIPTION
## 何が良くなるか

`vitest.config.mts` の `coverage.exclude` に並ぶ 19 エントリは、実バインディングの上でしか動かないモジュールを coverage の gate から外す例外です。vitest はこのパターンを picomatch と tinyglobby に渡すだけで（`pm.isMatch(filename, glob, { contains: true, dot: true, ignore: this.options.exclude })` と `glob(include, { cwd: root, ignore: [...], dot: true, onlyFiles: true })`）、どちらも「何にも当たらないパターン」を報告しません。モジュールを消したり移動したりするとエントリだけが残り、その path にまた何かが置かれた日に、誰にも気づかれないまま gate の外に出ます。stale なエントリは gate の穴であると同時に、ツリーについての偽になった主張でもあります。

同じ沈黙が `coverage.include` にもあります。`tools/` を rename すると `tools/**/*.{ts,js}` は何も選ばなくなり、そこにある 7 ファイルが 100% branch の threshold から外れますが、fail する test も出る warning もありません。

`vitest.config.test.ts` が、include と exclude のどのパターンも working tree の何かを選ぶことを確かめます。

## 判断

**check は test に置きました。** CI の `Run Tests` step と、コードを触った session の Stop gate (`.claude/hooks/stop-gate.sh`) がどちらも `bun run test` を走らせるので、CI step も新しい script も増えません。script にすると `coverage.include` の `scripts/**/*.ts` に入るので、100% branch を満たすか exclude に一行足すかになり、後者はこの check が取り締まっている種類のエントリそのものになります。

**判定は vitest と同じ engine と option です。** はじめ `node:fs` の `globSync` で書きましたが、実測で 2 方向にずれました。空の `src/empty/` に対して `src/empty/**` は `fs.globSync` が 1 件（directory 自身）を返すのに tinyglobby は `onlyFiles: true` で 0 件を返すので、ファイルを 1 つも外していないエントリが live と判定されます。逆に `src/.gen/routes.ts` だけを持つツリーに対して `src/**/*.ts` は `fs.globSync` が 0 件で、vitest が渡す `dot: true` つきの picomatch は当たります。`fs.globSync` に `dot` option は無く、渡しても無視されるので option では閉じられないため、vitest が渡す `dot` と `onlyFiles` をそのまま tinyglobby に渡します。tinyglobby は 0.2.17 が既にツリーにありながら package.json のどちらの欄にも無かったので、devDependencies に固定しました。`bun run knip` は前後とも exit 0 です。

**`*` を持つパターンも同じ 1 本が見ます。** literal path と wildcard を二種類に分けません。exclude の 19 のうち 2 つと include の 3 つが wildcard で、何にも当たらない glob は literal と同じ沈黙です。`git ls-files` を選ばなかったのは、coverage が見るのが index ではなく working tree だからです。新しいモジュールを書いて exclude に足し、commit する前に `bun run test` を回す順番だと index にはまだ無く、`git ls-files` は false failure を出します（scratch file を作って両方に問い合わせ、`git ls-files` が空、glob が当該 path を返すことを確認しました）。

**追加したファイルは gate の外です。** `coverage.include` は `src/**`、`tools/**`、`scripts/**` だけなので、repository root にある `vitest.config.mts` とその test はどちらも対象に入りません。加えて vitest 4.1.11 は `resolved.include`（test file のパターン）と config file を `coverage.exclude` へ自身で追記していて、その行のコメントは "These cannot be overridden by user config" です。exclude に足す必要はなく、足せばそれ自体が「gate が見ていない path を名指すエントリ」になります。

**test file の拡張子は `.ts` です。** `ultracite/oxlint/vitest` の override が `**/*.{test,spec}.{ts,tsx,js,jsx}` に限られていて `.mts` を含まないので、`vitest.config.test.mts` では `vitest/prefer-expect-assertions`、`vitest/require-test-timeout`、`vitest/no-importing-vitest-globals` が lint error になりました（5 errors）。`.ts` にすると `bun run check` が通ります。

**負の 3 本は temp tree に対して走ります。** 実ツリーの `src/deleted-module.ts` を名指す形だと、誰かがその path を作った日に false pass になります。`treeWithOneModule()` が `src/lib/live.ts` だけを持つ temp tree を作り、そこに対して `src/lib/moved.ts`、`src/moved/**`、そして空の directory を選ぶ `src/empty/**` を尋ねます。この 3 本だけが、判定を `() => false` に潰したときに fail します（実ツリーを見る 1 本目はそのとき通ります）。

## 残したコスト

**path の羅列そのものは残ります。** exclude の 14 エントリは、3 階層離れたモジュールの性質（実バインディングの上でしか動かない）を root の config に書き写したものです。それをモジュール名の形（例えば `*.live.ts`）に移せば `coverage.exclude` から path が消え、この check も `coverageExclude` の export も要らなくなります。14 ファイルとその importer の rename になるので、別 ticket です。

## 見送った指摘

- `coverageExclude` を root の別モジュールに切り出して config graph の import を避ける案（計測値は 146ms と +62MB RSS）。2.9s の suite に対する 146ms のために root にファイルを一つ増やす取引をしませんでした。
- `expect(stale, "…")` で直し方を出す案。`vitest/valid-expect` が 2 引数の `expect` を拒みます。
- 「生成物の `src/routeTree.gen.ts` が無い checkout で false failure になる」という懸念。実際に消すと他の 21 test file は通りこの check だけが fail しますが、CI は `Generate route tree` step を `Run Tests` の前に置き、README も local で同じ順を書いているので、この経路は起きません。代わりにこの件を書いていたコメントは、別ファイルの一覧を主張していたので消しました。

## 確認

- `bun run check` / `bun run test` 通過（22 files / 502 tests）、`bun run knip` は exit 0
- 修正前: `coverage.exclude` に `src/lib/storage/deleted-module.ts` と `src/no-such-dir/**` を足しても `bun run test` は exit 0
- stale な literal entry と何にも当たらない glob を足すと、live check が両方を並べて fail し、`bun run test` は exit 1
- 空の `src/legacy/` を作って `src/legacy/**` を足すと fail（`fs.globSync` のときは通っていた case）
- include の `tools/**/*.{ts,js}` を `toolz/**/*.{ts,js}` にすると fail
- 判定を `() => false` に潰すと負の 3 本が fail し、live check だけが通る
- `bunx vp test --run vitest.config.test.ts -t <当たらない名前>` のあと `/tmp` に `coverage-patterns-*` は残らない
- 戻して 4 tests 通過、`bun run test` は exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TW5S9YkMGqwgN3g4sScv9D
