### PR TITLE
docs: アニメーション規則の所有者が design.md に決まる

### DIFF
--- a/.claude/rules/design.md
+++ b/.claude/rules/design.md
@@ -291,6 +291,18 @@ or grid children, never on elements in normal flow.
 
 Never animate a keyboard-initiated action.
 
+### Duration
+
+| Element | Duration |
+| --- | --- |
+| Button press feedback | 100-160ms |
+| Tooltips, small popovers | 125-200ms |
+| Dropdowns, selects | 150-250ms |
+| Modals, drawers | 200-500ms |
+| Marketing or explanatory motion | Longer is allowed |
+
+Stay inside the element's row. A longer duration needs a stated reason.
+
 ### Easing
 
 Pick the curve from what the element is doing:

--- a/.claude/rules/design.md
+++ b/.claude/rules/design.md
@@ -110,8 +110,9 @@ neutral, so it belongs under a display face rather than carrying one.
 - Limit to 2 typefaces max (body + code).
 - Keep body text line length under ~75 characters.
 - Never center-align multi-line paragraphs.
-- Maintain a clear typographic hierarchy. Where two text elements look the
-  same weight and size, one of them is wrong.
+- Build the hierarchy from weight, size, and leading together rather than from
+  size alone. Where two text elements look the same weight and size, one of them
+  is wrong.
 - Set monospace where the content is data: a timestamp, a code, a price, a
   table. Captions, labels, and running copy take the body family.
 - Give the small text roles different treatments. Where the eyebrow, the button

--- a/.claude/rules/design.md
+++ b/.claude/rules/design.md
@@ -201,6 +201,16 @@ blends at every edge. Where the blur bands, the shadow leaks past the shape, or
 the effect jumps on hover, give the element an opaque surface. Never stack one
 translucent surface on another.
 
+Under `prefers-reduced-transparency: reduce`, give the surface a frostier or
+opaque fill, and under `prefers-contrast: more`, a near-solid background with a
+defined border.
+
+```css
+@media (prefers-reduced-transparency: reduce) {
+  .toolbar { background: white; backdrop-filter: none; }
+}
+```
+
 ## Interaction & Content
 
 ### Interactive States
@@ -347,6 +357,21 @@ and the stagger never blocks interaction while it plays.
 Animate `transform` and `opacity` only, because the compositor runs them
 without layout or paint. `padding`, `margin`, `height`, `width`, `top`, and
 `left` run all three steps on every frame.
+
+### Reduced Motion
+
+`prefers-reduced-motion: reduce` asks for gentler motion rather than none.
+Replace a slide or a spring with a short cross-fade, drop the overshoot, and
+keep opacity and color.
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .sheet { transition: opacity 200ms ease; transform: none !important; }
+}
+```
+
+Leave out a full-viewport moving background, a slow looping oscillation around
+0.2 Hz, and an abrupt brightness jump.
 
 ### Interruptibility
 

--- a/.claude/rules/design.md
+++ b/.claude/rules/design.md
@@ -324,6 +324,24 @@ project takes alongside the other tokens in `src/styles.css`:
 Find further curves at [easing.dev](https://easing.dev/) or
 [easings.co](https://easings.co/).
 
+### Physicality
+
+An entrance starts at `scale(0.9)` to `scale(0.97)` with `opacity: 0`, never at
+`scale(0)`.
+
+A popover, dropdown, or tooltip scales from its trigger. The Radix primitives in
+`src/components/ui/` publish that point as a CSS variable, which
+`dropdown-menu.tsx` and `tooltip.tsx` read through Tailwind's
+`origin-(--radix-<part>-content-transform-origin)`. A modal keeps
+`transform-origin: center`.
+
+A button's press feedback is `transform: scale(0.97)` on `:active` with
+`transition: transform 160ms ease-out`, and the scale stays between `0.95` and
+`0.98`.
+
+Stagger a group's entrance by 30-80ms per item. A longer delay reads as slow,
+and the stagger never blocks interaction while it plays.
+
 ### Properties
 
 Animate `transform` and `opacity` only, because the compositor runs them

--- a/.claude/rules/design.md
+++ b/.claude/rules/design.md
@@ -358,6 +358,12 @@ Animate `transform` and `opacity` only, because the compositor runs them
 without layout or paint. `padding`, `margin`, `height`, `width`, `top`, and
 `left` run all three steps on every frame.
 
+Name each property in a `transition`, because `transition: all` also animates
+whatever else changes.
+
+Set `transform` on the element that moves. A CSS variable on the parent driving
+a child's transform recalculates the styles of every child.
+
 ### Reduced Motion
 
 `prefers-reduced-motion: reduce` asks for gentler motion rather than none.

--- a/.claude/rules/design.md
+++ b/.claude/rules/design.md
@@ -207,7 +207,7 @@ defined border.
 
 ```css
 @media (prefers-reduced-transparency: reduce) {
-  .toolbar { background: white; backdrop-filter: none; }
+  .toolbar { background: var(--background); backdrop-filter: none; }
 }
 ```
 

--- a/.claude/rules/design.md
+++ b/.claude/rules/design.md
@@ -196,7 +196,8 @@ and text on one hue.
 
 A translucent surface needs a backdrop worth showing through and a blur that
 blends at every edge. Where the blur bands, the shadow leaks past the shape, or
-the effect jumps on hover, give the element an opaque surface.
+the effect jumps on hover, give the element an opaque surface. Never stack one
+translucent surface on another.
 
 ## Interaction & Content
 

--- a/.claude/rules/design.md
+++ b/.claude/rules/design.md
@@ -291,6 +291,27 @@ or grid children, never on elements in normal flow.
 
 Never animate a keyboard-initiated action.
 
+### Easing
+
+Pick the curve from what the element is doing:
+- Entering or exiting: `ease-out`
+- Moving or morphing on screen: `ease-in-out`
+- Hover or a color change: `ease`
+- Constant motion (marquee, progress): `linear`
+- Anything else: `ease-out`
+
+Never `ease-in` on UI. The built-in CSS curves are weak, so define the ones a
+project takes alongside the other tokens in `src/styles.css`:
+
+```css
+--ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+--ease-in-out: cubic-bezier(0.77, 0, 0.175, 1);
+--ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);      /* iOS-like drawer */
+```
+
+Find further curves at [easing.dev](https://easing.dev/) or
+[easings.co](https://easings.co/).
+
 ### Properties
 
 Animate `transform` and `opacity` only, because the compositor runs them

--- a/.claude/rules/design.md
+++ b/.claude/rules/design.md
@@ -275,8 +275,9 @@ or grid children, never on elements in normal flow.
 
 ### Animations
 
-Animate `transform` and `opacity` only, never layout properties, which
-trigger reflow on every frame.
+Animate `transform` and `opacity` only, because the compositor runs them
+without layout or paint. `padding`, `margin`, `height`, `width`, `top`, and
+`left` run all three steps on every frame.
 
 ## Decoration
 

--- a/.claude/rules/design.md
+++ b/.claude/rules/design.md
@@ -1,5 +1,5 @@
 ---
-description: Design system, covering color roles, typography, spacing, shapes, composition, and component conventions
+description: Design system, covering color roles, typography, spacing, shapes, composition, animation, and component conventions
 globs: src/**/*.css,src/**/*.tsx
 alwaysApply: false
 paths: src/**/*.css, src/**/*.tsx
@@ -16,8 +16,9 @@ That base is a starting point rather than an identity, so a project that wants a
 palette, a typeface, or a corner treatment of its own replaces the values there
 and leaves the rules below alone.
 
-Keyboard behavior, forms, hydration, and performance sit outside this
-document's subject.
+Keyboard behavior, forms, and hydration sit outside this document's subject.
+Page performance sits outside it too, apart from the frame cost of animation,
+which the Animations section below settles.
 
 ## Colors
 
@@ -277,7 +278,20 @@ visible.
 Avoid over-targeting selectors. `z-index` only works on positioned, flex,
 or grid children, never on elements in normal flow.
 
-### Animations
+## Animations
+
+### Frequency
+
+| How often the element is seen | Decision |
+| --- | --- |
+| 100+/day (keyboard shortcuts, command palette) | No animation |
+| Tens/day (hover effects, list navigation) | Remove it, or reduce it |
+| Occasional (modals, drawers, toasts) | Standard animation |
+| Rare or first-time (onboarding, celebrations) | Delight is allowed |
+
+Never animate a keyboard-initiated action.
+
+### Properties
 
 Animate `transform` and `opacity` only, because the compositor runs them
 without layout or paint. `padding`, `margin`, `height`, `width`, `top`, and

--- a/.claude/rules/design.md
+++ b/.claude/rules/design.md
@@ -208,6 +208,8 @@ focus-visible, active, and disabled. Never remove the focus indicator.
 
 A hover state changes fill, color, or an icon's position while the element keeps
 its size and place. Reserve any lift for a card, and carry it with a value shift.
+Gate a hover animation behind `@media (hover: hover) and (pointer: fine)`, which
+leaves it out on a device whose pointer cannot hover.
 
 Set `background` explicitly on every button, because the user-agent default
 differs across browsers.

--- a/.claude/rules/design.md
+++ b/.claude/rules/design.md
@@ -348,6 +348,22 @@ Animate `transform` and `opacity` only, because the compositor runs them
 without layout or paint. `padding`, `margin`, `height`, `width`, `top`, and
 `left` run all three steps on every frame.
 
+### Interruptibility
+
+A CSS transition retargets from the current value when something interrupts it,
+and `@keyframes` restarts from zero, so anything triggered rapidly takes a
+transition.
+
+`@starting-style` gives an entrance its start value without JavaScript:
+
+```css
+.toast {
+  opacity: 1; transform: translateY(0);
+  transition: opacity 400ms ease, transform 400ms ease;
+  @starting-style { opacity: 0; transform: translateY(100%); }
+}
+```
+
 ## Decoration
 
 A decoration earns its place by encoding information. Each form below arrives by

--- a/.claude/rules/design.md
+++ b/.claude/rules/design.md
@@ -336,8 +336,9 @@ Find further curves at [easing.dev](https://easing.dev/) or
 
 ### Physicality
 
-An entrance starts at `scale(0.9)` to `scale(0.97)` with `opacity: 0`, never at
-`scale(0)`.
+Where an entrance scales, it starts between `scale(0.9)` and `scale(0.97)` with
+`opacity: 0`, never at `scale(0)`. An entrance pairs its opacity change with a
+transform rather than fading alone.
 
 A popover, dropdown, or tooltip scales from its trigger. The Radix primitives in
 `src/components/ui/` publish that point as a CSS variable, which

--- a/.claude/skills/motion-craft/SKILL.md
+++ b/.claude/skills/motion-craft/SKILL.md
@@ -450,9 +450,12 @@ Stagger is decorative — never block interaction while it plays.
 
 ## Accessibility (implementation)
 
+`.claude/rules/design.md` (Interactive States) gates hover animation and bounds
+what a hover may change.
+
 ```css
 @media (hover: hover) and (pointer: fine) {
-  .element:hover { transform: scale(1.05); }
+  .card:hover .card-icon { transform: translateX(2px); }
 }
 ```
 
@@ -510,7 +513,8 @@ Every animation in the diff is measured against these. A violation is a finding.
    (Animations).
 
 8. **Accessibility.** `prefers-reduced-motion` is honored (gentler, not zero).
-   Hover animations gated behind `@media (hover: hover) and (pointer: fine)`.
+   Hover animation is measured against `.claude/rules/design.md` (Interactive
+   States).
 
 9. **Asymmetric enter/exit.** Deliberate actions animate slower; system
    responses snap. Symmetric timing on a press-and-release is a finding.

--- a/.claude/skills/motion-craft/SKILL.md
+++ b/.claude/skills/motion-craft/SKILL.md
@@ -156,8 +156,9 @@ not the position the gesture reached.
 
 - **Enter and exit along the same path.** A panel that slides in from the right
   must dismiss to the right.
-- **Anchor interactions to their source.** A menu or popover should originate
-  from the element that triggered it — set `transform-origin` to the trigger.
+- **Anchor interactions to their source.** A menu or popover originates from
+  the element that triggered it, and `.claude/rules/design.md` (Animations)
+  sets how.
 - **Mirror the easing on reversible transitions** with the inverse
   cubic-bezier.
 
@@ -271,9 +272,8 @@ Three rules for combining visual + sound + haptic:
 - **Design interaction and visuals together.** "You shouldn't be able to tell
   where one ends and the other begins." Motion is not a layer added after the
   pixels.
-- **Test with real people in real context**, and review motion with fresh
-  eyes — play it in slow motion / frame-by-frame to catch what's invisible at
-  full speed.
+- **Test with real people in real context.** Part 2's Debugging section says
+  how to review the motion itself.
 
 ---
 
@@ -425,12 +425,13 @@ Every animation in the diff is measured against these. A violation is a finding.
 8. **Accessibility.** Measured against `.claude/rules/design.md`: reduced
    motion in Animations, hover in Interactive States.
 
-9. **Asymmetric enter/exit.** Deliberate actions animate slower; system
-   responses snap. Symmetric timing on a press-and-release is a finding.
+9. **Asymmetric enter/exit.** Measured against Part 2's Asymmetric timing.
+   Symmetric timing on a press-and-release is a finding.
 
 10. **Cohesion.** Motion matches the component's personality and the rest of the
-    product. Mismatched personality is a finding. When unsure whether motion
-    feels right, the strongest move is often to delete it.
+    product. Mismatched personality is a finding. Where it is unclear whether
+    the motion feels right, review it as Part 2's Debugging section says before
+    deciding, and deleting it is often the strongest move.
 
 ## Remedial Preference Hierarchy
 
@@ -475,13 +476,6 @@ Close with an explicit decision:
 
 Cite `file:line`. Pull exact values from `.claude/rules/design.md` and Part 2
 rather than approximating.
-
-## Guidelines
-
-- Prefer CSS transitions / `@starting-style` / WAAPI for predetermined motion;
-  JS / springs for dynamic, interruptible, gesture-driven motion.
-- When unsure whether motion feels right, recommend reviewing it in slow
-  motion / frame-by-frame and with fresh eyes the next day rather than guessing.
 
 ---
 

--- a/.claude/skills/motion-craft/SKILL.md
+++ b/.claude/skills/motion-craft/SKILL.md
@@ -314,22 +314,6 @@ Feel natural because they simulate physics; no fixed duration.
 Keep bounce subtle (0.1-0.3); reserve for drag-to-dismiss and playful
 interactions. Springs maintain velocity when interrupted.
 
-## Interruptibility
-
-CSS **transitions** can be interrupted and retargeted mid-animation;
-**keyframes** restart from zero. For anything triggered rapidly, transitions
-are smoother.
-
-Use `@starting-style` for entry without JS:
-
-```css
-.toast {
-  opacity: 1; transform: translateY(0);
-  transition: opacity 400ms ease, transform 400ms ease;
-  @starting-style { opacity: 0; transform: translateY(100%); }
-}
-```
-
 ## Asymmetric timing
 
 Slow where the user is deciding, fast where the system responds.
@@ -447,11 +431,9 @@ Every animation in the diff is measured against these. A violation is a finding.
 5. **Origin & physical correctness.** Measured against the physicality rules in
    `.claude/rules/design.md` (Animations).
 
-6. **Interruptibility.** Rapidly-triggered motion (toasts, toggles) must be
-   interruptible via CSS transitions that retarget from current state, not
-   keyframes that restart from zero. Gesture-driven motion (drag, swipe)
-   specifically requires springs or WAAPI — CSS transitions cannot receive
-   release-velocity handoff (see Part 1 section 3).
+6. **Interruptibility.** Measured against `.claude/rules/design.md`
+   (Animations) for CSS, and against Part 1 section 3 for gesture-driven
+   motion.
 
 7. **GPU-only properties.** Measured against `.claude/rules/design.md`
    (Animations).

--- a/.claude/skills/motion-craft/SKILL.md
+++ b/.claude/skills/motion-craft/SKILL.md
@@ -248,11 +248,9 @@ and abrupt brightness jumps.
 
 ## 15. Typography — optical sizing, tracking, leading
 
-- **Tracking is size-specific.** Large display text wants *negative* tracking;
-  small text wants slightly *positive* tracking. Tighten headings, leave body
-  near `0`.
+- **Tracking and hierarchy.** Both are settled in `.claude/rules/design.md`
+  (Typographic Rules, Typographic Pitfalls).
 - **Leading tracks size inversely.** Tight on large headings, looser on body.
-- **Build hierarchy from weight + size + leading as a set,** not size alone.
 - **Respect the user's text-size setting.** Scale layout with `rem`/`em`.
 
 ```css

--- a/.claude/skills/motion-craft/SKILL.md
+++ b/.claude/skills/motion-craft/SKILL.md
@@ -299,27 +299,6 @@ Distilled from Emil Kowalski's design engineering philosophy (animations.dev).
 What this repository's CSS and TSX must do is settled in
 `.claude/rules/design.md` (Animations); this part is the reference behind it.
 
-## Easing
-
-Decision order:
-- Entering or exiting -> **`ease-out`**
-- Moving / morphing on screen -> **`ease-in-out`**
-- Hover / color change -> **`ease`**
-- Constant motion (marquee, progress) -> **`linear`**
-- Default -> **`ease-out`**
-
-**Never `ease-in` on UI.** Built-in CSS easings are too weak. Use strong custom
-curves:
-
-```css
---ease-out: cubic-bezier(0.23, 1, 0.32, 1);
---ease-in-out: cubic-bezier(0.77, 0, 0.175, 1);
---ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);      /* iOS-like drawer */
-```
-
-Find curves at [easing.dev](https://easing.dev/) or
-[easings.co](https://easings.co/).
-
 ## Duration
 
 | Element | Duration |
@@ -483,8 +462,8 @@ Every animation in the diff is measured against these. A violation is a finding.
 2. **Frequency-appropriate.** Measured against the frequency table in
    `.claude/rules/design.md` (Animations).
 
-3. **Responsive easing.** Entering/exiting elements use `ease-out` or a strong
-   custom curve. `ease-in` on UI is a block. Built-in CSS easings are too weak.
+3. **Responsive easing.** Measured against the curve order in
+   `.claude/rules/design.md` (Animations).
 
 4. **Duration within range.** A duration past its element's row in Part 2's
    duration table needs justification.

--- a/.claude/skills/motion-craft/SKILL.md
+++ b/.claude/skills/motion-craft/SKILL.md
@@ -296,17 +296,8 @@ and abrupt brightness jumps.
 
 Precise values, curves, and techniques. Cite these in code and reviews.
 Distilled from Emil Kowalski's design engineering philosophy (animations.dev).
-
-## Frequency table — should it animate?
-
-| Frequency | Decision |
-| --- | --- |
-| 100+/day (keyboard shortcuts, command palette) | No animation. Ever. |
-| Tens/day (hover effects, list navigation) | Remove or drastically reduce |
-| Occasional (modals, drawers, toasts) | Standard animation |
-| Rare / first-time (onboarding, celebrations) | Can add delight |
-
-**Never animate keyboard-initiated actions.**
+What this repository's CSS and TSX must do is settled in
+`.claude/rules/design.md` (Animations); this part is the reference behind it.
 
 ## Easing
 
@@ -489,8 +480,8 @@ Every animation in the diff is measured against these. A violation is a finding.
    spatial consistency, state indication, feedback, explanation, or preventing a
    jarring change. "It looks cool" on a frequently-seen element is a block.
 
-2. **Frequency-appropriate.** Match motion to how often it's seen (see the
-   frequency table in Part 2).
+2. **Frequency-appropriate.** Measured against the frequency table in
+   `.claude/rules/design.md` (Animations).
 
 3. **Responsive easing.** Entering/exiting elements use `ease-out` or a strong
    custom curve. `ease-in` on UI is a block. Built-in CSS easings are too weak.

--- a/.claude/skills/motion-craft/SKILL.md
+++ b/.claude/skills/motion-craft/SKILL.md
@@ -299,19 +299,6 @@ Distilled from Emil Kowalski's design engineering philosophy (animations.dev).
 What this repository's CSS and TSX must do is settled in
 `.claude/rules/design.md` (Animations); this part is the reference behind it.
 
-## Duration
-
-| Element | Duration |
-| --- | --- |
-| Button press feedback | 100-160ms |
-| Tooltips, small popovers | 125-200ms |
-| Dropdowns, selects | 150-250ms |
-| Modals, drawers | 200-500ms |
-| Marketing / explanatory | Can be longer |
-
-**Rule: stay inside the element's row above. A longer duration needs a stated
-reason.**
-
 ## Physicality
 
 - **Never `scale(0)`.** Start from `scale(0.9-0.97)` + `opacity: 0`.
@@ -465,8 +452,8 @@ Every animation in the diff is measured against these. A violation is a finding.
 3. **Responsive easing.** Measured against the curve order in
    `.claude/rules/design.md` (Animations).
 
-4. **Duration within range.** A duration past its element's row in Part 2's
-   duration table needs justification.
+4. **Duration within range.** Measured against the duration table in
+   `.claude/rules/design.md` (Animations).
 
 5. **Origin & physical correctness.** Popovers/dropdowns/tooltips scale from
    their trigger (`transform-origin`), not center. Never `scale(0)` — start
@@ -543,7 +530,8 @@ Close with an explicit decision:
 - **Approve** — no feel-breaking regressions, durations and easing within
   bounds, interruptibility handled, reduced-motion respected.
 
-Cite `file:line`. Pull exact values from Part 2 rather than approximating.
+Cite `file:line`. Pull exact values from `.claude/rules/design.md` and Part 2
+rather than approximating.
 
 ## Guidelines
 

--- a/.claude/skills/motion-craft/SKILL.md
+++ b/.claude/skills/motion-craft/SKILL.md
@@ -299,17 +299,6 @@ Distilled from Emil Kowalski's design engineering philosophy (animations.dev).
 What this repository's CSS and TSX must do is settled in
 `.claude/rules/design.md` (Animations); this part is the reference behind it.
 
-## Physicality
-
-- **Never `scale(0)`.** Start from `scale(0.9-0.97)` + `opacity: 0`.
-- **Origin-aware popovers.** Scale from the trigger, not center:
-  ```css
-  .popover { transform-origin: var(--radix-popover-content-transform-origin); }
-  ```
-  **Modals are exempt** — keep `transform-origin: center`.
-- **Button press feedback.** `transform: scale(0.97)` on `:active`,
-  `transition: transform 160ms ease-out`. Subtle (0.95-0.98).
-
 ## Springs
 
 Feel natural because they simulate physics; no fixed duration.
@@ -395,8 +384,8 @@ Safari).
 
 ## Stagger
 
-Stagger group entrances; 30-80ms between items. Longer delays feel slow.
-Stagger is decorative — never block interaction while it plays.
+`.claude/rules/design.md` (Animations) sets the delay between items and what a
+stagger may not hold up.
 
 ```css
 .item { opacity: 0; transform: translateY(8px); animation: fadeIn 300ms ease-out forwards; }
@@ -455,9 +444,8 @@ Every animation in the diff is measured against these. A violation is a finding.
 4. **Duration within range.** Measured against the duration table in
    `.claude/rules/design.md` (Animations).
 
-5. **Origin & physical correctness.** Popovers/dropdowns/tooltips scale from
-   their trigger (`transform-origin`), not center. Never `scale(0)` — start
-   from `scale(0.9-0.97)` + opacity. Modals are exempt.
+5. **Origin & physical correctness.** Measured against the physicality rules in
+   `.claude/rules/design.md` (Animations).
 
 6. **Interruptibility.** Rapidly-triggered motion (toasts, toggles) must be
    interruptible via CSS transitions that retarget from current state, not

--- a/.claude/skills/motion-craft/SKILL.md
+++ b/.claude/skills/motion-craft/SKILL.md
@@ -312,8 +312,6 @@ Slow where the user is deciding, fast where the system responds.
 
 - **Animated properties.** `.claude/rules/design.md` (Animations) settles which
   properties may animate.
-- **Don't drive child transforms via a CSS variable on the parent** — it recalcs
-  styles for all children. Set `transform` directly on the element.
 - **Motion (Framer Motion) shorthands `x`/`y`/`scale` are NOT
   hardware-accelerated.** They run on the main thread via rAF and drop frames
   under load. Use the full transform string:
@@ -421,7 +419,8 @@ Every animation in the diff is measured against these. A violation is a finding.
    motion.
 
 7. **GPU-only properties.** Measured against `.claude/rules/design.md`
-   (Animations).
+   (Animations). Motion's `x`/`y`/`scale` shorthands run on the main thread, so
+   they are a finding on motion that plays while the page is busy.
 
 8. **Accessibility.** Measured against `.claude/rules/design.md`: reduced
    motion in Animations, hover in Interactive States.
@@ -432,16 +431,6 @@ Every animation in the diff is measured against these. A violation is a finding.
 10. **Cohesion.** Motion matches the component's personality and the rest of the
     product. Mismatched personality is a finding. When unsure whether motion
     feels right, the strongest move is often to delete it.
-
-## Aggressive Escalation Triggers
-
-Each of these is a finding on sight, and no standard above decides it:
-
-- `transition: all`
-- A pure-fade entrance with no initial transform
-- Motion `x`/`y`/`scale` props on motion that runs while the page is busy
-- Updating a CSS variable on a parent to drive a child transform
-- Everything-at-once entrance where a 30-80ms stagger belongs
 
 ## Remedial Preference Hierarchy
 

--- a/.claude/skills/motion-craft/SKILL.md
+++ b/.claude/skills/motion-craft/SKILL.md
@@ -227,24 +227,9 @@ Three rules for combining visual + sound + haptic:
 
 ## 14. Reduced motion & accessibility
 
-Reduced motion means *gentler*, not zero. Respond to three independent signals:
-
-- **`prefers-reduced-motion: reduce`** — replace slides/springs with short
-  cross-fades. Drop elastic/overshoot. Keep opacity/color.
-- **`prefers-reduced-transparency: reduce`** — frostier/solid surfaces.
-- **`prefers-contrast: more`** — near-solid backgrounds with defined borders.
-
-Avoid full-viewport moving backgrounds, slow looping oscillations (~0.2 Hz),
-and abrupt brightness jumps.
-
-```css
-@media (prefers-reduced-motion: reduce) {
-  .sheet { transition: opacity 200ms ease; transform: none !important; }
-}
-@media (prefers-reduced-transparency: reduce) {
-  .toolbar { background: white; backdrop-filter: none; }
-}
-```
+`.claude/rules/design.md` sets what this repository does under
+`prefers-reduced-motion` (Animations), and under
+`prefers-reduced-transparency` and `prefers-contrast` (Elevation).
 
 ## 15. Typography — optical sizing, tracking, leading
 
@@ -438,9 +423,8 @@ Every animation in the diff is measured against these. A violation is a finding.
 7. **GPU-only properties.** Measured against `.claude/rules/design.md`
    (Animations).
 
-8. **Accessibility.** `prefers-reduced-motion` is honored (gentler, not zero).
-   Hover animation is measured against `.claude/rules/design.md` (Interactive
-   States).
+8. **Accessibility.** Measured against `.claude/rules/design.md`: reduced
+   motion in Animations, hover in Interactive States.
 
 9. **Asymmetric enter/exit.** Deliberate actions animate slower; system
    responses snap. Symmetric timing on a press-and-release is a finding.

--- a/.claude/skills/motion-craft/SKILL.md
+++ b/.claude/skills/motion-craft/SKILL.md
@@ -199,13 +199,11 @@ function rubberband(overshoot, dimension, constant = 0.55) {
 ## 12. Materials & depth
 
 Apple uses translucent materials as a floating functional layer. On the web,
-approximate with `backdrop-filter`.
+approximate with `backdrop-filter`. Which surfaces here may be translucent, and
+where a shadow is allowed at all, is settled in `.claude/rules/design.md`
+(Elevation), which carries hierarchy on background color, border, backdrop dim,
+spacing, and typography instead.
 
-- **Build nav/toolbars/sheets as translucent layers** with content scrolling
-  underneath — not opaque bars.
-- **Material weight encodes hierarchy:** darker/heavier = structural,
-  lighter = interactive. **Never stack a light translucent surface on another.**
-- **Bigger surfaces should read as thicker:** stronger blur + deeper shadow.
 - **Scroll edge effects, not hard dividers.** Fade a gradient mask where
   content meets floating chrome.
 - **Materialize, don't just fade.** Animate blur radius and scale together on

--- a/.claude/skills/motion-craft/SKILL.md
+++ b/.claude/skills/motion-craft/SKILL.md
@@ -193,8 +193,8 @@ function rubberband(overshoot, dimension, constant = 0.55) {
   strobing.
 - For very fast motion, a subtle **motion blur / stretch** reads better than a
   hard sharp streak.
-- `requestAnimationFrame` is the web's display-synced clock. Animate only
-  compositor-friendly properties — `transform` and `opacity`.
+- `requestAnimationFrame` is the web's display-synced clock. Which properties
+  may animate is settled in `.claude/rules/design.md` (Animations).
 
 ## 12. Materials & depth
 
@@ -399,9 +399,8 @@ Slow where the user is deciding, fast where the system responds.
 
 ## Performance
 
-- **Only animate `transform` and `opacity`** — they skip layout/paint and run
-  on the GPU. `padding`/`margin`/`height`/`width`/`top`/`left` trigger all
-  three rendering steps.
+- **Animated properties.** `.claude/rules/design.md` (Animations) settles which
+  properties may animate.
 - **Don't drive child transforms via a CSS variable on the parent** — it recalcs
   styles for all children. Set `transform` directly on the element.
 - **Motion (Framer Motion) shorthands `x`/`y`/`scale` are NOT
@@ -509,7 +508,8 @@ Every animation in the diff is measured against these. A violation is a finding.
    specifically requires springs or WAAPI — CSS transitions cannot receive
    release-velocity handoff (see Part 1 section 3).
 
-7. **GPU-only properties.** Animate `transform` and `opacity` only.
+7. **GPU-only properties.** Measured against `.claude/rules/design.md`
+   (Animations).
 
 8. **Accessibility.** `prefers-reduced-motion` is honored (gentler, not zero).
    Hover animations gated behind `@media (hover: hover) and (pointer: fine)`.

--- a/.claude/skills/motion-craft/SKILL.md
+++ b/.claude/skills/motion-craft/SKILL.md
@@ -420,8 +420,9 @@ Slow where the user is deciding, fast where the system responds.
   `translateY(100%)` moves by the element's height regardless of dimensions.
 - **`scale()` scales children too** (font, icons, content).
 - **3D**: `rotateX/Y` + `transform-style: preserve-3d` for depth/orbit/flip.
-- **`clip-path: inset(t r b l)`** is a powerful animation tool: reveal-on-scroll,
-  hold-to-delete overlay, seamless tab color transitions, comparison sliders.
+- **`clip-path: inset(t r b l)`** drives a hold-to-delete overlay, a seamless
+  tab color transition, and a comparison slider. A reveal gated on scroll is
+  ruled out by `.claude/rules/design.md` (Content States).
 
 ## Gestures & drag
 


### PR DESCRIPTION
`.claude/rules/design.md` と `.claude/skills/motion-craft/SKILL.md` の間の重複と矛盾を解消し、
このリポジトリの CSS と TSX に対するアニメーション規則を design.md が持つようにした。
motion-craft には review 手順（Part 3）、用語集（Part 4）、Apple / Kowalski の参照資料が残り、
規則そのものは design.md を指す。

## design.md に追加・変更した節タイトル

`### Animations`（`## CSS Architecture` 配下）を独立した `## Animations` に上げ、その下に節を作った。
タイトルの文字列が変わった節はなく、追加は次の 7 つ。

- `## Animations`（`### Animations` から昇格。文字列は同じ）
- `### Frequency`
- `### Duration`
- `### Easing`
- `### Physicality`
- `### Properties`
- `### Reduced Motion`
- `### Interruptibility`

`## Elevation` と `### Interactive States` には本文を足したが、タイトルは変えていない。

## コミット

1 コミット 1 件。A10 から A15 は inventory の見出し番号。

- A10: `transform`/`opacity` の規則を design.md 1 箇所にし、motion-craft の 3 箇所をポインタにした
- A11: 半透明バーと「面が大きいほど深い影」を削り、design.md の Elevation に従わせた
- A12: hover の `scale(1.05)` を icon の位置移動に差し替え、`@media (hover: hover) and (pointer: fine)` を Interactive States に置いた
- A13: body の tracking を「0 付近」から design.md の Typographic Rules に寄せた
- A14: `clip-path` の用途から reveal-on-scroll を外した（Part 4 の用語定義は残す）
- B3: 頻度表、duration 表、easing、physicality、`@starting-style`、reduced motion、escalation trigger を design.md へ移した（7 コミット）
- A15: Part 3 が Part 1 / Part 2 の規則を書き直していた箇所を 1 箇所にまとめた
- 残り 2 件は移設中に自分で作った不備の修正（entrance の規則が scale しない entrance まで縛っていた件、例が生の色 `white` を使っていた件）

## 確認

- frontmatter の `paths` / `globs` は `src/**/*.css, src/**/*.tsx` のままで、移した規則が効く CSS と TSX を覆う。`motion` / `framer-motion` は package.json になく src/ からの import もないため、その参照は motion-craft 側に残した
- `bun .claude/hooks/check-md-links.ts`、`bun run check`、`bun run test` が通る
- `.cursor/rules/design.mdc` は symlink のままで触っていない

## 指示の前提のうち、実際と違ったもの

- inventory は design.md の Overview に animation が「outside」として載っていないと書いており、これは正しい。ただし同じ文が `performance` を outside に挙げており、移した規則にはフレームあたりのコスト（compositor が走らせるプロパティ）が含まれる。Overview はこの 1 文を 2 文に分け、animation のフレームコストだけが例外だと書いた
- B3 が挙げた escalation trigger 5 件のうち 4 件は、移設後は standard 5 と standard 7 が判定する。「no standard above decides it」という節の前提が成り立たなくなったため、残り 1 件を standard 7 に畳んで motion-craft の Aggressive Escalation Triggers 節を削除した。stagger の間隔（30-80ms）も、trigger の 1 件がこの値を指していたため design.md へ移した
- それ以外に、この ticket のプロンプトと inventory の前提で実際と違うものは見つからなかった

🤖 Generated with [Claude Code](https://claude.com/claude-code)
