### PR TITLE
docs: worker が別プロセスの完了を待つ手段を Worker brief から読める

### DIFF
--- a/.claude/skills/dispatch-run/SKILL.md
+++ b/.claude/skills/dispatch-run/SKILL.md
@@ -17,6 +17,8 @@ Hold the pull request as AGENTS.md's *A PR's author holds it until it merges* bu
 - On #122 the only other check was `cubic · AI code reviewer`, which reported at 5m44s against `build`'s 37s, so the loop tests `build` alone.
 - `gh pr update-branch` merges the base branch into the remote branch, which leaves the local branch behind it, so run `git pull` before committing there again.
 
+While a subagent runs, waiting means ending the turn, because the `Agent` tool notifies you when one completes. A shell that sleeps to pass the time buys nothing, and when the dispatching session killed one worker's sleep shells in the 2026-09-08 run, the kill also stopped the background task carrying that worker's mutation runs, which it then re-ran. A wait on a condition nothing will make true never returns. Ending the turn waits only while something that will wake you is running, so where nothing is in flight and you still need a result, dispatch it again rather than end, as `ticket-work` step 7 says for a `code-reviewer` that returned no report. The poll above stays in the foreground, because `gh pr checks` is not a subagent and nothing wakes you when `build` turns green.
+
 Name every scratch file after the ticket, `<branch>-pr-body.md` rather than `pr-body.md`. The workers of one run share one scratchpad directory, so a second worker writing the plain name overwrites the first worker's file.
 
 ## Watching the run


### PR DESCRIPTION
## What changed

`.claude/skills/dispatch-run/SKILL.md` の `## Worker brief` に、worker が別のものの完了を待つあいだ何をするかを 5 文追記した。見出しは足していない。

- subagent の完了は `Agent` ツールが通知するので、待ち方はターンを終えること。
- 時間稼ぎの sleep シェルは何も買わず、それを kill すると同じ worker の他の background task も止まる（2026-09-08 の run で mutation run の task が巻き込まれ、再実行になった）。
- 成立しえない条件を待つループは終わらない。
- 起こす相手が走っていないターンは待ちにならないので、必要な結果が出ていないなら再 dispatch する（`ticket-work` step 7 が `code-reviewer` について同じことを言っている）。
- CI チェックの polling だけは前面のまま。`gh pr checks` は subagent ではなく、`build` が緑になっても誰も worker を起こさない。

## Verification

- `bun .claude/hooks/check-md-links.ts` → `markdown links ok (22 files checked, no dead relative links)`
- docs のみのため `bun run check` / `bun run test` は pre-push hook 経由で実行され、いずれも通っている。

## Assumptions

- 「subagent の完了で worker が再起動する」の裏取りは、このセッションの `Agent` ツール説明にある "Subagents run in the background; you'll be notified when one completes." と "Never fabricate or predict a pending agent's results — the notification is never something you write yourself" の 2 文。ツール説明が使う語は「通知」なので、本文もそう書いた。
- sleep シェルの本数（50 超 / 19 本）と mutation run の本数（9 本）、および kill が background task を巻き込んだ因果は dispatch 元のセッションが観測した記録で、こちらでは再現していない。本文には日付と出来事だけを残し、数は入れていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TW5S9YkMGqwgN3g4sScv9D


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents in `dispatch-run`'s Worker brief how a worker should wait on another process, so workers stop improvising with sleep shells, impossible wait loops, and turns that nothing will wake.

- Waiting on a subagent means ending the turn, because the `Agent` tool notifies on completion.
- Sleep shells and impossible-condition loops are harmful — killing a sleep shell can stop sibling background tasks, as in the 2026-09-08 run, and a wait on an impossible condition never returns.
- A turn only waits while something running will wake the worker, so with nothing in flight re-dispatch instead, as `ticket-work` step 7 does for `code-reviewer`; `gh pr checks` polling stays in the foreground since nothing wakes the worker when `build` turns green.

Docs-only change; the markdown link check passes.

<sup>Written for commit 48f9036fa495beb6f7b3b371f3d6c2713b0d98a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/imaimai17468/imaimai-front-templete/pull/159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

