### PR TITLE
fix: pre-bash-guard が木全体を取る git rm を止める

### DIFF
--- a/.claude/hooks/pre-bash-guard.sh
+++ b/.claude/hooks/pre-bash-guard.sh
@@ -5,9 +5,9 @@
 #    grep, head, tail, redirections) could walk around it.
 # 2. find gate — prompt for the `find` shapes that reach past the deny list or
 #    run/delete, while leaving scoped path discovery unattended.
-# 3. unnamed-changes gate — refuse a `git add` (or its `git stage` synonym)
-#    whose operands are not explicit paths, and a `git commit` that takes
-#    changes nobody named, because either puts files in the commit that nobody
+# 3. unnamed-changes gate — refuse a `git add` (or its `git stage` synonym) or
+#    a `git rm` whose operands are not explicit paths, and a `git commit` that
+#    takes changes nobody named, because each of the three acts on files nobody
 #    chose.
 
 set -euo pipefail
@@ -299,6 +299,18 @@ fi
 # branch of its own: git answered
 # `fatal: No paths with --include/--only does not make sense.`
 #
+# `git rm` reads its operands as a pathspec too, and reaches the whole tree the
+# same way. Run as `git rm -n` against a scratch repository holding `a.txt`,
+# `sub/b.txt` and `old-dir/c.txt`, each of `-r .`, `-r -- .`, `-rf .`,
+# `--cached -r .`, `-r ./`, `-r :/`, `-r :(top)`, `-r '*'` and `'*.txt'` listed
+# all three, where `-r old-dir` listed that directory's file alone and a bare
+# `git rm` answered `fatal: No pathspec was given. Which files should I
+# remove?` (git 2.50.1, 2026-09-09). Every option `git rm -h` lists apart from
+# `--pathspec-from-file` (dry-run, quiet, cached, force, `-r`, ignore-unmatch,
+# sparse, pathspec-file-nul) changes how it removes rather than which paths, so
+# its operands decide the refusal and its walk carries no flag branch of its
+# own.
+#
 # The text is Guard 1's SCRUBBED, so a `git`/`gh` message body quoting a refused
 # shape stays prose, plus one more heredoc drop so a body written under any other
 # command is prose too. The command is then split on `;|&()` and on newlines,
@@ -321,10 +333,11 @@ fi
 # which otherwise let `g""it add -A` past with no literal `git` in its text.
 
 # Set REFUSED to the reason one operand takes more than it names, and leave it
-# alone when the operand names a path of its own. `git add` and `git commit`
-# both read their operands as a pathspec, so both call this. It assigns rather
-# than printing its answer, because a `$(...)` read-back forks a subshell per
-# operand token on a hook that runs before every Bash call.
+# alone when the operand names a path of its own. `git add`, `git rm` and
+# `git commit` all read their operands as a pathspec, so all three call this.
+# It assigns rather than printing its answer, because a `$(...)` read-back
+# forks a subshell per operand token on a hook that runs before every Bash
+# call.
 refuse_unnamed_operand() { # $1 = one operand token
   case "$1" in
     :*)
@@ -364,16 +377,27 @@ case "$CMD_PLAIN" in
   *git*) ;;
   *) exit 0 ;;
 esac
-# A refusal needs a segment whose token is `add`, `stage` or `commit`, and the
-# heredoc drop below only removes whole lines, so a command whose text holds
-# none of those three names cannot reach one. `git status`, `git log` and
+# A refusal needs a segment whose token is `add`, `stage`, `commit` or `rm`,
+# and the heredoc drop below only removes whole lines, so a command whose text
+# holds none of those four names cannot reach one. `git status`, `git log` and
 # `git push` all leave here instead of forking the awk, where
 # `git diff --staged` walks on because its flag carries `stage`. On a
 # `git status --short` payload, 60 runs of this hook took 20.4 s, 20.2 s and
-# 21.5 s in three rounds with this case, against 23.5 s, 24.3 s and 22.6 s for
-# 60 runs without it (a machine under parallel load, 2026-09-09).
+# 21.5 s in three rounds with the three-name form of this case, against 23.5 s,
+# 24.3 s and 22.6 s for 60 runs without it (a machine under parallel load,
+# 2026-09-09).
+#
+# `rm` is two letters and needs its own token boundaries, where the other three
+# do not. Over 3300 Bash commands taken from this project's session
+# transcripts, the three-name form admitted 429, a bare `*rm*` 580, and the
+# four patterns below 471; `format`, `permission`, `nrm` and `rmtree` are what
+# the extra 151 hold. The four spell "the token `rm`, at either end of the text
+# or with a separator on each side", and the class lists the characters a
+# separator is not. None of the 109 they drop holds a `git rm`, and this guard
+# decides each of those 109 the way it did before `rm` joined the case.
 case "$CMD_PLAIN" in
   *add* | *stage* | *commit*) ;;
+  rm | rm[!A-Za-z0-9_.-]* | *[!A-Za-z0-9_.-]rm | *[!A-Za-z0-9_.-]rm[!A-Za-z0-9_.-]*) ;;
   *) exit 0 ;;
 esac
 REFUSED=""
@@ -444,6 +468,10 @@ while IFS= read -r SEG; do
             SUB=$TOK
             STATE=commit
             ;;
+          rm)
+            SUB=$TOK
+            STATE=remove
+            ;;
           *) break ;;
         esac
         ;;
@@ -485,6 +513,28 @@ while IFS= read -r SEG; do
               *[pie]*) HAS_SELECTION=1 ;;
             esac
             ;;
+          *)
+            refuse_unnamed_operand "$TOK"
+            if [ -n "$REFUSED" ]; then
+              break
+            fi
+            HAS_SELECTION=1
+            ;;
+        esac
+        ;;
+      remove)
+        case "$TOK" in
+          # With a file holding `.`, both
+          # `git rm -n -r --pathspec-from-file=ps.txt` and the prefix spelling
+          # `git rm -n -r --pathspec-from-f ps.txt` listed all three tracked
+          # files of the scratch repository (git 2.50.1, 2026-09-09). The `-f*`
+          # tail matches both, because git's parse-options takes any
+          # unambiguous prefix.
+          --pathspec-f*)
+            REFUSED="\`--pathspec-from-file\` takes its pathspec from a file the command text does not show"
+            break
+            ;;
+          -*) ;;
           *)
             refuse_unnamed_operand "$TOK"
             if [ -n "$REFUSED" ]; then
@@ -555,22 +605,23 @@ while IFS= read -r SEG; do
         ;;
     esac
   done
-  # An allowed `git add` either names a path or selects hunks. This branch is
-  # what makes that the rule rather than a list of bad flags, and it is the only
-  # refusal that `--pathspec-from-file=paths.txt` and
-  # `git diff --name-only | xargs git add` reach: both take their operands from
-  # somewhere the command text does not show. A bare `git add` stages nothing by
-  # itself and prints `hint: Maybe you wanted to say 'git add .'?`
-  # (git 2.50.1), so the refusal names the right form before the hint names the
-  # wrong one. A bare `git commit` takes the set that was already staged, so the
-  # branch is `git add`'s alone.
-  case "$SUB" in
-    add | stage)
-      if [ -z "$REFUSED" ] && [ "$HAS_SELECTION" -eq 0 ]; then
-        REFUSED="it names no path to stage"
-      fi
-      ;;
-  esac
+  # An allowed `git add` either names a path or selects hunks, and an allowed
+  # `git rm` names a path. This branch is what makes that the rule rather than a
+  # list of bad flags, and it is the only refusal that
+  # `--pathspec-from-file=paths.txt` and `git diff --name-only | xargs git add`
+  # reach: both take their operands from somewhere the command text does not
+  # show. A bare `git add` stages nothing by itself and prints
+  # `hint: Maybe you wanted to say 'git add .'?`, and a bare `git rm` answers
+  # `fatal: No pathspec was given. Which files should I remove?`
+  # (git 2.50.1), so the refusal names the right form before git names the
+  # wrong one or gives up. A bare `git commit` takes the set that was already
+  # staged, so it stays out of the branch.
+  if [ -z "$REFUSED" ] && [ "$HAS_SELECTION" -eq 0 ]; then
+    case "$SUB" in
+      add | stage) REFUSED="it names no path to stage" ;;
+      rm) REFUSED="it names no path to remove" ;;
+    esac
+  fi
   # The loop body runs in this shell, so SUB survives the break and names the
   # subcommand the refusal came from.
   if [ -n "$REFUSED" ]; then
@@ -583,13 +634,16 @@ set +f
 if [ -n "$REFUSED" ]; then
   case "$SUB" in
     commit)
-      NEXT_STEP="Stage the files this commit needs (\`git add src/foo.ts src/bar.ts\`, or \`git add -p\` for part of a file), then commit that staged set with \`git commit -m\`."
+      NEXT_STEP="Stage the files this commit needs (\`git add src/foo.ts src/bar.ts\`, or \`git add -p\` for part of a file), then commit that staged set with \`git commit -m\`. \`git status --short\` lists what changed."
+      ;;
+    rm)
+      NEXT_STEP="Name the paths to delete (\`git rm src/foo.ts src/bar.ts\`, or \`git rm -r src/old-dir\` for one directory). \`git ls-files\` lists the tracked paths."
       ;;
     *)
-      NEXT_STEP="Name the files this commit needs (\`git add src/foo.ts src/bar.ts\`), and take part of a file with \`git add -p\`."
+      NEXT_STEP="Name the files this commit needs (\`git add src/foo.ts src/bar.ts\`), and take part of a file with \`git add -p\`. \`git status --short\` lists what changed."
       ;;
   esac
-  deny "PreToolUse(Bash): this \`git ${SUB}\` is refused because ${REFUSED}. ${NEXT_STEP} \`git status --short\` lists what changed."
+  deny "PreToolUse(Bash): this \`git ${SUB}\` is refused because ${REFUSED}. ${NEXT_STEP}"
   exit 0
 fi
 

--- a/.claude/hooks/pre-bash-guard.sh
+++ b/.claude/hooks/pre-bash-guard.sh
@@ -421,6 +421,13 @@ case "$SCRUBBED" in
     ;;
 esac
 WALK_PLAIN=${WALK_PLAIN//[\"\'\`]/}
+# A backslash before a newline is a line continuation the shell splices away,
+# so `git \` on one line and `rm -r .` on the next is one command running
+# `git rm -r .`. The blanket backslash strip below leaves the newline behind,
+# and the segment split reads a newline as a separator, so the walk got `git`
+# and `rm -r .` as two segments and neither is a refusable shape. Joining the
+# pair into a space puts the subcommand back beside its `git`.
+WALK_PLAIN=${WALK_PLAIN//\\$'\n'/ }
 WALK_PLAIN=${WALK_PLAIN//\\/}
 # A line of the split that reads `EOF` does not end the heredoc below, because
 # bash finds that delimiter in the script text before expanding anything into

--- a/.claude/hooks/pre-bash-guard.sh
+++ b/.claude/hooks/pre-bash-guard.sh
@@ -440,6 +440,15 @@ case "$SCRUBBED" in
       scrub_message_body '"' "$GIT_MESSAGE_FLAG")
     ;;
 esac
+# `$'x'` and `$"x"` hand git the same argument `'x'` does, and the quote strip
+# below leaves their `$` behind: `git rm -r $'.'` and `git rm -r .$''` each
+# listed all three tracked files of the scratch repository, where the walk saw
+# the operand `$.` and read it as a name (git 2.50.1, 2026-09-09). Dropping the
+# `$` puts them back on the plain spelling. This runs after the message scrub
+# above rather than before it, so an ANSI-C body stays outside what the scrub
+# takes and `git commit -m $'fix .'` is still refused.
+WALK_PLAIN=${WALK_PLAIN//\$\'/\'}
+WALK_PLAIN=${WALK_PLAIN//\$\"/\"}
 WALK_PLAIN=${WALK_PLAIN//[\"\'\`]/}
 # A backslash before a newline is a line continuation the shell splices away,
 # so `git \` on one line and `rm -r .` on the next is one command running

--- a/.claude/hooks/pre-bash-guard.sh
+++ b/.claude/hooks/pre-bash-guard.sh
@@ -569,7 +569,11 @@ while IFS= read -r SEG; do
           # `git rm -n -r --pathspec-from-f ps.txt` listed all three tracked
           # files of the scratch repository (git 2.50.1, 2026-09-09). The `-f*`
           # tail matches both, because git's parse-options takes any
-          # unambiguous prefix.
+          # unambiguous prefix. It also matches `--pathspec-file-nul`, which
+          # this refusal does not name: git answers that flag on its own with
+          # `fatal: the option '--pathspec-file-nul' requires
+          # '--pathspec-from-file'`, so the over-match costs no working command.
+          # The `git add` and `git commit` walks carry the same pattern.
           --pathspec-f*)
             REFUSED="\`--pathspec-from-file\` takes its pathspec from a file the command text does not show"
             break

--- a/.claude/hooks/pre-bash-guard.sh
+++ b/.claude/hooks/pre-bash-guard.sh
@@ -352,6 +352,26 @@ refuse_unnamed_operand() { # $1 = one operand token
     REFUSED="\`${1}\` names no file or directory of its own"
     return
   fi
+  # An operand that ends at `..` climbs back out of the directory it names:
+  # `git rm -n -r sub/..`, `sub/../` and `sub/../.` each listed all three
+  # tracked files of the scratch repository, where `sub` listed one
+  # (git 2.50.1, 2026-09-09). Trailing `/` and `/.` come off first so all three
+  # spellings meet the same test, and only where `..` is the last component,
+  # which leaves `git add ../sibling/foo.ts` naming its own file.
+  CLIMBS_OUT=$1
+  while :; do
+    case "$CLIMBS_OUT" in
+      */) CLIMBS_OUT=${CLIMBS_OUT%/} ;;
+      */.) CLIMBS_OUT=${CLIMBS_OUT%/.} ;;
+      *) break ;;
+    esac
+  done
+  case "$CLIMBS_OUT" in
+    .. | */..)
+      REFUSED="\`${1}\` ends at \`..\`, so it reaches the directory above the one it names"
+      return
+      ;;
+  esac
   # A glob in the first path component starts its match at the top:
   # `git add '*.ts'` from the repository root staged every `.ts` in the tree,
   # including the ones nobody listed, and `git commit -m x '[ab].txt'` reported

--- a/.claude/hooks/pre-bash-guard.sh
+++ b/.claude/hooks/pre-bash-guard.sh
@@ -440,6 +440,14 @@ case "$SCRUBBED" in
       scrub_message_body '"' "$GIT_MESSAGE_FLAG")
     ;;
 esac
+# The heredoc drop reads the raw text, ahead of the strips below, because the
+# backslash strip turns `echo a \<\< MARK` into a heredoc opener the shell
+# never saw: bash ran the next line of `echo a \<\< MARK` / `echo LINE2_RAN` /
+# `MARK` and printed `a << MARK` and `LINE2_RAN`, where the awk read `MARK` as
+# a delimiter and dropped both lines after it. Written as `echo "a << MARK"`
+# the two `<` are adjacent in the raw text as well, and the awk has no quote
+# state to tell that pair from an opener, so that spelling still drops them.
+WALK_PLAIN=$(printf '%s' "$WALK_PLAIN" | drop_heredoc_body)
 # `$'x'` and `$"x"` hand git the same argument `'x'` does, and the quote strip
 # below leaves their `$` behind: `git rm -r $'.'` and `git rm -r .$''` each
 # listed all three tracked files of the scratch repository, where the walk saw
@@ -458,11 +466,7 @@ WALK_PLAIN=${WALK_PLAIN//[\"\'\`]/}
 # pair into a space puts the subcommand back beside its `git`.
 WALK_PLAIN=${WALK_PLAIN//\\$'\n'/ }
 WALK_PLAIN=${WALK_PLAIN//\\/}
-# A line of the split that reads `EOF` does not end the heredoc below, because
-# bash finds that delimiter in the script text before expanding anything into
-# the body.
-CMD_TEXT=$(printf '%s' "$WALK_PLAIN" | drop_heredoc_body)
-CMD_SEGMENTS=${CMD_TEXT//[;|\&()]/$'\n'}
+CMD_SEGMENTS=${WALK_PLAIN//[;|\&()]/$'\n'}
 # A bare `*` operand has to survive word splitting as itself rather than
 # expanding to the working directory's entries.
 set -f

--- a/.claude/hooks/pre-bash-guard.test.ts
+++ b/.claude/hooks/pre-bash-guard.test.ts
@@ -48,6 +48,7 @@ const HookOutput = z.object({
   hookSpecificOutput: z
     .object({ permissionDecision: z.string().optional() })
     .optional(),
+  reason: z.string().optional(),
 });
 
 const asDecision = (permissionDecision: string | undefined): Decision =>
@@ -86,19 +87,35 @@ interface HookRun {
   stderr: string;
 }
 
-const runHook = async (command: string): Promise<HookRun> => {
+const hookStdout = async (
+  command: string
+): Promise<[string, string, number | null]> => {
   const hook = spawn("bash", [HOOK], {
     env: { ...process.env, CLAUDE_PROJECT_DIR: REPO },
   });
   hook.stdin.end(
     JSON.stringify({ tool_input: { command }, tool_name: "Bash" })
   );
-  const [stdout, stderr, status] = await Promise.all([
+  return await Promise.all([
     text(hook.stdout),
     text(hook.stderr),
     exitStatusOf(hook),
   ]);
+};
+
+const runHook = async (command: string): Promise<HookRun> => {
+  const [stdout, stderr, status] = await hookStdout(command);
   return { decision: readDecision(stdout), status, stderr };
+};
+
+/**
+ * The sentence a refusal hands the agent, which `runHook` drops. A case built
+ * on the decision alone cannot tell one subcommand's remediation from
+ * another's, so `git rm` could be told to run `git add`.
+ */
+const refusalOf = async (command: string): Promise<string> => {
+  const [stdout] = await hookStdout(command);
+  return readHookJson(stdout, HookOutput).reason ?? "";
 };
 
 interface Case {
@@ -1330,3 +1347,38 @@ group("git rm: a pathspec the command text does not show is refused", [
     why: "the paths sit in a file the guard cannot read, under the prefix spelling git accepts",
   },
 ]);
+
+// Every case above reads the decision, so the sentence a refusal hands the
+// agent is judged here instead: a `git rm` told to stage with `git add` would
+// pass all of them.
+describe.concurrent("the refusal names the subcommand's own next step", () => {
+  it(
+    "should name git rm and git ls-files when a git rm is refused",
+    async () => {
+      await expect(refusalOf(`${RM} -r .`)).resolves.toBe(
+        "PreToolUse(Bash): this `git rm` is refused because `.` names no file or directory of its own. Name the paths to delete (`git rm src/foo.ts src/bar.ts`, or `git rm -r src/old-dir` for one directory). `git ls-files` lists the tracked paths."
+      );
+    },
+    HOOK_TIMEOUT_MS
+  );
+
+  it(
+    "should name git add and git status when a git add is refused",
+    async () => {
+      await expect(refusalOf("git add -A")).resolves.toBe(
+        "PreToolUse(Bash): this `git add` is refused because the short option -A stages every change in the worktree instead of the paths you name. Name the files this commit needs (`git add src/foo.ts src/bar.ts`), and take part of a file with `git add -p`. `git status --short` lists what changed."
+      );
+    },
+    HOOK_TIMEOUT_MS
+  );
+
+  it(
+    "should name staging first when a git commit is refused",
+    async () => {
+      await expect(refusalOf(`${COMMIT} -a`)).resolves.toBe(
+        "PreToolUse(Bash): this `git commit` is refused because the short option -a commits every tracked change in the worktree instead of the ones you staged. Stage the files this commit needs (`git add src/foo.ts src/bar.ts`, or `git add -p` for part of a file), then commit that staged set with `git commit -m`. `git status --short` lists what changed."
+      );
+    },
+    HOOK_TIMEOUT_MS
+  );
+});

--- a/.claude/hooks/pre-bash-guard.test.ts
+++ b/.claude/hooks/pre-bash-guard.test.ts
@@ -1216,6 +1216,42 @@ group("git rm: named paths stay unattended", [
   },
 ]);
 
+// `sub/..` is the directory above `sub`, and the operand test reads the last
+// component rather than searching the whole path, so a `..` in the middle of a
+// named path keeps that path named.
+group("an operand that ends at .. reaches above what it names", [
+  {
+    command: `${RM} -r sub/..`,
+    expected: "block",
+    why: "a removal that climbs back to the repository root",
+  },
+  {
+    command: `${RM} -r sub/../`,
+    expected: "block",
+    why: "the same climb with a trailing slash",
+  },
+  {
+    command: `${RM} -r sub/../.`,
+    expected: "block",
+    why: "the same climb with a trailing dot",
+  },
+  {
+    command: "git add sub/..",
+    expected: "block",
+    why: "the same operand stages everything above sub",
+  },
+  {
+    command: "git add ../sibling/foo.ts",
+    expected: "allow",
+    why: "a .. that is not the last component still names its own file",
+  },
+  {
+    command: `${RM} -r ../sibling/old-dir`,
+    expected: "allow",
+    why: "a directory outside the working directory is still named",
+  },
+]);
+
 // The shell splices a backslash-newline pair away before it reads the command,
 // so each of these runs one `git` with its subcommand beside it.
 group("a line continuation does not split a subcommand from its git", [

--- a/.claude/hooks/pre-bash-guard.test.ts
+++ b/.claude/hooks/pre-bash-guard.test.ts
@@ -3,7 +3,7 @@
  *
  * The guard carries three decisions that are easy to break and impossible to
  * notice: the protected-env-file block, the `find` gate and the unnamed-changes
- * gate over `git add` and `git commit`.
+ * gate over `git add`, `git rm` and `git commit`.
  * Each case below feeds the real hook a synthetic PreToolUse payload and asserts
  * the decision it returns. Nothing in the repository is modified and no command
  * from a case is ever executed.
@@ -29,6 +29,8 @@ const REPO = path.resolve(import.meta.dirname, "../..");
 // Joined so this file's own text is not itself a commit-shaped command.
 const COMMIT_SUB = ["com", "mit"].join("");
 const COMMIT = `git ${COMMIT_SUB}`;
+const RM_SUB = ["r", "m"].join("");
+const RM = `git ${RM_SUB}`;
 
 // `ask` is a decision the guard's find gate weighs emitting and argues against
 // where it denies instead, so a case may come to expect it; none does today.
@@ -1163,5 +1165,67 @@ group("git commit: the shapes that defeated earlier guards here", [
     command: `gh api repos/o/r/pulls/comments/1/replies -f body='Fixed. (${COMMIT} -a is denied now.)'`,
     expected: "block",
     why: "a gh api -f body is not scrubbed, so a parenthesised shape inside it is refused",
+  },
+]);
+
+// `git rm` deletes from the worktree the set `git add` stages, and its
+// operands are read as a pathspec the same way. The `git add` groups above
+// already drive the shared operand test and the prefix walk, so these cases
+// cover what `git rm` adds: the subcommand routing, the flags it has of its
+// own, and the reason it carries when nothing is named.
+group("git rm: a removal that takes the whole tree is refused", [
+  { command: `${RM} -r .`, expected: "block", why: "the working directory" },
+  {
+    command: `${RM} -r -- .`,
+    expected: "block",
+    why: "a -- separator does not make it a path",
+  },
+  {
+    command: `${RM} -rf .`,
+    expected: "block",
+    why: "the force letter in the cluster does not make it a path",
+  },
+  {
+    command: `${RM} --cached -r .`,
+    expected: "block",
+    why: "--cached takes the same set out of the index",
+  },
+  { command: `${RM} -r ./`, expected: "block", why: "bare ./" },
+  {
+    command: `git status && ${RM} -r .`,
+    expected: "block",
+    why: "chained behind another command",
+  },
+]);
+
+group("git rm: named paths stay unattended", [
+  {
+    command: `${RM} -r src/old-dir`,
+    expected: "allow",
+    why: "a bulk delete of one named directory",
+  },
+  {
+    command: `${RM} --cached src/foo.ts`,
+    expected: "allow",
+    why: "an index-only removal of a named path",
+  },
+  {
+    command: `${RM_SUB} -rf node_modules`,
+    expected: "allow",
+    why: "a shell rm opens the segment itself, so the git walk never starts",
+  },
+]);
+
+group("git rm: a pathspec the command text does not show is refused", [
+  { command: RM, expected: "block", why: "no operand at all" },
+  {
+    command: `${RM} -r`,
+    expected: "block",
+    why: "a recursive flag still names no path",
+  },
+  {
+    command: `${RM} --pathspec-from-f paths.txt`,
+    expected: "block",
+    why: "the paths sit in a file the guard cannot read, under the prefix spelling git accepts",
   },
 ]);

--- a/.claude/hooks/pre-bash-guard.test.ts
+++ b/.claude/hooks/pre-bash-guard.test.ts
@@ -108,6 +108,14 @@ interface Case {
 // A heredoc case spans lines, and a test name has to stay on one.
 const oneLine = (command: string): string => command.replaceAll("\n", "\\n");
 
+// A case waits on the other cases of its group, so its wall time tracks the
+// machine's load rather than the hook's own work. At vitest's 5 s default this
+// file failed 18 of its 202 cases in one round of three, and passed the other
+// two, on a machine under parallel load (2026-09-09). Six times that default
+// carried three rounds run beside a `bun run check`, and a hook that hangs
+// still fails.
+const HOOK_TIMEOUT_MS = 30_000;
+
 const group = (title: string, cases: readonly Case[]): void => {
   describe.concurrent(title, () => {
     it.each(
@@ -117,13 +125,17 @@ const group = (title: string, cases: readonly Case[]): void => {
         // truncates the label from the right.
         label: `${one.expected} (${one.why}) \`${oneLine(one.command)}\``,
       }))
-    )("$label", async ({ command, expected }) => {
-      await expect(runHook(command)).resolves.toStrictEqual({
-        decision: expected,
-        status: 0,
-        stderr: "",
-      });
-    });
+    )(
+      "$label",
+      async ({ command, expected }) => {
+        await expect(runHook(command)).resolves.toStrictEqual({
+          decision: expected,
+          status: 0,
+          stderr: "",
+        });
+      },
+      HOOK_TIMEOUT_MS
+    );
   });
 };
 

--- a/.claude/hooks/pre-bash-guard.test.ts
+++ b/.claude/hooks/pre-bash-guard.test.ts
@@ -1216,6 +1216,41 @@ group("git rm: named paths stay unattended", [
   },
 ]);
 
+// `$'x'` is bash's ANSI-C quoting and `$"x"` its locale form; both hand git
+// the argument `'x'` hands it.
+group("a dollar sign before a quote does not hide the operand", [
+  {
+    command: `${RM} -r $'.'`,
+    expected: "block",
+    why: "an ANSI-C quoted working directory",
+  },
+  {
+    command: `${RM} -r .$''`,
+    expected: "block",
+    why: "an empty ANSI-C quote appended to the working directory",
+  },
+  {
+    command: `${RM} -r $"."`,
+    expected: "block",
+    why: "the locale-quoted spelling of the same operand",
+  },
+  {
+    command: "git add $'-A'",
+    expected: "block",
+    why: "the same spelling around a blanket stage flag",
+  },
+  {
+    command: `${COMMIT} -m $'fix .'`,
+    expected: "block",
+    why: "an ANSI-C message body is not scrubbed, so its words stay operands",
+  },
+  {
+    command: `${RM} $'src/foo.ts'`,
+    expected: "allow",
+    why: "an ANSI-C quoted path still names its own file",
+  },
+]);
+
 // `sub/..` is the directory above `sub`, and the operand test reads the last
 // component rather than searching the whole path, so a `..` in the middle of a
 // named path keeps that path named.

--- a/.claude/hooks/pre-bash-guard.test.ts
+++ b/.claude/hooks/pre-bash-guard.test.ts
@@ -1216,6 +1216,36 @@ group("git rm: named paths stay unattended", [
   },
 ]);
 
+// The shell splices a backslash-newline pair away before it reads the command,
+// so each of these runs one `git` with its subcommand beside it.
+group("a line continuation does not split a subcommand from its git", [
+  {
+    command: `git \\\n  ${RM_SUB} -r .`,
+    expected: "block",
+    why: "a wrapped git rm still takes the whole tree",
+  },
+  {
+    command: "git \\\n  add -A",
+    expected: "block",
+    why: "a wrapped git add still stages the whole worktree",
+  },
+  {
+    command: `git \\\n  ${COMMIT_SUB} -a`,
+    expected: "block",
+    why: "a wrapped git commit still sweeps the worktree",
+  },
+  {
+    command: `${RM} \\\n  src/foo.ts`,
+    expected: "allow",
+    why: "a wrapped removal that names its path is still named",
+  },
+  {
+    command: `${COMMIT} -F - <<'MSG'\nends with a backslash \\\nMSG\ngit push`,
+    expected: "allow",
+    why: "a heredoc body line ending in a backslash still ends at its terminator",
+  },
+]);
+
 group("git rm: a pathspec the command text does not show is refused", [
   { command: RM, expected: "block", why: "no operand at all" },
   {

--- a/.claude/hooks/pre-bash-guard.test.ts
+++ b/.claude/hooks/pre-bash-guard.test.ts
@@ -1233,6 +1233,21 @@ group("git rm: named paths stay unattended", [
   },
 ]);
 
+// `echo a \<\< MARK` prints the text `a << MARK` and runs the next line, so a
+// removal written there is a command rather than a heredoc body.
+group("an escaped << does not open a heredoc", [
+  {
+    command: `echo a \\<\\< MARK\n${RM} -r .\nMARK`,
+    expected: "block",
+    why: "a removal on the line after an escaped <<",
+  },
+  {
+    command: "echo a \\<\\< MARK\ngit add -A\nMARK",
+    expected: "block",
+    why: "a blanket stage on the line after an escaped <<",
+  },
+]);
+
 // `$'x'` is bash's ANSI-C quoting and `$"x"` its locale form; both hand git
 // the argument `'x'` hands it.
 group("a dollar sign before a quote does not hide the operand", [


### PR DESCRIPTION
`pre-bash-guard.sh` refused `git add -A`, `git add .` and `git commit -a`, and let `git rm -r .` through, which takes the same set out of the worktree and the index in one step. #158's handoff note named it.

## What `git rm` reaches, measured

`git rm -n` against a scratch repository holding `a.txt`, `sub/b.txt` and `old-dir/c.txt` (git 2.50.1, 2026-09-09). Each of `-r .`, `-r -- .`, `-rf .`, `--cached -r .`, `-r ./`, `-r :/`, `-r :(top)`, `-r '*'`, `'*.txt'`, `-r sub/..`, `-r $'.'` and `-r .$''` listed all three files. `-r old-dir` and `-r "$PWD/sub"` each listed one. A bare `git rm` answers `fatal: No pathspec was given. Which files should I remove?`, and `git rm .` without `-r` answers `fatal: not removing '.' recursively without -r`. With a file holding `.`, `--pathspec-from-file=ps.txt` and the prefix spelling `--pathspec-from-f ps.txt` each listed all three.

## The change

Guard 3's subcommand walk gets a `remove` state. `git rm -h` lists dry-run, quiet, `--cached`, force, `-r`, `--ignore-unmatch`, `--sparse`, `--pathspec-from-file` and `--pathspec-file-nul`, and none but `--pathspec-from-file` changes which paths it takes, so the state refuses that option by name, ignores every other flag, and hands each operand to the existing `refuse_unnamed_operand`. The "names no path" tail and the remediation text each gained an `rm` row; `rm`'s points at `git ls-files` where the other two point at `git status --short`.

The early-out that decides whether to fork awk needed `rm`, and two letters match far more text than `add`, `stage` or `commit` do. Over 3300 Bash commands taken from this project's session transcripts, the three-name form admitted 429, a bare `*rm*` 580, and four token-boundary patterns 471. `format`, `permission`, `nrm` and `rmtree` are what the extra 151 hold; none of the 109 the token form drops holds a `git rm`, and the guard decides each of those 109, and each of the 471 it admits, exactly as `origin/main`'s guard does.

## Four holes the reviews found, each its own commit

Two `code-reviewer` agents ran on the diff. Three of these let a real whole-tree `git rm` through and the fourth is a test gap; each was reproduced against git before it was fixed.

- **An operand that ends at `..`.** `git rm -r sub/..` was allowed. The shared operand test dropped path punctuation and refused only what emptied, so `sub/..` left `sub` and read as a named path; `git add sub/..` was allowed the same way. Trailing `/` and `/.` now come off before the last component is read, which leaves `git add ../sibling/foo.ts` naming its own file. This lands for all three subcommands at once.
- **ANSI-C and locale quoting.** `git rm -r $'.'`, `.$''` and `$"."` were allowed, because the walk stripped the quote and left the `$`, so the operand arrived as `$.` and read as a name; `git add $'-A'` went the same way. The `$` of `$'` and `$"` is now dropped ahead of the quote strip, after the message scrub so `git commit -m $'fix .'` is still refused.
- **A line continuation.** `git \` on one line and `rm -r .` on the next is one command, and the blanket backslash strip left the newline that the segment split reads as a separator, so the walk got `git` and `rm -r .` apart. The pair now folds into a space first. `git add -A` and `git commit -a` were allowed in that shape too.
- **An escaped `<<`.** `echo a \<\< MARK` prints the text and runs the next line; the walk stripped backslashes before dropping heredoc bodies, so the awk read `MARK` as a delimiter and threw the executed line away. The drop now reads the raw text. Written `echo "a << MARK"` the two `<` are adjacent in the raw text as well, and the awk carries no quote state, so that spelling still drops them.

## Outcome per spelling

Refused: `git rm -r .`, `-r -- .`, `-rf .`, `--cached -r .`, `-r ./`, `-r :/`, `-r :(top)`, `-r '*'`, `'*.ts'`, `'[a-z].ts'`, `-r ..`, `-r /`, `-r sub/..`, `-r sub/../`, `-r sub/../.`, `-r $'.'`, `-r .$''`, `-r $"."`, `.` with no `-r`, bare `git rm`, `-r` alone, all three `--pathspec-from-file` spellings, `git ls-files | xargs git rm`, and each of those behind `&&`, `;`, `cd src &&`, a line continuation, `sh -c`, `bash -c`, `zsh -c`, `env`, `command`, `eval`, `nohup`, `time`, `timeout 5`, `xargs`, `GIT_DIR=x`, `git -C sub`, `git --git-dir=`, `git --work-tree=`, `git --namespace x`, `git --no-pager`, a leading redirect, a trailing `&`, a tab, `g""it` and `\.`.

Allowed: `git rm -r src/old-dir`, `git rm src/foo.ts src/bar.ts`, `--cached src/foo.ts`, `-f src/foo.ts`, `-n -r src/old-dir`, `./src/foo.ts`, `src/components/ui/*.tsx`, `$'src/foo.ts'`, `../sibling/old-dir`, `rm -rf node_modules`, `git format-patch -1 --stdout`, `git log --format=%H`, `rg 'git rm -r .' .claude`, and a commit message quoting the refused shape. `git add -A`, `git add .` and `git commit -a` are refused with the same reason text as before, now pinned by a test.

## What stays allowed, and why

- **`git rm -r "$PWD"`, and `$(pwd)`.** Guard 3 records a decided policy at its header: an operand only the shell can resolve passes as a named path, which is what leaves `git add "$FILE"` unattended. I built the narrower carve-out first, refusing the four literal spellings `$PWD`, `${PWD}`, `$PWD/` and `${PWD}/`, and dropped it after a review showed `git add "$PWD"/.`, `git add "${PWD:-.}"` and `git rm -r $PWD/sub/..` all still passing, and `$(pwd)` unreachable at all because the segment splitter cuts on `()`. A four-literal list under a comment claiming "the one variable this guard can read" reads as coverage it does not have. Closing the class properly means reversing the `git add "$FILE"` allowance for every subcommand, which is a decision about how much shell the guard pretends to evaluate.
- **`{ git rm -r .; }`, `if true; then git rm -r .; fi`, `for f in x; do git rm -r .; done`.** The `prefix` state stops at `{`, `then` and `do`, which it does not list as wrappers. `origin/main` allows `git add -A` in each of the three, so `git rm` inherits them. Closing them changes which tokens may stand ahead of `git` for all three walks.
- **`git -c alias.z='rm -r .' z`.** An alias the guard cannot resolve, in the same class the header already places out of reach alongside a shell function and a script file.
- **`git rm -r $'\x2e'`.** A parameter expansion cannot decode the escape, so the `$'` rewrite leaves `$x2e`.

## One false refusal, reported rather than fixed

`cat > a.md <<'E1'` / `text` / `E1` / `cat > b.md <<'E2'` / `git rm -r .` / `E2` is refused for a command nobody wrote. `drop_heredoc_body` tracks the first operator only (`op == 0`), so a second heredoc's body is read as commands. `origin/main` refuses the `git add -A` version of the same shape, so the mechanism predates this change; what is new is that `git rm` text now reaches it. The fix rewrites the awk to record every dropped range rather than one pair, which is the kind of change the 236 cases here exist to protect and belongs in its own ticket.

## Tests

`.claude/hooks/pre-bash-guard.test.ts` goes from 202 to 236 cases. Applying one break at a time to the guard and requiring the suite to fail, 18 of 19 were caught: the early-out's `rm` token and both of its halves, the subcommand routing, the `--pathspec-f*` refusal, the flag arm that lets `-r` through without counting as a path, the operand test, the `HAS_SELECTION` assignment, both rows of the no-path-named branch, the `..` test and each of its two trailing strips, the two quote rewrites, the line-continuation join, and the `rm` remediation string. The one miss is the `--pathspec-from-file` refusal's own wording, which no case reads.

Pinning the remediation needed the harness to see it: the spawn is split into `hookStdout`, and `refusalOf` reads the `reason` field that `runHook` drops. Three tests hold the whole sentence for `rm`, `add` and `commit`, so a `git rm` told to run `git add` fails.

## A pre-existing flake, fixed in its own commit

At vitest's 5 s default this file failed 18 of its 202 cases in one round of three on `origin/main` untouched, and passed the other two, on a machine under parallel load. A case waits on the other cases of its concurrent group, so its wall time tracks the machine rather than the hook. `it.each`'s third argument now sets 30 s; three rounds run beside a `bun run check` passed, and setting it to 1 ms fails all of them, which is what shows the argument is read.

## Findings from review that I did not take

- **Fold the three subcommand states into one `case "$SUB"` table.** Two reviewers proposed routing `rm` into the existing `operands` arm, one verifying 0 differing decisions and reason strings over 89 commands, because `git rm` has none of `-A`, `-u`, `--all`, `--update`, `-p`, `-i`, `-e` or `--chmod`. A third enumerated the seven axes on which the arms diverge and recommended against: the merged form would refuse `git rm --all` with "stages every change in the worktree", a false sentence that is only unreachable because git rejects the flag first, and the short-cluster axis is three different algorithms, so a `case "$SUB"` comes back inside the merged walk. I kept the states separate. The duplication is the nine-line operand tail.
- **Narrow `--pathspec-f*` to `--pathspec-fr*` in the `rm` arm.** The wider pattern also matches `--pathspec-file-nul`, and the refusal then names a flag the command did not carry. git answers that flag on its own with `fatal: the option '--pathspec-file-nul' requires '--pathspec-from-file'`, so no working command is lost, and narrowing only the `rm` arm would leave it spelled differently from the `add` and `commit` arms. The comment now says what the pattern matches instead.
- **Hoist `--pathspec-from-file` out of all three arms.** `git add --pathspec-from-file=paths.txt` is refused with "it names no path to stage" where `git commit` names the option. I gave the `rm` arm the specific wording and left the `add` arm alone, because changing it rewrites a walk this ticket does not otherwise touch.
- **Re-measure the early-out.** The comment's 20.4/20.2/21.5 s figures were taken on the three-name form and stay labelled that way. The four-pattern form's own CPU cost is **not measured**; what is measured is how many commands it admits.

## Gates

`bun run check`, `bun run test` (760), `bun run knip`, `mise exec -- bun run check:shell` and `similarity-ts ./src --fail-on-duplicates` all pass. Nothing here was skipped for a missing binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
