### PR TITLE
test: hook のゲートが bun run test と CI で走り shellcheck が shell を静的に検査する

### DIFF
--- a/.claude/hooks/hook-output.test.ts
+++ b/.claude/hooks/hook-output.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Exercise readHookJson's two branches directly.
+ *
+ * `coverage.include` in vitest.config.mts covers `src/**`, `tools/**` and
+ * `scripts/**`, so no per-file branch threshold reaches this directory and
+ * a branch here is pinned by a case rather than by a number.
+ */
+
+import { describe, expect, it } from "vite-plus/test";
+import { z } from "zod";
+import { readHookJson } from "./hook-output";
+
+const Decision = z.object({
+  decision: z.string().default(""),
+  reason: z.string().default(""),
+});
+
+describe("hook-output", () => {
+  it("should fall back to the schema's defaults when the hook printed nothing", () => {
+    const stdout = "   \n";
+
+    const parsed = readHookJson(stdout, Decision);
+
+    expect(parsed).toStrictEqual({ decision: "", reason: "" });
+  });
+
+  it("should return the fields the hook printed when its stdout is JSON", () => {
+    const stdout = '{"decision":"block","reason":"named a protected file"}\n';
+
+    const parsed = readHookJson(stdout, Decision);
+
+    expect(parsed).toStrictEqual({
+      decision: "block",
+      reason: "named a protected file",
+    });
+  });
+
+  it("should throw when the hook printed something that is not JSON", () => {
+    const stdout = "pre-bash-guard.sh: line 14: jq: command not found\n";
+
+    expect(() => readHookJson(stdout, Decision)).toThrow(SyntaxError);
+  });
+
+  it("should throw when the hook printed JSON the schema rejects", () => {
+    const stdout = '{"decision":7}';
+
+    expect(() => readHookJson(stdout, Decision)).toThrow(z.ZodError);
+  });
+});

--- a/.claude/hooks/hook-output.ts
+++ b/.claude/hooks/hook-output.ts
@@ -1,0 +1,14 @@
+import type { ZodType } from "zod";
+
+/**
+ * A hook's JSON stdout, validated against the shape its caller expects.
+ *
+ * A hook that decides nothing prints nothing, so silence is read as an empty
+ * object and the schema's own defaults answer for the absent fields. That keeps
+ * a silent hook and a malformed one apart: the second still throws.
+ */
+export const readHookJson = <T>(stdout: string, schema: ZodType<T>): T => {
+  const trimmed = stdout.trim();
+  const emitted: unknown = trimmed === "" ? {} : JSON.parse(trimmed);
+  return schema.parse(emitted);
+};

--- a/.claude/hooks/hook-output.ts
+++ b/.claude/hooks/hook-output.ts
@@ -5,9 +5,9 @@ import type { ZodType } from "zod";
  *
  * Empty stdout is read as an empty object, so the schema's own defaults answer
  * for every field. Whether that silence came from a hook that decided nothing
- * or from one that died is not visible here, and the caller settles it: the
- * pre-bash-guard cases assert the hook's exit status alongside its decision.
- * Text that is not JSON throws rather than reading as silence.
+ * or from one that died is not visible here, so a caller that needs to tell
+ * those apart reads the hook's exit status. Text that is not JSON throws rather
+ * than reading as silence.
  */
 export const readHookJson = <T>(stdout: string, schema: ZodType<T>): T => {
   const trimmed = stdout.trim();

--- a/.claude/hooks/hook-output.ts
+++ b/.claude/hooks/hook-output.ts
@@ -3,9 +3,11 @@ import type { ZodType } from "zod";
 /**
  * A hook's JSON stdout, validated against the shape its caller expects.
  *
- * A hook that decides nothing prints nothing, so silence is read as an empty
- * object and the schema's own defaults answer for the absent fields. That keeps
- * a silent hook and a malformed one apart: the second still throws.
+ * Empty stdout is read as an empty object, so the schema's own defaults answer
+ * for every field. Whether that silence came from a hook that decided nothing
+ * or from one that died is not visible here, and the caller settles it: the
+ * pre-bash-guard cases assert the hook's exit status alongside its decision.
+ * Text that is not JSON throws rather than reading as silence.
  */
 export const readHookJson = <T>(stdout: string, schema: ZodType<T>): T => {
   const trimmed = stdout.trim();

--- a/.claude/hooks/pre-bash-guard.sh
+++ b/.claude/hooks/pre-bash-guard.sh
@@ -162,6 +162,7 @@ if [ -n "$TEXT_FLAG_PATTERN" ]; then
   # only when the command contains no substitution opener at all. A bare `$`
   # (e.g. "$5/mo") is inert and still scrubs; any backtick is conservatively
   # treated as a potential pair (= execution) and blocks scrubbing.
+  # shellcheck disable=SC2016 # the openers are matched as literal text here
   case "$SCRUBBED" in
     *'$('*|*'${'*|*'`'*) ;;
     *) SCRUBBED=$(printf '%s' "$SCRUBBED" | scrub_message_body '"' "$TEXT_FLAG_PATTERN") ;;

--- a/.claude/hooks/pre-bash-guard.sh
+++ b/.claude/hooks/pre-bash-guard.sh
@@ -27,7 +27,7 @@ case "$TOOL" in
 esac
 
 # Emit a deny in both dialects at once: Claude Code reads the legacy
-# decision/reason pair (scripts/test-bash-guard.ts keys on the literal
+# decision/reason pair (pre-bash-guard.test.ts keys on the literal
 # "block"), Cursor reads hookSpecificOutput.permissionDecision. Cursor was
 # observed honoring exactly this combined output (a guard in this file blocked a
 # live command in a Cursor session, 2026-08-07). Claude Code has NOT been observed

--- a/.claude/hooks/pre-bash-guard.test.ts
+++ b/.claude/hooks/pre-bash-guard.test.ts
@@ -57,7 +57,14 @@ const readDecision = (stdout: string): Decision => {
   return asDecision(parsed.hookSpecificOutput?.permissionDecision);
 };
 
-/** The hook's decision for a Bash command. */
+/**
+ * The hook's decision for a Bash command.
+ *
+ * A silent hook means "allow", so a hook that died before printing would read
+ * as allow and every case expecting that would pass on a broken guard. The
+ * hook writes nothing to stderr while it is working, so anything there ends
+ * the case instead of being read as a decision.
+ */
 const decide = async (command: string): Promise<Decision> => {
   const hook = spawn("bash", [HOOK], {
     env: { ...process.env, CLAUDE_PROJECT_DIR: REPO },
@@ -65,7 +72,14 @@ const decide = async (command: string): Promise<Decision> => {
   hook.stdin.end(
     JSON.stringify({ tool_input: { command }, tool_name: "Bash" })
   );
-  return readDecision(await text(hook.stdout));
+  const [stdout, stderr] = await Promise.all([
+    text(hook.stdout),
+    text(hook.stderr),
+  ]);
+  if (stderr !== "") {
+    throw new Error(`the hook wrote to stderr instead of deciding: ${stderr}`);
+  }
+  return readDecision(stdout);
 };
 
 interface Case {

--- a/.claude/hooks/pre-bash-guard.test.ts
+++ b/.claude/hooks/pre-bash-guard.test.ts
@@ -1,9 +1,5 @@
-#!/usr/bin/env bun
-
 /**
  * Exercise .claude/hooks/pre-bash-guard.sh against the shapes it must judge.
- *
- *     bun run scripts/test-bash-guard.ts
  *
  * The guard carries three decisions that are easy to break and impossible to
  * notice: the protected-env-file block, the `find` gate and the unnamed-changes
@@ -12,57 +8,64 @@
  * the decision it returns. Nothing in the repository is modified and no command
  * from a case is ever executed.
  *
- * Not named `*.test.ts` on purpose: vitest would then run it on every
- * `bun run test` and in CI, where a hook that only runs during local agent
- * sessions has nothing to report. Run it after touching pre-bash-guard.sh.
- * Exits non-zero on a mismatch.
+ * Every case forks the hook, which forks jq and awk of its own, so one case took
+ * 235 ms on average when they ran one after another (202 cases in 47.4 s,
+ * 2026-09-09, a machine under parallel load). The cases of a group run
+ * concurrently to spend that on several cores instead of one.
  */
 
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { text } from "node:stream/consumers";
+import { describe, expect, it } from "vite-plus/test";
+import { z } from "zod";
+import { readHookJson } from "./hook-output";
 
-const REPO = fileURLToPath(new URL("..", import.meta.url));
-const HOOK = path.join(REPO, ".claude/hooks/pre-bash-guard.sh");
+const HOOK = path.resolve(import.meta.dirname, "pre-bash-guard.sh");
+const REPO = path.resolve(import.meta.dirname, "../..");
 
 // Joined so this file's own text is not itself a commit-shaped command.
 const COMMIT_SUB = ["com", "mit"].join("");
 const COMMIT = `git ${COMMIT_SUB}`;
 
+// `ask` is a decision the guard's find gate weighs emitting and argues against
+// where it denies instead, so a case may come to expect it; none does today.
 const DECISIONS = ["allow", "block", "ask"] as const;
 
 type Decision = (typeof DECISIONS)[number];
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null;
+/**
+ * The two dialects the hook emits at once. `permissionDecision` stays a plain
+ * string because a deny carries Cursor's own word "deny", which is not one of
+ * the DECISIONS a case expects.
+ */
+const HookOutput = z.object({
+  decision: z.string().optional(),
+  hookSpecificOutput: z
+    .object({ permissionDecision: z.string().optional() })
+    .optional(),
+});
 
-const asDecision = (value: unknown): Decision | undefined =>
-  DECISIONS.find((decision) => decision === value);
+const asDecision = (permissionDecision: string | undefined): Decision =>
+  DECISIONS.find((decision) => decision === permissionDecision) ?? "allow";
 
-/** The hook's decision for a Bash command. */
-const decide = (command: string): Decision => {
-  const { stdout } = spawnSync("bash", [HOOK], {
-    encoding: "utf-8",
-    env: { ...process.env, CLAUDE_PROJECT_DIR: REPO },
-    input: JSON.stringify({ tool_input: { command }, tool_name: "Bash" }),
-  });
-  const out = stdout.trim();
-  const hookStayedSilent = out === "";
-  if (hookStayedSilent) {
-    return "allow";
-  }
-  const parsed: unknown = JSON.parse(out);
-  if (!isRecord(parsed)) {
-    return "allow";
-  }
+const readDecision = (stdout: string): Decision => {
+  const parsed = readHookJson(stdout, HookOutput);
   if (parsed.decision === "block") {
     return "block";
   }
-  const specific = parsed.hookSpecificOutput;
-  if (!isRecord(specific)) {
-    return "allow";
-  }
-  return asDecision(specific.permissionDecision) ?? "allow";
+  return asDecision(parsed.hookSpecificOutput?.permissionDecision);
+};
+
+/** The hook's decision for a Bash command. */
+const decide = async (command: string): Promise<Decision> => {
+  const hook = spawn("bash", [HOOK], {
+    env: { ...process.env, CLAUDE_PROJECT_DIR: REPO },
+  });
+  hook.stdin.end(
+    JSON.stringify({ tool_input: { command }, tool_name: "Bash" })
+  );
+  return readDecision(await text(hook.stdout));
 };
 
 interface Case {
@@ -71,19 +74,21 @@ interface Case {
   why: string;
 }
 
-const failures: string[] = [];
+// A heredoc case spans lines, and a test name has to stay on one.
+const oneLine = (command: string): string => command.replaceAll("\n", "\\n");
 
 const group = (title: string, cases: readonly Case[]): void => {
-  console.log(title);
-  cases.forEach(({ command, expected, why }) => {
-    const actual = decide(command);
-    const ok = actual === expected;
-    if (!ok) {
-      failures.push(`${why}: ${command}`);
-    }
-    console.log(
-      `  ${ok ? "ok  " : "FAIL"} ${actual.padEnd(5)} (want ${expected.padEnd(5)})  ${why}`
-    );
+  describe.concurrent(title, () => {
+    it.each(
+      cases.map((one) => ({
+        ...one,
+        // The reason comes ahead of the command because a failure line
+        // truncates the label from the right.
+        label: `${one.expected} (${one.why}) \`${oneLine(one.command)}\``,
+      }))
+    )("$label", async ({ command, expected }) => {
+      await expect(decide(command)).resolves.toBe(expected);
+    });
   });
 };
 
@@ -1113,13 +1118,3 @@ group("git commit: the shapes that defeated earlier guards here", [
     why: "a gh api -f body is not scrubbed, so a parenthesised shape inside it is refused",
   },
 ]);
-
-console.log("");
-if (failures.length > 0) {
-  console.log(`FAILED: ${failures.length}`);
-  failures.forEach((failure) => {
-    console.log(`  - ${failure}`);
-  });
-  process.exit(1);
-}
-console.log("all checks passed");

--- a/.claude/hooks/pre-bash-guard.test.ts
+++ b/.claude/hooks/pre-bash-guard.test.ts
@@ -14,7 +14,9 @@
  * concurrently to spend that on several cores instead of one.
  */
 
+import type { ChildProcess } from "node:child_process";
 import { spawn } from "node:child_process";
+import { once } from "node:events";
 import path from "node:path";
 import { text } from "node:stream/consumers";
 import { describe, expect, it } from "vite-plus/test";
@@ -57,29 +59,44 @@ const readDecision = (stdout: string): Decision => {
   return asDecision(parsed.hookSpecificOutput?.permissionDecision);
 };
 
+/** node emits `close` with the exit code and the signal that ended the child. */
+const CloseArgs = z.tuple([z.number().nullable(), z.string().nullable()]);
+
+const exitStatusOf = async (hook: ChildProcess): Promise<number | null> => {
+  const closed: unknown = await once(hook, "close");
+  const [status] = CloseArgs.parse(closed);
+  return status;
+};
+
 /**
- * The hook's decision for a Bash command.
+ * What one run of the hook produced for a Bash command.
  *
- * A silent hook means "allow", so a hook that died before printing would read
- * as allow and every case expecting that would pass on a broken guard. The
- * hook writes nothing to stderr while it is working, so anything there ends
- * the case instead of being read as a decision.
+ * The decision alone is not enough to judge a case. A silent hook means
+ * "allow", so a hook that died before printing produces the same empty stdout
+ * as an allow, and every `exit` in pre-bash-guard.sh is `exit 0`, both deny
+ * sites included. So a case asserts the status and the empty stderr with the
+ * decision, and a guard that dies under GNU awk on the CI runner fails the
+ * cases expecting allow rather than passing them.
  */
-const decide = async (command: string): Promise<Decision> => {
+interface HookRun {
+  decision: Decision;
+  status: number | null;
+  stderr: string;
+}
+
+const runHook = async (command: string): Promise<HookRun> => {
   const hook = spawn("bash", [HOOK], {
     env: { ...process.env, CLAUDE_PROJECT_DIR: REPO },
   });
   hook.stdin.end(
     JSON.stringify({ tool_input: { command }, tool_name: "Bash" })
   );
-  const [stdout, stderr] = await Promise.all([
+  const [stdout, stderr, status] = await Promise.all([
     text(hook.stdout),
     text(hook.stderr),
+    exitStatusOf(hook),
   ]);
-  if (stderr !== "") {
-    throw new Error(`the hook wrote to stderr instead of deciding: ${stderr}`);
-  }
-  return readDecision(stdout);
+  return { decision: readDecision(stdout), status, stderr };
 };
 
 interface Case {
@@ -101,7 +118,11 @@ const group = (title: string, cases: readonly Case[]): void => {
         label: `${one.expected} (${one.why}) \`${oneLine(one.command)}\``,
       }))
     )("$label", async ({ command, expected }) => {
-      await expect(decide(command)).resolves.toBe(expected);
+      await expect(runHook(command)).resolves.toStrictEqual({
+        decision: expected,
+        status: 0,
+        stderr: "",
+      });
     });
   });
 };

--- a/.claude/hooks/session-start-env-check.sh
+++ b/.claude/hooks/session-start-env-check.sh
@@ -28,10 +28,11 @@ command -v bun >/dev/null 2>&1 || MISSING+=("bun (the Stop quality gate, its mar
 # binary the hook cannot invoke is absent as far as the gate is concerned, so
 # accepting ~/.cargo/bin here would report a skipped check as present.
 command -v similarity-ts >/dev/null 2>&1 || MISSING+=("similarity-ts not on PATH (lefthook pre-push skips duplicate-type/function detection; install: cargo install similarity-ts, and put ~/.cargo/bin on PATH)")
-# `mise`, not `actionlint`: lefthook runs the workflow check as `mise exec --
-# actionlint` and skips on a missing mise, so mise is the condition that decides
-# whether the check runs. mise.toml pins the version it resolves.
-command -v mise >/dev/null 2>&1 || MISSING+=("mise not on PATH (lefthook pre-push skips the GitHub Actions workflow check; install: https://mise.jdx.dev/, then mise install)")
+# `mise`, not `actionlint` or `shellcheck`: lefthook runs both static checks
+# through `mise exec --` and skips each on a missing mise, so mise is the
+# condition that decides whether they run. mise.toml pins the versions it
+# resolves.
+command -v mise >/dev/null 2>&1 || MISSING+=("mise not on PATH (lefthook pre-push skips the GitHub Actions workflow check and the shellcheck run; install: https://mise.jdx.dev/, then mise install)")
 # The installed hooks, not the binary: `bun run setup` writes them through
 # `lefthook install`, and a tree whose hooks are absent runs no pre-commit check
 # while every binary above is present. Resolved through git because in a linked

--- a/.claude/hooks/stop-gate.sh
+++ b/.claude/hooks/stop-gate.sh
@@ -10,9 +10,9 @@
 #
 # Every step above runs even after an earlier one failed, and one block names
 # all of them, so no failure waits for a later Stop to be reported. That block
-# respects stop_hook_active: if this Stop was already blocked once, it
-# downgrades to a warning instead of blocking again, so a pre-existing failure
-# the agent cannot fix does not loop forever.
+# downgrades to a warning instead of blocking again when the payload says this
+# Stop already triggered a followup, so a pre-existing failure the agent cannot
+# fix does not loop forever. The warning names which field said so.
 
 set -uo pipefail
 
@@ -31,20 +31,22 @@ fi
 # triggered) instead — and it runs Claude-registered stop hooks with NO loop
 # limit (loop_limit defaults to null for third-party hooks), so without this
 # mapping a pre-existing failure would re-block forever there.
-STOP_ACTIVE=$(printf '%s' "$INPUT" | jq -r \
-  'if (.stop_hook_active == true) or ((.loop_count // 0) > 0) then "true" else "false" end' \
-  2>/dev/null || echo false)
+# The warning below quotes this value, so a Cursor turn reads `loop_count`
+# rather than a Claude field its payload never carried.
+DOWNGRADE_CAUSE=$(printf '%s' "$INPUT" | jq -r \
+  'if .stop_hook_active == true then "stop_hook_active" elif (.loop_count // 0) > 0 then "loop_count" else "" end' \
+  2>/dev/null || echo "")
 
-# Emit a block — downgraded to a warning when this Stop was already blocked
-# once (stop_hook_active), to prevent an unfixable failure from looping.
+# Emit a block, downgraded to a warning when DOWNGRADE_CAUSE is set, to prevent
+# an unfixable failure from looping.
 # The body reaches jq through a pipe rather than argv: `--arg body "$2"` made
 # execve fail with E2BIG once a step's diagnostics crossed ARG_MAX (1048576 on
 # macOS), and the exit below then ended the turn having printed nothing.
 # `printf` is a shell builtin, so the body never passes through an argv again.
 emit_block() { # $1 = summary, $2 = reason body
-  if [ "$STOP_ACTIVE" = "true" ]; then
-    printf '%s' "$2" | jq -n --arg sum "$1" --rawfile body /dev/stdin '{
-      systemMessage: ("⚠️ Stop gate STILL failing (not re-blocking — stop_hook_active): " + $sum + " — if this failure is pre-existing or unfixable, report it to the user explicitly; do not treat it as passed.\n" + $body)
+  if [ -n "$DOWNGRADE_CAUSE" ]; then
+    printf '%s' "$2" | jq -n --arg sum "$1" --arg cause "$DOWNGRADE_CAUSE" --rawfile body /dev/stdin '{
+      systemMessage: ("⚠️ Stop gate STILL failing (not re-blocking — " + $cause + "): " + $sum + " — if this failure is pre-existing or unfixable, report it to the user explicitly; do not treat it as passed.\n" + $body)
     }'
   else
     printf '%s' "$2" | jq -n --arg sum "$1" --rawfile body /dev/stdin '{

--- a/.claude/hooks/stop-gate.sh
+++ b/.claude/hooks/stop-gate.sh
@@ -26,7 +26,6 @@ CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null || true)
 if [ -n "$CWD" ] && [ -d "$CWD/.claude/hooks" ]; then
   ROOT="$CWD"
 fi
-cd "$ROOT"
 # `stop_hook_active` is Claude Code's "this Stop was already blocked once"
 # flag. Cursor's stop payload carries `loop_count` (auto-followups already
 # triggered) instead — and it runs Claude-registered stop hooks with NO loop
@@ -77,6 +76,15 @@ run_step() { # $1 = the `bun run` script to run
   out=$(bun run "$1" 2>&1) && return 0
   record_failure "bun run $1" "$out"
 }
+
+# Every step below reads the tree through the working directory, and `set -e` is
+# off, so a failed `cd` would leave them judging whatever tree the session was
+# started from. This is the one failure where nothing at all ran, so it takes
+# the same block as a failed step rather than a quieter exit. It sits after
+# emit_block for that reason.
+cd "$ROOT" || emit_block \
+  "the Stop gate could not enter $ROOT, so no check ran." \
+  "The directory named by the Stop payload's cwd, or by CLAUDE_PROJECT_DIR, is gone or unreadable. Nothing below it was judged: no typecheck, no lint, no format, no test suite, no markdown link check."
 
 # Skip when there are no changes
 if [ -z "$(git status --porcelain)" ]; then

--- a/.claude/hooks/stop-gate.sh
+++ b/.claude/hooks/stop-gate.sh
@@ -86,8 +86,25 @@ cd "$ROOT" || emit_block \
   "the Stop gate could not enter $ROOT, so no check ran." \
   "The directory named by the Stop payload's cwd, or by CLAUDE_PROJECT_DIR, is gone or unreadable. Nothing below it was judged: no typecheck, no lint, no format, no test suite, no markdown link check."
 
+# A failed `git status` prints nothing on stdout, and the emptiness test below
+# reads that as a clean tree and ends the turn with no check run, so the exit
+# status is tested first. stderr joins stdout so the block carries git's own
+# diagnostic, which names causes the gate cannot tell apart itself and often
+# carries the command that fixes them. A warning on a successful run lands in
+# GIT_STATUS too, and costs a checked run over a clean tree, never a skipped one.
+GIT_STATUS=$(git status --porcelain 2>&1)
+GIT_STATUS_RC=$?
+if [ "$GIT_STATUS_RC" -ne 0 ]; then
+  emit_block \
+    "the Stop gate could not read git status in $ROOT, so no check ran." \
+    "\`git status --porcelain\` exited $GIT_STATUS_RC in $ROOT:
+$GIT_STATUS
+
+The gate cannot tell a clean tree from an unjudged one. Nothing below it was judged: no typecheck, no lint, no format, no test suite, no markdown link check."
+fi
+
 # Skip when there are no changes
-if [ -z "$(git status --porcelain)" ]; then
+if [ -z "$GIT_STATUS" ]; then
   exit 0
 fi
 

--- a/.claude/hooks/stop-gate.sh
+++ b/.claude/hooks/stop-gate.sh
@@ -59,6 +59,10 @@ emit_block() { # $1 = summary, $2 = reason body
 FAILED_STEPS=""
 FAILURE_OUTPUT=""
 
+# Both blocks that fire before any step runs end with this, so a step added
+# below reaches them without being written into each body again.
+NOTHING_RAN="Nothing below it was judged: no typecheck, no lint, no format, no test suite, no markdown link check."
+
 # A failure is collected instead of emitted, so the steps after it still run and
 # one block names all of them.
 record_failure() { # $1 = step name, $2 = the step's output
@@ -84,7 +88,7 @@ run_step() { # $1 = the `bun run` script to run
 # emit_block for that reason.
 cd "$ROOT" || emit_block \
   "the Stop gate could not enter $ROOT, so no check ran." \
-  "The directory named by the Stop payload's cwd, or by CLAUDE_PROJECT_DIR, is gone or unreadable. Nothing below it was judged: no typecheck, no lint, no format, no test suite, no markdown link check."
+  "The directory named by the Stop payload's cwd, or by CLAUDE_PROJECT_DIR, is gone or unreadable. $NOTHING_RAN"
 
 # A failed `git status` prints nothing on stdout, and the emptiness test below
 # reads that as a clean tree and ends the turn with no check run, so the exit
@@ -100,7 +104,7 @@ if [ "$GIT_STATUS_RC" -ne 0 ]; then
     "\`git status --porcelain\` exited $GIT_STATUS_RC in $ROOT:
 $GIT_STATUS
 
-The gate cannot tell a clean tree from an unjudged one. Nothing below it was judged: no typecheck, no lint, no format, no test suite, no markdown link check."
+The gate cannot tell a clean tree from an unjudged one. $NOTHING_RAN"
 fi
 
 # Skip when there are no changes

--- a/.claude/hooks/stop-gate.test.ts
+++ b/.claude/hooks/stop-gate.test.ts
@@ -339,6 +339,21 @@ md links: FAILED`,
     );
   });
 
+  // In a worktree session CLAUDE_PROJECT_DIR is the checkout the session
+  // started in and the payload's cwd is the one the turn edited, so the gate
+  // prefers cwd. The session tree here is clean, which is what the gate would
+  // report if it read CLAUDE_PROJECT_DIR instead.
+  it("should judge the tree the payload names when the session started in another one", () => {
+    const session = scratchRepo(PASSING, []);
+    const work = scratchRepo(PASSING, ["a.ts"]);
+
+    const run = runGate(work, { cwd: work, projectDir: session });
+
+    expect(run.systemMessage).toBe(
+      "✅ Stop gate: typecheck / lint / format and the test suite pass (md links: clean)"
+    );
+  });
+
   // The scratch repository's `check` fails, so a gate that carried on in the
   // wrong tree would block naming `bun run check` rather than the root.
   it("should block naming the unreachable root when it cannot enter the tree to judge", () => {

--- a/.claude/hooks/stop-gate.test.ts
+++ b/.claude/hooks/stop-gate.test.ts
@@ -372,4 +372,26 @@ md links: FAILED`,
       systemMessage: `⛔ Stop block: the Stop gate could not enter ${missing}, so no check ran.`,
     });
   });
+
+  // `.git` is a file holding text that is not a gitfile pointer, so `git status`
+  // exits non-zero with empty stdout without walking up to any repository above
+  // the scratch directory. The gate's step stand-ins are absent, so a gate that
+  // read that emptiness as a clean tree would exit 0 having judged nothing.
+  it("should block naming the root when it cannot read git status in the tree", () => {
+    const broken = scratchDir("stop-gate-nogit-");
+    fs.mkdirSync(path.join(broken, ".claude/hooks"), { recursive: true });
+    fs.writeFileSync(path.join(broken, ".git"), "not a gitfile\n");
+
+    const run = runGate(broken, { cwd: broken, projectDir: broken });
+
+    expect({
+      decision: run.decision,
+      status: run.status,
+      systemMessage: run.systemMessage,
+    }).toStrictEqual({
+      decision: "block",
+      status: 0,
+      systemMessage: `⛔ Stop block: the Stop gate could not read git status in ${broken}, so no check ran.`,
+    });
+  });
 });

--- a/.claude/hooks/stop-gate.test.ts
+++ b/.claude/hooks/stop-gate.test.ts
@@ -323,7 +323,7 @@ md links: FAILED`,
     }).toStrictEqual({
       decision: "",
       summary:
-        "⚠️ Stop gate STILL failing (not re-blocking — stop_hook_active): bun run check failed. Fix before ending the turn. — if this failure is pre-existing or unfixable, report it to the user explicitly; do not treat it as passed.",
+        "⚠️ Stop gate STILL failing (not re-blocking — loop_count): bun run check failed. Fix before ending the turn. — if this failure is pre-existing or unfixable, report it to the user explicitly; do not treat it as passed.",
     });
   });
 

--- a/.claude/hooks/stop-gate.test.ts
+++ b/.claude/hooks/stop-gate.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Exercise .claude/hooks/stop-gate.sh against the payloads and step outcomes it
+ * has to judge.
+ *
+ * Two of its decisions cost a turn's report when they break, and both broke:
+ * a failure body over ARG_MAX made `jq --arg` fail with E2BIG, so the gate ended
+ * the turn having printed nothing, and a LINK_NOTE left at "clean" contradicted
+ * the link failure in the same body. Each case runs the real hook against a
+ * scratch git repository whose `check`, `test` and link-check steps this file
+ * writes, so no step of this repository's own toolchain runs.
+ */
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, onTestFinished } from "vite-plus/test";
+import { z } from "zod";
+import { readHookJson } from "./hook-output";
+
+const GATE = path.resolve(import.meta.dirname, "stop-gate.sh");
+
+/** A directory the case owns, removed when the case ends. */
+const scratchDir = (prefix: string): string => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  onTestFinished(() => {
+    fs.rmSync(dir, { force: true, recursive: true });
+  });
+  return dir;
+};
+
+/** A step's stand-in: what `bun run <script>` runs, and what bun executes for the link check. */
+interface Steps {
+  check: string;
+  test: string;
+  /** The body of the check-md-links.ts stand-in bun runs directly. */
+  links: string;
+}
+
+const PASSING: Steps = {
+  check: "exit 0",
+  links: "process.exit(0);",
+  test: "exit 0",
+};
+
+/**
+ * A committed git repository with the three step stand-ins in place, plus the
+ * named files left untracked so `git status --porcelain` reports them and
+ * CODE_CHANGED counts them.
+ */
+const scratchRepo = (steps: Steps, untracked: readonly string[]): string => {
+  const root = scratchDir("stop-gate-");
+  fs.mkdirSync(path.join(root, ".claude/hooks"), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, "package.json"),
+    `${JSON.stringify({
+      name: "stop-gate-scratch",
+      scripts: { check: steps.check, test: steps.test },
+    })}\n`
+  );
+  fs.writeFileSync(
+    path.join(root, ".claude/hooks/check-md-links.ts"),
+    `${steps.links}\n`
+  );
+  // The identity comes from the environment because a CI runner's git has
+  // none, and signing is turned off because a machine whose global config
+  // signs every commit has no key for this scratch repository.
+  const git = (...args: string[]): void => {
+    const result = spawnSync(
+      "git",
+      ["-c", "commit.gpgsign=false", "-c", "init.defaultBranch=main", ...args],
+      {
+        cwd: root,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          GIT_AUTHOR_EMAIL: "gate@example.com",
+          GIT_AUTHOR_NAME: "gate",
+          GIT_COMMITTER_EMAIL: "gate@example.com",
+          GIT_COMMITTER_NAME: "gate",
+        },
+      }
+    );
+    if (result.status !== 0) {
+      throw new Error(`git ${args.join(" ")} failed: ${result.stderr}`);
+    }
+  };
+  git("init", "--quiet");
+  git("add", "package.json", ".claude/hooks/check-md-links.ts");
+  git("commit", "--quiet", "-m", "scaffolding");
+  untracked.forEach((name) => {
+    fs.writeFileSync(path.join(root, name), "x\n");
+  });
+  return root;
+};
+
+/**
+ * The gate's own output shape. Each field defaults to "" so a run that emitted
+ * nothing, and one whose branch emits no `decision`, both read as absent rather
+ * than as a parse failure.
+ */
+const GateOutput = z.object({
+  decision: z.string().default(""),
+  reason: z.string().default(""),
+  systemMessage: z.string().default(""),
+});
+
+/** What one Stop gate run reported. */
+type GateRun = z.infer<typeof GateOutput> & {
+  status: number | null;
+  stderr: string;
+  stdout: string;
+};
+
+/** The Stop payload the harness sends. JSON.stringify drops the absent fields. */
+interface StopPayload {
+  cwd: string;
+  hook_event_name: string;
+  loop_count: number | undefined;
+  stop_hook_active: boolean | undefined;
+}
+
+interface RunOptions {
+  /** Overrides the payload's `cwd`, which the gate prefers over CLAUDE_PROJECT_DIR. */
+  cwd?: string;
+  loopCount?: number;
+  path?: string;
+  projectDir?: string;
+  stopHookActive?: boolean;
+}
+
+const runGate = (root: string, options: RunOptions = {}): GateRun => {
+  const payload: StopPayload = {
+    cwd: options.cwd ?? root,
+    hook_event_name: "Stop",
+    loop_count: options.loopCount,
+    stop_hook_active: options.stopHookActive,
+  };
+  const result = spawnSync("bash", [GATE], {
+    cwd: root,
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      CLAUDE_PROJECT_DIR: options.projectDir ?? root,
+      PATH: options.path ?? process.env.PATH,
+    },
+    input: JSON.stringify(payload),
+    maxBuffer: 8 * 1024 * 1024,
+  });
+  return {
+    ...readHookJson(result.stdout, GateOutput),
+    status: result.status,
+    stderr: result.stderr,
+    stdout: result.stdout,
+  };
+};
+
+/**
+ * The gate's warning branch puts the failure body in the same string as its
+ * summary, separated by a newline, so a case about the summary reads this.
+ */
+const firstLine = (text: string): string => text.split("\n")[0] ?? "";
+
+/**
+ * A PATH resolving the named commands and nothing else, so `command -v bun`
+ * answers no while the commands the gate needs before it still resolve. `bash`
+ * is one of them because node looks the gate's own interpreter up on this PATH.
+ */
+const pathWithOnly = (names: readonly string[]): string => {
+  const dir = scratchDir("stop-gate-path-");
+  const searched = (process.env.PATH ?? "").split(path.delimiter);
+  names.forEach((name) => {
+    const found = searched
+      .map((searchDir) => path.join(searchDir, name))
+      .find((candidate) => fs.existsSync(candidate));
+    if (found === undefined) {
+      throw new Error(`${name} is not on PATH, so this case cannot run`);
+    }
+    fs.symlinkSync(found, path.join(dir, name));
+  });
+  return dir;
+};
+
+describe("stop-gate.sh", () => {
+  it("should stay silent when the tree holds no change", () => {
+    const root = scratchRepo(PASSING, []);
+
+    const run = runGate(root);
+
+    expect({ status: run.status, stdout: run.stdout }).toStrictEqual({
+      status: 0,
+      stdout: "",
+    });
+  });
+
+  it("should skip the quality gate when only a docs file changed", () => {
+    const root = scratchRepo(PASSING, ["notes.md"]);
+
+    const run = runGate(root);
+
+    expect(run.systemMessage).toBe(
+      "✅ Stop gate: no code-relevant changes (quality gate skipped, md links: clean)"
+    );
+  });
+
+  it("should report the quality gate and the link check as passing when a code file changed and every step succeeds", () => {
+    const root = scratchRepo(PASSING, ["a.ts"]);
+
+    const run = runGate(root);
+
+    expect(run.systemMessage).toBe(
+      "✅ Stop gate: typecheck / lint / format and the test suite pass (md links: clean)"
+    );
+  });
+
+  it("should block and name the step when the quality gate fails", () => {
+    const root = scratchRepo({ ...PASSING, check: "exit 1" }, ["a.ts"]);
+
+    const run = runGate(root);
+
+    expect({
+      decision: run.decision,
+      status: run.status,
+      systemMessage: run.systemMessage,
+    }).toStrictEqual({
+      decision: "block",
+      status: 0,
+      systemMessage:
+        "⛔ Stop block: bun run check failed. Fix before ending the turn.",
+    });
+  });
+
+  it("should name both steps in one block when the step after a failing one fails too", () => {
+    const root = scratchRepo({ ...PASSING, check: "exit 1", test: "exit 1" }, [
+      "a.ts",
+    ]);
+
+    const run = runGate(root);
+
+    expect(run.systemMessage).toBe(
+      "⛔ Stop block: bun run check, bun run test failed. Fix before ending the turn."
+    );
+  });
+
+  it("should report the link check as failed rather than clean when it fails", () => {
+    const root = scratchRepo(
+      {
+        ...PASSING,
+        links: 'console.log("links said no");\nprocess.exit(1);',
+      },
+      ["a.ts"]
+    );
+
+    const run = runGate(root);
+
+    expect({ decision: run.decision, reason: run.reason }).toStrictEqual({
+      decision: "block",
+      reason: `markdown link check failed. Fix before ending the turn.
+
+===== markdown link check =====
+links said no
+
+md links: FAILED`,
+    });
+  });
+
+  // `jq --arg body "$2"` failed with E2BIG here (ARG_MAX is 1048576 on macOS,
+  // and Linux caps one argument at 131072), and the gate's own `exit` then
+  // ended the turn having printed nothing at all.
+  it("should carry the whole failure body into the block when that body is larger than ARG_MAX", () => {
+    const fillerBytes = 1_500_000;
+    const root = scratchRepo(
+      {
+        ...PASSING,
+        // `process.exit` after a write this large on a pipe dropped everything
+        // past 65 KB, so the exit code is set and the runtime flushes on its own.
+        links: `process.stdout.write("x".repeat(${fillerBytes}) + "\\ntail-marker\\n");\nprocess.exitCode = 1;`,
+      },
+      ["a.ts"]
+    );
+    // The reason is this head, the filler, and this tail; the whole 1.5 MB
+    // string is never built here, because only its length is compared.
+    const head =
+      "markdown link check failed. Fix before ending the turn.\n\n===== markdown link check =====\n";
+    const tail = "\ntail-marker\n\nmd links: FAILED";
+
+    const run = runGate(root);
+
+    expect({
+      decision: run.decision,
+      reasonBytes: run.reason.length,
+      reasonTail: run.reason.slice(-tail.length),
+    }).toStrictEqual({
+      decision: "block",
+      reasonBytes: head.length + fillerBytes + tail.length,
+      reasonTail: tail,
+    });
+  });
+
+  it("should warn instead of blocking when Claude Code reports this Stop was already blocked", () => {
+    const root = scratchRepo({ ...PASSING, check: "exit 1" }, ["a.ts"]);
+
+    const run = runGate(root, { stopHookActive: true });
+
+    expect({
+      decision: run.decision,
+      summary: firstLine(run.systemMessage),
+    }).toStrictEqual({
+      decision: "",
+      summary:
+        "⚠️ Stop gate STILL failing (not re-blocking — stop_hook_active): bun run check failed. Fix before ending the turn. — if this failure is pre-existing or unfixable, report it to the user explicitly; do not treat it as passed.",
+    });
+  });
+
+  it("should warn instead of blocking when Cursor reports an auto-followup already ran", () => {
+    const root = scratchRepo({ ...PASSING, check: "exit 1" }, ["a.ts"]);
+
+    const run = runGate(root, { loopCount: 1 });
+
+    expect({
+      decision: run.decision,
+      summary: firstLine(run.systemMessage),
+    }).toStrictEqual({
+      decision: "",
+      summary:
+        "⚠️ Stop gate STILL failing (not re-blocking — stop_hook_active): bun run check failed. Fix before ending the turn. — if this failure is pre-existing or unfixable, report it to the user explicitly; do not treat it as passed.",
+    });
+  });
+
+  it("should report the link check as skipped rather than clean when bun is not installed", () => {
+    const root = scratchRepo(PASSING, ["notes.md"]);
+
+    const run = runGate(root, {
+      path: pathWithOnly(["bash", "cat", "git", "grep", "jq", "sort"]),
+    });
+
+    expect(run.systemMessage).toBe(
+      "✅ Stop gate: no code-relevant changes (quality gate skipped, md links: SKIPPED (bun not installed))"
+    );
+  });
+
+  // The scratch repository's `check` fails, so a gate that carried on in the
+  // wrong tree would block naming `bun run check` rather than the root.
+  it("should block naming the unreachable root when it cannot enter the tree to judge", () => {
+    const root = scratchRepo({ ...PASSING, check: "exit 1" }, ["a.ts"]);
+    const missing = path.join(root, "gone");
+
+    const run = runGate(root, { cwd: missing, projectDir: missing });
+
+    expect({
+      decision: run.decision,
+      status: run.status,
+      systemMessage: run.systemMessage,
+    }).toStrictEqual({
+      decision: "block",
+      status: 0,
+      systemMessage: `⛔ Stop block: the Stop gate could not enter ${missing}, so no check ran.`,
+    });
+  });
+});

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,8 +24,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Installs every tool in mise.toml and exports them on PATH for the
-      # steps below, so mise.toml is the one place the node, bun and actionlint
-      # versions are written.
+      # steps below, so mise.toml is the one place those versions are written.
       - name: Install the toolchain from mise.toml
         uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,6 +74,13 @@ jobs:
       - name: Lint GitHub Actions workflows (actionlint)
         run: actionlint
 
+      # The shell counterpart of the step above, over every tracked `*.sh`: the
+      # PreToolUse, Stop and SessionStart hooks and the two setup scripts. It
+      # sits here rather than beside "Run Tests" so a finding in a hook fails
+      # ahead of the check, knip, doctor, test and build steps below.
+      - name: Lint the shell hooks and scripts (shellcheck)
+        run: bun run check:shell
+
       # `bg-sidebar` and `text-chart-3` are tokens only src/styles.css defines,
       # so sorting them proves the formatter resolved that stylesheet. When it
       # cannot, oxfmt leaves the classes untouched and still exits 0, which no

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ TanStack Start + TypeScript + Tailwind CSS + shadcn/ui を使用したモダン�
 ```bash
 git clone <your-repo-url>
 cd <your-repo-name>
-mise install                 # Node / Bun / actionlint を mise.toml の版で用意
+mise install                 # Node / Bun / actionlint / shellcheck を mise.toml の版で用意
 cargo install similarity-ts  # lefthook の pre-push が回す重複検出（Rust 製）
 cp .env.local.example .env.local
 bun run setup                # 依存・git hooks・生成ファイルをまとめて用意
@@ -41,7 +41,7 @@ bun run dev
 
 ## Tools
 
-- **[mise](https://mise.jdx.dev/)**：Node / Bun / actionlint のバージョン固定 (`mise.toml`)
+- **[mise](https://mise.jdx.dev/)**：Node / Bun / actionlint / shellcheck のバージョン固定 (`mise.toml`)
 - **[shadcn/ui](https://ui.shadcn.com/)**：UI components (`components.json`)
 - **[TypeScript 7](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/)**：Type checker (Go-native `tsc`)
 - **[Vite+](https://viteplus.dev/)**：Vite / Vitest / oxlint / oxfmt を束ねる CLI。設定は `vite.config.ts` の `lint` / `fmt` ブロックに集約される
@@ -55,6 +55,7 @@ bun run dev
 - **[knip](https://knip.dev/)**：Unused deps/exports/files detection (`knip.json`)
 - **[similarity-ts](https://github.com/mizchi/similarity)**：Code similarity detector
 - **[actionlint](https://github.com/rhysd/actionlint)**：GitHub Actions workflow checker (`mise.toml` が版を固定)
+- **[shellcheck](https://www.shellcheck.net/)**：tracked な `*.sh` の静的検査。`bun run check:shell` が lefthook の pre-push と CI の両方から呼ぶ (`mise.toml` が版を固定)
 
 ## プロジェクト構成
 

--- a/knip.json
+++ b/knip.json
@@ -8,6 +8,7 @@
     "src/lib/utils.ts"
   ],
   "project": ["src/**/*.{ts,tsx,css}"],
+  "ignoreBinaries": ["shellcheck"],
   "ignoreDependencies": ["oxlint-plugin-react-doctor"],
   "ignore": ["src/server/cloudflare.ts", "src/test/**/*.{ts,tsx}"]
 }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -42,6 +42,14 @@ pre-push:
       run: mise exec -- actionlint
       skip:
         - run: "! command -v mise"
+    # The shell counterpart of the step above, over every tracked `*.sh`: the
+    # PreToolUse, Stop and SessionStart hooks and the two setup scripts, which
+    # no other step here reads. It goes through `mise exec` for the same PATH
+    # reason, and skips on the same missing binary.
+    shellcheck:
+      run: mise exec -- bun run check:shell
+      skip:
+        - run: "! command -v mise"
     # `similarity-ignore` comments are honoured by similarity-ts itself, and
     # without --fail-on-duplicates it exits 0 whatever it finds. The skip keeps a
     # machine that never installed this cargo binary from being unable to push

--- a/mise.toml
+++ b/mise.toml
@@ -2,3 +2,6 @@
 node = "26.7.0"
 bun = "1.3.1"
 actionlint = "1.7.12"
+# `bun run check:shell` calls this, and it comes from here rather than from
+# node_modules, so knip.json lists it under ignoreBinaries.
+shellcheck = "0.11.0"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "check": "vp check",
     "check:fix": "vp check --fix",
     "check:pins": "bun scripts/check-toolchain-pins.ts",
+    "check:shell": "shellcheck $(git ls-files '*.sh')",
     "typecheck": "vp check --no-fmt --no-lint",
     "cf-typegen": "wrangler types --env-interface CloudflareEnv",
     "cf-typegen:check": "wrangler types --check --env-interface CloudflareEnv",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "check": "vp check",
     "check:fix": "vp check --fix",
     "check:pins": "bun scripts/check-toolchain-pins.ts",
-    "check:shell": "shellcheck $(git ls-files '*.sh')",
+    "check:shell": "git ls-files -z '*.sh' | xargs -0r shellcheck",
     "typecheck": "vp check --no-fmt --no-lint",
     "cf-typegen": "wrangler types --env-interface CloudflareEnv",
     "cf-typegen:check": "wrangler types --check --env-interface CloudflareEnv",

--- a/scripts/cloud-agent-install.sh
+++ b/scripts/cloud-agent-install.sh
@@ -21,6 +21,7 @@ mise exec -- bun run cf-typegen
 # rc を読むシェル(対話・ログイン)に shims の PATH を通す。
 # rc を読まないワンショットの非対話シェルには届かないため、そこでは
 # `mise exec -- <cmd>` を使う(このスクリプト自身も上でそうしている)
+# shellcheck disable=SC2016 # the rc file this line is appended to expands it
 shims_line='export PATH="$HOME/.local/bin:$HOME/.local/share/mise/shims:$PATH"'
 for rc in "$HOME/.bashrc" "$HOME/.profile"; do
   grep -qsF 'mise/shims' "$rc" || printf '%s\n' "$shims_line" >>"$rc"

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -3,7 +3,7 @@ import { CodeBlock } from "@/components/shared/code-block/code-block";
 
 const SETUP = `git clone https://github.com/imaimai17468/imaimai-front-templete.git
 cd imaimai-front-templete
-mise install                 # Node / Bun / actionlint を mise.toml の版で用意
+mise install                 # Node / Bun / actionlint / shellcheck を mise.toml の版で用意
 cargo install similarity-ts  # Stop gate の重複検出（Rust 製）
 bun install
 bun run generate-routes

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -158,22 +158,25 @@ export default defineConfig({
       },
       {
         // These files are run as commands, so what they write to stdout is the
-        // report their caller reads rather than leftover debugging.
+        // report their caller reads rather than leftover debugging. They also
+        // iterate for effect rather than for a value, writing a scratch file
+        // per name or a line per finding, and the remedy `no-array-for-each`
+        // asks for is `for...of`, which `style-rules/no-loops` forbids.
         files: CLI_ENTRYPOINTS,
-        rules: { "no-console": "off" },
+        rules: {
+          "no-console": "off",
+          "unicorn/no-array-for-each": "off",
+        },
       },
       {
-        // The script drives a hook and parses its JSON stdout, so `unknown` is
-        // what the input actually is, and `Record<string, unknown>` is the
+        // A script drives a command and parses its JSON stdout, so `unknown`
+        // is what the input actually is, and `Record<string, unknown>` is the
         // parsed shape a type guard narrows from: that covers
         // no-unknown-parameters and no-unsafe-dictionary-type.
-        // `no-array-for-each` is dropped because the remedy it asks for is
-        // `for...of`, which `style-rules/no-loops` forbids.
         files: ["scripts/**"],
         rules: {
           "anti-slop/no-unknown-parameters": "off",
           "anti-slop/no-unsafe-dictionary-type": "off",
-          "unicorn/no-array-for-each": "off",
         },
       },
       {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -157,11 +157,12 @@ export default defineConfig({
         rules: { "vitest/require-hook": "off" },
       },
       {
-        // These files are run as commands, so what they write to stdout is the
-        // report their caller reads rather than leftover debugging. They also
-        // iterate for effect rather than for a value, writing a scratch file
-        // per name or a line per finding, and the remedy `no-array-for-each`
-        // asks for is `for...of`, which `style-rules/no-loops` forbids.
+        // The scripts and hooks here are run as commands, so what they write
+        // to stdout is the report their caller reads rather than leftover
+        // debugging, and the hook tests beside them iterate for effect rather
+        // than for a value, writing a scratch file per name. The remedy
+        // `no-array-for-each` asks for is `for...of`, which
+        // `style-rules/no-loops` forbids.
         files: CLI_ENTRYPOINTS,
         rules: {
           "no-console": "off",

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -15,7 +15,6 @@ export const coverageExclude = [
   "scripts/check-cursor-rule-mirrors.ts",
   "scripts/check-toolchain-pins.ts",
   "scripts/orchestrate.ts",
-  "scripts/test-bash-guard.ts",
   // include のパターンは picomatch の contains モードで照合されるので
   // `*.ts` が `.tsx` にも当たる。コンポーネントはこの行で外れる。
   "src/**/*.tsx",


### PR DESCRIPTION
## What improves

`.claude/hooks/pre-bash-guard.sh` (595 lines, three gates) and
`.claude/hooks/stop-gate.sh` (139 lines then) carried this repository's gates
with nothing automatic behind them: `scripts/test-bash-guard.ts` appeared in
neither `.github/workflows/ci.yaml` nor `lefthook.yml`, `bun run test` did not
collect it because it is not named `*.test.ts`, and `stop-gate.sh` had no cases
at all. A hook change could merge with its cases never run. Now both hooks run
under `bun run test`, and `shellcheck` reads every tracked `*.sh` on pre-push
and in CI.

Test count: 504 tests in 22 files before, 723 in 25 after (+202 moved,
+21 new). On this pull request's own CI runs the `Run Tests` step went from
4.20 s at 504 tests to 8.24 s at 717; locally `bun run test` went from 29.6 s
to 24.0 s, because the added files fit inside the parallel worker pool.

## The four decisions, each with its reason

**`scripts/test-bash-guard.ts` moves to `.claude/hooks/pre-bash-guard.test.ts`
and runs under `bun run test`.** `.claude/hooks/check-md-links.test.ts` already
runs there (`bunx vitest list` names it), so the directory is one vitest
collects, and `coverage.include` in `vitest.config.mts` lists only `src/**`,
`tools/**` and `scripts/**`, so a test in `.claude/hooks/` needs neither a
coverage threshold of its own nor an exclusion entry. Its header argued the
other way: "vitest would then run it on every `bun run test` and in CI, where a
hook that only runs during local agent sessions has nothing to report." What
that reason costs, measured here: the 202 cases each fork the hook, which forks
jq and awk, so they took 47.4 s run one after another on a loaded macOS
machine. `describe.concurrent` brings that to 17.9 s there, and on the CI
runner the whole step costs 8.24 s. The header's other half was right that the
payoff stays invisible until a hook breaks, which is how the cases drifted out
of every gate in the first place.

**`stop-gate.sh` is covered in this ticket rather than named as the next one.**
It is fed JSON on stdin and answers with JSON, so the harness shape is the
guard's. Both defects found by hand on 2026-09-08 are now pinned: the `jq
--arg` that failed with E2BIG on a large failure body and printed nothing, and
the `LINK_NOTE` left at "clean" in a body reporting a link failure. Each case
runs the real hook against a scratch git repository whose `check`, `test` and
link-check steps the test file writes, so no step of this repository's own
toolchain runs inside a case.

**`shellcheck` joins the toolchain, pinned in `mise.toml` at 0.11.0** (the
latest release, tagged v0.11.0 on 2025-08-04). The pin costs one more tool per
machine and adds nothing to CI beyond the check itself, because
`jdx/mise-action` already installs everything in `mise.toml` and exports it on
PATH, which is how `actionlint` is called bare today. Against that: 877 lines
of tracked shell across the three hooks and two scripts, which four workers on
2026-09-08 each reported as not statically linted, and by hand found four real
bypasses in. `shellcheck` found one real defect on its first run, fixed below.
It also reports SC2016 on one line of `pre-bash-guard.sh` and one of
`scripts/cloud-agent-install.sh`, where single-quoted `$(`, `${` and backtick
text is matched or written as literal text; each carries a
`# shellcheck disable=SC2016` naming that reason. A repo-wide `disable=SC2016`
in a `.shellcheckrc` was the first draft and is not what landed: it would have
dropped the rule for the other three scripts and every one added later, on the
evidence of two lines.

**The CI step is `Lint the shell hooks and scripts (shellcheck)` and sits right
after `Lint GitHub Actions workflows (actionlint)`.** The two are counterparts,
and from there a finding in a hook fails ahead of the `check`, `knip`,
`doctor`, `test` and `build` steps rather than after them. The guard and Stop
cases need no CI step of their own: the existing `Run Tests` step runs them.

## The one hook fix this forced

`shellcheck` reported SC2164 on `stop-gate.sh`: `cd "$ROOT"` with no failure
branch, under `set -uo pipefail` where `-e` is off. A `cd` that failed left
every step below judging whatever tree the session was started from. Reverting
the fix and running the suite showed exactly that: the gate ran `bun run check`
in the test's own cwd and blocked naming that step. The `cd` now sits below
`emit_block`'s definition and emits the gate's own `decision: "block"`,
because a root the gate cannot enter is the one failure where nothing at all
ran, and a bare `exit 1` is a non-blocking hook error that would have made it
the quietest branch in the file. Nothing between the old position and the new
one reads the working directory.

Two comments named what this change moved and are reconciled:
`pre-bash-guard.sh`'s reference to `scripts/test-bash-guard.ts`, and
`session-start-env-check.sh`'s line saying a missing `mise` skips only the
workflow check, which now skips the shellcheck run too.

## Mutations run

Every case was checked by breaking the behaviour it pins, running the file, and
restoring. Sixteen mutations, all caught, none survived. Each of the 13 Stop
cases fails under at least one of the eleven below.

`stop-gate.sh`:

| mutation | case that failed |
| --- | --- |
| `--rawfile body /dev/stdin` back to `--arg body "$2"` | the ARG_MAX body case |
| `LINK_NOTE="md links: FAILED"` to `"clean"` | the link-failure case, and the ARG_MAX one |
| the `cd` failure branch removed | the unreachable-root case |
| the `git status` exit-status check removed | the unreadable-git-status case |
| the `loop_count` branch removed from the jq | the Cursor auto-followup case |
| `FAILED_STEPS="${FAILED_STEPS:+…, }$1"` to `="$1"` | the both-steps-named case |
| `ts` dropped from the code-relevant extensions | five cases |
| `LINK_NOTE="md links: SKIPPED (bun not installed)"` to `"clean"` | the bun-absent case |
| the no-changes early exit removed | the clean-tree case |
| the final `-gt 0` to `-ge 0` | the docs-only case, and the bun-absent one |
| the three lines preferring the payload's `cwd` deleted | the worktree-session case |

`pre-bash-guard.sh`:

| mutation | cases that failed |
| --- | --- |
| `-delete` removed from the find action list | 2 |
| the quote strip removed from the env-file grep | 2 |
| the `-A` branch removed from the `git add` walk | 1 |
| a `command not found` line inserted after `set -euo pipefail` | 202 |
| `exit 1` inserted after `INPUT=$(cat)` | 202 |

The first three check that the move to vitest still catches a break in a gate.
The last two are the harness itself: before the exit status and the empty
stderr were asserted, the `exit 1` left the 71 allow-expecting cases green.

The `-A` mutation fails one of the eight `git add -A` cases, because a bare
`git add -A` is still refused by the walk's "it names no path to stage" branch.
That is the guard's design rather than a gap in the cases.

Deleting the `# shellcheck disable=SC2016` from `pre-bash-guard.sh` and running
`bun run check:shell` reports the two findings again, so the directive is not
dead. Appending an `[ p -a q ]` test to `scripts/setup.sh` makes
`bun run check:shell` exit 1 on SC2166, so the gate blocks on a warning rather
than only on an error.

## Findings raised in review and what happened to them

Two holes the review found in the harness, both fixed and both with the
mutation that proves it:

- **A hook that died read as `allow`, so 71 of the 202 cases passed on a dead
  guard.** `pre-bash-guard.sh` prints nothing on an allow, and a hook that dies
  before printing produces the same empty stdout: with `exit 1` inserted after
  `INPUT=$(cat)`, the 71 allow-expecting cases stayed green. Every `exit` in
  that hook is `exit 0`, both deny sites included, so a case now asserts the
  exit status and an empty stderr alongside the decision in one `expect`. With
  the same `exit 1` inserted, all 202 fail. The stderr half also catches the
  reviewer's own reproduction, `env PATH=/bin bash pre-bash-guard.sh`, which
  exits 127 with nothing on stdout.
- **The Stop gate's preference for the payload's `cwd` over
  `CLAUDE_PROJECT_DIR` was unpinned**, because every case passed the same
  directory as both. That is the branch a worktree session depends on, and the
  three lines could be deleted with all 11 cases still green. A twelfth case
  passes a clean session tree and a dirty work tree; deleting those lines fails
  it alone.

Four comments and documents that named what this change moved:
`.github/workflows/ci.yaml`'s mise comment enumerated three tools where
`mise.toml` now pins four; `vite.config.ts`'s `CLI_ENTRYPOINTS` comment said
"these files are run as commands" while the glob had grown two test files;
`README.md` (three places) and `src/routes/index.tsx`'s rendered `SETUP` block
stopped at actionlint, so a reader who followed them met a pre-push step whose
binary the document never named.

`check:shell` was `shellcheck $(git ls-files '*.sh')`, an unquoted substitution
that would split a path containing a space into two nonexistent paths. It is
now `git ls-files -z '*.sh' | xargs -0r shellcheck`; `printf 'a b.sh\0' |
xargs -0 -n99 printf` passes `[a b.sh]` as one argument, and `-r` guards
against an empty list reaching shellcheck with no arguments. `/usr/bin/xargs`
on Darwin 25.5.0 accepts `-0r` and exits 0 on a one-item list and on an empty
one, and CI's `ubuntu-latest` runner has passed `bun run check:shell` on every
run of this branch.

`readHookJson` is pure and `.claude/hooks/` is outside `coverage.include`, so
no per-file branch threshold reaches it. Bringing the directory inside would
mean raising `check-md-links.ts` from 82.79% branch to 100%, which is its own
ticket, so `.claude/hooks/hook-output.test.ts` pins both branches with cases
instead of with a number.

From the earlier cleanup round:

- The "trim stdout, treat silence as empty, parse, validate" reader was written
  twice in sibling files. It is now `readHookJson` in
  `.claude/hooks/hook-output.ts`, called by both.
- The ARG_MAX case built a 1.5 MB string twice to read its length. It computes
  the length from the head, the filler size and the tail instead.
- `describe.concurrent` on the Stop cases was proposed for the 9.6 s they take.
  Not applied: `runGate` uses `spawnSync`, which blocks the worker thread, so
  `.concurrent` alone would overlap nothing, and at 9.6 s that file is not the
  suite's longest, so its serial time hides behind `pre-bash-guard.test.ts` in
  the worker pool.
- `Decision` keeps `ask`, which no case expects, because the find gate's own
  comment weighs emitting it and argues against it; the harness now says so
  where `DECISIONS` is declared, instead of leaving a reader to scan 202 cases.

### The second review round

`cubic` raised four findings against the last commit. Three are fixed here and
the fourth is the decision below.

- **A failing `git status` passed the turn as a clean tree.** `git status
  --porcelain` prints nothing on stdout when it fails, and the emptiness test
  that skips a clean tree read that silence as "no changes" and exited 0, so a
  gate pointed at a directory it could not read as a repository ended the turn
  having run no check. The exit status is now captured beside the output and
  tested first, blocking through the same `emit_block` the failed-`cd` path
  uses, and stderr joins stdout so the block carries git's own message rather
  than a cause the gate guessed. A case writes `.git` as a file holding text
  that is not a gitfile pointer, which makes `git status` exit 128 with empty
  stdout without walking up to any repository above the scratch directory;
  deleting the new check fails that case alone.
- **The downgrade message named `stop_hook_active` on a Cursor turn.** The
  boolean `STOP_ACTIVE` became `DOWNGRADE_CAUSE`, holding the name of the field
  that fired, and jq interpolates it, so a Cursor turn now reads
  `not re-blocking — loop_count`. This reverses the call recorded in the
  previous round, which kept the wording and left it to you: the finding is
  that the message states something false about the payload in front of it,
  which the two cases now pin separately.
- **`hook-output.ts`'s comment described another file's assertions.** Its last
  clause said the pre-bash-guard cases assert the hook's exit status, which
  AGENTS.md's "A comment's subject never lives outside what it ships with"
  bans, and which goes stale the moment those cases move. It now says what this
  module does: silence is not distinguishable here, so a caller that needs to
  tell the two apart reads the exit status.

### The code-reviewer round on those fixes

The `code-reviewer` agent read the three fixes before they were committed and
returned two, both applied.

- **The block threw git's diagnostic away and asserted a cause it had not
  read.** The first draft sent stderr to `/dev/null` and wrote "That directory
  is not a readable git repository" into the body. Running
  `GIT_TEST_ASSUME_DIFFERENT_OWNER=1 git status --porcelain` against a valid
  scratch repository gives exit 128 with `fatal: detected dubious ownership`
  and the `git config --global --add safe.directory …` line that fixes it, so
  the asserted cause was false there and the one string carrying the remedy was
  discarded. `2>&1` now carries git's message into the body and the invented
  sentence is gone. Both cases were run against the built gate: the broken
  gitfile reports `fatal: invalid gitfile format`, and the dubious-ownership
  one reports its `safe.directory` command. A warning printed on a *successful*
  run lands in `GIT_STATUS` too, which costs a checked run over a clean tree
  and never a skipped one, because that variable feeds only the emptiness test.
- **The "nothing was judged" enumeration was written twice.** The `cd` body and
  the new git-status body each spelled out the five steps, so a sixth step
  would reach one copy and leave the other describing a gate that no longer
  exists. `NOTHING_RAN` is defined once beside `FAILED_STEPS` and both bodies
  end with it; `grep -c 'no typecheck, no lint, no format' .claude/hooks/stop-gate.sh`
  prints 1.

## One finding left for you to decide

`cubic` reported that `xargs -r` in `check:shell` is GNU-only and that
`bun run check:shell` therefore fails on a macOS developer machine with
`xargs: illegal option -- r`, blocking the push, and asked for `-r` to be
dropped. **I did not drop it, because the premise is false on this machine.**
On Darwin 25.5.0 arm64, `printf 'a\0' | /usr/bin/xargs -0r echo GOT` prints
`GOT a` and exits 0, and `printf '' | /usr/bin/xargs -0r echo GOT` prints
nothing and exits 0. `mise exec -- bun run check:shell` in this worktree exits
0 over all tracked `*.sh`, and CI's `ubuntu-latest` runner has passed the same
command with `-r` in place on every run of this branch.

Two things are yours to weigh, because I could not run either. I checked one
macOS version, so a machine old enough that its `/usr/bin/xargs` predates `-r`
would still break; and no GNU `xargs` was on this machine, so what GNU does
with an empty list and no `-r` is untested here. If you keep a macOS that old,
the fix is to drop `-r` and guard the empty list in the script instead. Say so
and I will change it.

## What this leaves open

- `bun run check:shell` reads `git ls-files`, so any `*.sh` added later is
  checked without a list to maintain, and `knip.json` gains an
  `ignoreBinaries` entry for a binary `mise.toml` provides. The reason is
  written at the pin.
- `.claude/hooks/` stays outside `coverage.include`, so a pure module added
  there is not caught by the per-file branch threshold. Raising
  `check-md-links.ts` from 82.79% branch to 100% is what bringing the directory
  inside would cost.
- The 202 guard cases were written and measured on macOS with BSD awk, sed and
  grep. This pull request's CI run answered whether they hold under the GNU
  ones and bash 5: all 722 tests pass on `ubuntu-latest`, and the new
  `Lint the shell hooks and scripts (shellcheck)` step passes there too.

## Files

- `.claude/hooks/pre-bash-guard.test.ts` (new, the moved cases under vitest)
- `.claude/hooks/stop-gate.test.ts` (new)
- `.claude/hooks/hook-output.ts` and `.claude/hooks/hook-output.test.ts`
  (new, the shared stdout reader)
- `.claude/hooks/stop-gate.sh` (the `cd` guard, the `git status` guard, and
  the downgrade cause the warning names)
- `.claude/hooks/pre-bash-guard.sh`, `.claude/hooks/session-start-env-check.sh`,
  `scripts/cloud-agent-install.sh` (comment, message and two shellcheck
  directives)
- `mise.toml`, `package.json`, `lefthook.yml`,
  `.github/workflows/ci.yaml`, `knip.json`, `README.md`,
  `src/routes/index.tsx`
- `vitest.config.mts` (the stale exclusion entry), `vite.config.ts` (the
  `no-array-for-each` override folded into the `CLI_ENTRYPOINTS` block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TW5S9YkMGqwgN3g4sScv9D

