### PR TITLE
docs: 監査 skill の規則が design.md と page-audit を指す

### DIFF
--- a/.claude/skills/launch-checklist/SKILL.md
+++ b/.claude/skills/launch-checklist/SKILL.md
@@ -184,7 +184,7 @@ Create `docs/launch-checklist/YYYY-MM-DD.md`:
 ```markdown
 # Launch Checklist Report: YYYY-MM-DD
 
-Commit: `{short hash}` {commit message}
+Commit: `{short hash}` {subject}
 
 ## Summary
 
@@ -224,9 +224,10 @@ Priority fixes (FAIL items ordered by severity):
 3. **[Minor]** {item}: {fix suggestion}
 ```
 
-### 4. Compare with previous
+### 4. Compare with the previous report
 
-If a previous report exists in `docs/launch-checklist/`, compare results. Note newly passing or regressed items under `## Changes from previous audit`.
+Where `docs/launch-checklist/` already holds an earlier file, compare against the
+newest one and list newly passing and newly failing items under `## Changes`.
 
 ### 5. Fix issues (if requested)
 

--- a/.claude/skills/launch-checklist/SKILL.md
+++ b/.claude/skills/launch-checklist/SKILL.md
@@ -100,12 +100,12 @@ For each category in scope, inspect the codebase, configuration, and running app
 
 | # | Item | How to verify |
 |---|------|---------------|
-| 35 | Every page has an appropriate `<title>` tag | Check the router config and each page's head settings |
+| 35 | Every page has an appropriate `<title>` tag | Run a Lighthouse SEO audit (use the `page-audit` skill) |
 | 36 | Canonical URLs are set | Check `<link rel="canonical">`. Normalize URLs with query parameters |
 | 37 | Error pages return an appropriate status code (40x / 50x), or have `noindex` set | Check error handling and response codes |
 | 38 | Search result pages have `noindex` or a canonical URL set | Check the meta tags on search pages |
 | 39 | `noindex` is removed in production | Check the `robots` meta tag and `robots.txt` |
-| 40 | Key pages (top page, etc.) have a meta description | Check the head settings |
+| 40 | Key pages (top page, etc.) have a meta description | Run a Lighthouse SEO audit (use the `page-audit` skill) |
 | 41 | An XML sitemap is generated and registered | Check the `/sitemap.xml` route and its contents |
 
 ### OGP
@@ -136,9 +136,9 @@ For each category in scope, inspect the codebase, configuration, and running app
 
 | # | Item | How to verify |
 |---|------|---------------|
-| 56 | Images have appropriate `alt` attributes | Grep `<img>` tags and check the presence and content of `alt` |
-| 57 | Icon-only buttons / links have an `aria-label` | Check SVG icon buttons. Pattern: `<a aria-label="..."><svg aria-hidden="true"></svg></a>` |
-| 58 | Element roles are recognizable by screen readers | Run a Lighthouse a11y audit (use the `page-audit` skill) |
+| 56 | Images have appropriate `alt` attributes | Run a Lighthouse a11y audit (use the `page-audit` skill) |
+| 57 | Icon-only buttons / links have an `aria-label` | Same as above. A passing icon link reads `<a aria-label="..."><svg aria-hidden="true"></svg></a>` |
+| 58 | Element roles are recognizable by screen readers | Same as above |
 
 ### Performance
 
@@ -168,7 +168,7 @@ measurement. For real LCP / CLS / INP traces run the `page-audit` skill.
 |---|------|---------------|
 | 68 | No problem if local storage / cookies are cleared after 7 days under iOS Safari ITP | Check the auth persistence mechanism |
 | 69 | No dependency on third-party cookies | Check cookie settings and external service integrations |
-| 70 | `<html lang="...">` is set | Check the root HTML template |
+| 70 | `<html lang="...">` is set | Run a Lighthouse a11y audit (use the `page-audit` skill) |
 | 71 | A server-error detection / alerting mechanism exists | Check the error monitoring configuration |
 | 72 | 404 / 50x error pages have a link back to the top page | Check the error page components |
 | 73 | A favicon is set | Check `<link rel="icon">` |

--- a/.claude/skills/launch-checklist/SKILL.md
+++ b/.claude/skills/launch-checklist/SKILL.md
@@ -160,7 +160,7 @@ measurement. For real LCP / CLS / INP traces run the `page-audit` skill.
 | 64 | The UI does not break at phone / tablet sizes | Check responsiveness with chrome-devtools |
 | 65 | Verified in browsers other than Chrome (Safari, Firefox) | Manual check (note in the report) |
 | 66 | No layout jitter from the scrollbar on Windows | Check the `scrollbar-gutter` setting |
-| 67 | The UI does not break when user input is long | Check rendering with long usernames, etc. |
+| 67 | The UI does not break when user input is long | Run the text-container tests in `.claude/rules/design.md` (Dynamic Content) |
 
 ### Other
 

--- a/.claude/skills/launch-checklist/SKILL.md
+++ b/.claude/skills/launch-checklist/SKILL.md
@@ -146,7 +146,7 @@ For each category in scope, inspect the codebase, configuration, and running app
 |---|------|---------------|
 | 59 | Unnecessary modules are not included in the bundle | Check with a `bundle-analyzer` or similar |
 | 60 | Static files are cached by the CDN | Check `Cache-Control` headers and CDN settings |
-| 61 | Layout shift is prevented | Check that `<img>` has `aspect-ratio` or `width` / `height` set |
+| 61 | Layout shift is prevented | Check that `<img>` has `aspect-ratio` or `width` / `height` set. `.claude/rules/design.md` (Content States) settles the dimensions a loading state holds |
 | 62 | Image sizes are optimized | Check there are no images far larger than their display size |
 | 63 | The DB has appropriate indexes | Check the indexes in the schema definition |
 

--- a/.claude/skills/page-audit/SKILL.md
+++ b/.claude/skills/page-audit/SKILL.md
@@ -73,5 +73,7 @@ score down 5 or more, LCP up 500ms or more, or CLS up 0.05 or more.
 In priority order: render-blocking resources (defer or async-load), LCP (preload the
 element, cut server response time, optimize images), CLS (explicit dimensions, nothing
 inserted above the fold), long tasks and INP (split the tasks, debounce handlers,
-`startTransition` for non-urgent updates). Rebuild and restart the preview server before
-re-measuring, and add the after-fix numbers to the same report.
+`startTransition` for non-urgent updates). Where the shift arrives as data lands,
+`.claude/rules/design.md` (Content States) settles the dimensions the skeleton holds.
+Rebuild and restart the preview server before re-measuring, and add the after-fix numbers
+to the same report.


### PR DESCRIPTION
inventory の A8, A9, B5, B6 を解消した。編集したのは
`.claude/skills/launch-checklist/SKILL.md` と `.claude/skills/page-audit/SKILL.md` の
2 ファイルで、`.claude/rules/design.md` には触れていない。

## コミット

1 コミット 1 件。

- A8: レポートの規約を 1 つにした。launch-checklist の前回比較の節見出しを
  page-audit と同じ "Compare with the previous report" にし、比較結果の見出しを
  `## Changes from previous audit` から `## Changes` に、レポート冒頭の commit 行を
  `Commit: {short hash} {subject}` にそろえた。ポインタにしなかったのは、共有するのが
  見出し 1 つと commit 行 1 行で、レポート本体（表の形も比較の単位も）は各 skill の
  ものだから。片方を読むために他方を読み込ませる方が高くつく（AGENTS.md の
  Instruction documents）。
- A9: 項目 67（長い入力で UI が壊れない）の確認方法を
  `.claude/rules/design.md` (Dynamic Content) へのポインタにした。design.md は
  1 文字・最大長・複数行あふれの 3 つを課しており、旧文はそのうち 1 つしか指していなかった。
- B5: 両 skill の手順（img の寸法、CLS の修正）は残し、規則の出典として
  `.claude/rules/design.md` (Content States) へのポインタを添えた。
- B6: page-audit が集める Lighthouse の違反と同じものを別方法で確かめていた
  launch-checklist の 5 行を page-audit へのポインタにした。

## B6 で page-audit に寄せた行と、寄せなかった行

寄せたのは、build した成果物の markup に対する Lighthouse の audit が同じ判定を出す行。

| # | 項目 | Lighthouse の audit |
|---|------|---------------------|
| 35 | 各ページの `<title>` | `document-title`（SEO） |
| 40 | meta description | `meta-description`（SEO） |
| 56 | img の `alt` | `image-alt`（accessibility） |
| 57 | アイコンだけのボタン / リンクの名前 | `button-name` / `link-name`（accessibility） |
| 70 | `<html lang>` | `html-has-lang`（accessibility） |

57 の cell には合格する形（`<a aria-label="..."><svg aria-hidden="true"></svg></a>`）を
残した。これは確認方法ではなく直し方で、他のどこにも書かれていない。

寄せなかった行と理由:

- 36（canonical）: Lighthouse の `canonical` は canonical の有無と妥当性を見るが、
  この行が併せて求める query parameter 付き URL の正規化は audit の対象外。
- 37（エラーページのステータス）, 38（検索結果ページの `noindex`）, 41（sitemap）:
  対応する Lighthouse の audit がない。`http-status-code` は測ったページが
  2xx を返すことを見る audit で、エラーページに対しては判定が逆になる。
- 39（production で `noindex` が外れている）と Security: Response Headers（10, 11, 12, 24）:
  page-audit が測るのはローカルの production build の preview server で、
  デプロイ先の origin ではない。robots メタとセキュリティヘッダは環境で変わるため、
  ポインタにすると確認範囲が狭くなる。
- 59-63（Performance）: 行の下に既に page-audit へのポインタがあり（"Items 59-63 are
  static heuristics..."）、行ごとの重複はない。61 は B5 のポインタのみ追加した。

## design.md に規則がなくて据え置いた check

なし。A9 と B5 が指した 2 つの節（Dynamic Content, Content States）は design.md に
存在し、他に design.md 側へ寄せる必要のある check は今回の 4 件の範囲では出なかった。

## 確認

- `bun .claude/hooks/check-md-links.ts`: 22 files checked, no dead relative links
- `bun run check`: pass（116 files formatted, 98 files no warnings）
- `bun run test`: 27 files / 806 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
