### PR TITLE
fix: pre-bash-guard が $PWD で書かれた木全体の削除を止める

### DIFF
--- a/.claude/hooks/pre-bash-guard.sh
+++ b/.claude/hooks/pre-bash-guard.sh
@@ -322,8 +322,9 @@ fi
 # such as `env`, `sh -c` or `xargs`. That anchor is what leaves
 # `rg 'git add .' src` unattended instead of refusing a search for the text it
 # looks for. Two routes stay out of reach: a shell function or a script file,
-# which no token walk sees, and an operand that only the shell can resolve, so
+# which no token walk sees, and an operand whose value only the shell holds, so
 # `git add "$FILE"` and `git add $(git diff --name-only)` pass as named paths.
+# `$PWD` and `pwd` are the exception, and the rewrite below spells them `.`.
 # This binds the habit rather than a deliberate bypass.
 #
 # The shell drops a quote pair and a backslash from a word, so `g""it`, `\-A`
@@ -457,6 +458,32 @@ WALK_PLAIN=$(printf '%s' "$WALK_PLAIN" | drop_heredoc_body)
 # takes and `git commit -m $'fix .'` is still refused.
 WALK_PLAIN=${WALK_PLAIN//\$\'/\'}
 WALK_PLAIN=${WALK_PLAIN//\$\"/\"}
+# `$PWD`, `${PWD}`, `$(pwd)` and a backticked `pwd` each expand to the working
+# directory. `git rm -r` given each of those four spellings, and given
+# `"$PWD"/.`, took all three tracked files of the scratch repository out of the
+# index and off disk, the set `git rm -r .` took, and `--cached` left all three
+# on disk for `"$PWD"` as it did for `.` (git 2.50.1, 2026-09-09). Rewriting
+# them to `.` puts them through the operand tests the plain spelling already
+# meets, and leaves `git add "$PWD/src/foo.ts"` naming its own file. This runs
+# ahead of the quote strip below so the backticked form is still a pair, and
+# ahead of the segment split so `$(pwd)`'s parentheses do not cut the segment
+# in two. The four patterns are literal, so a spelling one character off prints
+# the same directory and is left alone: this guard allowed `git rm -r` given
+# `${PWD:-.}`, `$(pwd -P)` and `$(pwd )`, and `-n` listed all three tracked
+# files of the scratch repository for each of them (2026-09-09).
+WALK_BEFORE_PWD=$WALK_PLAIN
+WALK_PLAIN=${WALK_PLAIN//\$\{PWD\}/.}
+WALK_PLAIN=${WALK_PLAIN//\$\(pwd\)/.}
+WALK_PLAIN=${WALK_PLAIN//\`pwd\`/.}
+WALK_PLAIN=${WALK_PLAIN//\$PWD/.}
+# The rewrite runs before `refuse_unnamed_operand` reads an operand, so
+# `git rm -r "$PWD"` is refused for a `.` the command does not contain. This
+# note joins that refusal wherever the rewrite changed the text, so the agent
+# reads a verdict on the token it wrote.
+PWD_NOTE=""
+if [ "$WALK_PLAIN" != "$WALK_BEFORE_PWD" ]; then
+  PWD_NOTE=" \`\$PWD\` and \`pwd\` expand to the working directory, so this guard reads the operand you spelled with one of them as \`.\`."
+fi
 WALK_PLAIN=${WALK_PLAIN//[\"\'\`]/}
 # A backslash before a newline is a line continuation the shell splices away,
 # so `git \` on one line and `rm -r .` on the next is one command running
@@ -687,7 +714,7 @@ if [ -n "$REFUSED" ]; then
       NEXT_STEP="Name the files this commit needs (\`git add src/foo.ts src/bar.ts\`), and take part of a file with \`git add -p\`. \`git status --short\` lists what changed."
       ;;
   esac
-  deny "PreToolUse(Bash): this \`git ${SUB}\` is refused because ${REFUSED}. ${NEXT_STEP}"
+  deny "PreToolUse(Bash): this \`git ${SUB}\` is refused because ${REFUSED}.${PWD_NOTE} ${NEXT_STEP}"
   exit 0
 fi
 

--- a/.claude/hooks/pre-bash-guard.test.ts
+++ b/.claude/hooks/pre-bash-guard.test.ts
@@ -1363,6 +1363,70 @@ group("git rm: a pathspec the command text does not show is refused", [
   },
 ]);
 
+// The guard rewrites each spelling to `.` ahead of its walk, so a refusal here
+// quotes `.` rather than the spelling the command carried.
+group("an operand that expands to the working directory is refused", [
+  {
+    command: `${RM} -r "$PWD"`,
+    expected: "block",
+    why: "the variable the shell keeps the working directory in",
+  },
+  {
+    command: `${RM} -r "\${PWD}"`,
+    expected: "block",
+    why: "the braced spelling of that variable",
+  },
+  {
+    command: `${RM} -r $(pwd)`,
+    expected: "block",
+    why: "a command substitution, whose parentheses would otherwise cut the segment",
+  },
+  {
+    command: `${RM} -r \`pwd\``,
+    expected: "block",
+    why: "the backticked substitution, which the quote strip would otherwise flatten to a name",
+  },
+  {
+    command: `${RM} -r "$PWD"/.`,
+    expected: "block",
+    why: "a trailing component that still names the same directory",
+  },
+]);
+
+group("an operand that names its own path stays unattended", [
+  {
+    command: 'git add "$FILE"',
+    expected: "allow",
+    why: "an operand whose value only the shell holds",
+  },
+  {
+    command: "git add $(git diff --name-only)",
+    expected: "allow",
+    why: "a substitution the rewrite leaves whole",
+  },
+  {
+    command: 'git add "$PWD/src/foo.ts"',
+    expected: "allow",
+    why: "one file addressed from the working directory",
+  },
+]);
+
+// `${PWD:-.}` and `$(pwd -P)` print the working directory too, and the four
+// literal patterns miss them. These rows record that edge, so widening the
+// rewrite fails them instead of moving the edge in silence.
+group("a working-directory spelling the four patterns miss passes", [
+  {
+    command: `${RM} -r "\${PWD:-.}"`,
+    expected: "allow",
+    why: "an expansion carrying a default",
+  },
+  {
+    command: `${RM} -r $(pwd -P)`,
+    expected: "allow",
+    why: "a pwd carrying an option",
+  },
+]);
+
 // Every case above reads the decision, so the sentence a refusal hands the
 // agent is judged here instead: a `git rm` told to stage with `git add` would
 // pass all of them.
@@ -1372,6 +1436,16 @@ describe.concurrent("the refusal names the subcommand's own next step", () => {
     async () => {
       await expect(refusalOf(`${RM} -r .`)).resolves.toBe(
         "PreToolUse(Bash): this `git rm` is refused because `.` names no file or directory of its own. Name the paths to delete (`git rm src/foo.ts src/bar.ts`, or `git rm -r src/old-dir` for one directory). `git ls-files` lists the tracked paths."
+      );
+    },
+    HOOK_TIMEOUT_MS
+  );
+
+  it(
+    "should name the working-directory spellings when the rewrite fired",
+    async () => {
+      await expect(refusalOf(`${RM} -r "$PWD"`)).resolves.toBe(
+        "PreToolUse(Bash): this `git rm` is refused because `.` names no file or directory of its own. `$PWD` and `pwd` expand to the working directory, so this guard reads the operand you spelled with one of them as `.`. Name the paths to delete (`git rm src/foo.ts src/bar.ts`, or `git rm -r src/old-dir` for one directory). `git ls-files` lists the tracked paths."
       );
     },
     HOOK_TIMEOUT_MS


### PR DESCRIPTION
`pre-bash-guard.sh` refused `git rm -r .` and let `git rm -r "$PWD"` through. The ticket's rule was to block that spelling only where it does the same harm, and otherwise leave it passing. It does the same harm, so it is now blocked.

## Step 1: what each spelling removed, run for real

A scratch repository holding `a.txt`, `sub/b.txt` and `old-dir/c.txt`, one fresh copy per case, git 2.50.1 (Apple Git-155) on macOS, 2026-09-09. Each case ran the command for real (no `-n`), then read the index with `git ls-files` and the working tree with `find . -path ./.git -prune -o -print`.

```
================================================================
CASE: baseline git rm -r .
cwd:  $repo
cmd:  git rm -r .
--- exit: 0
--- stdout+stderr:
    rm 'a.txt'
    rm 'old-dir/c.txt'
    rm 'sub/b.txt'
--- index after (git ls-files):
--- worktree after (find, excluding .git):
    .

================================================================
CASE: git rm -r "$PWD"
cwd:  $repo
cmd:  git rm -r "$PWD"
--- exit: 0
--- stdout+stderr:
    rm 'a.txt'
    rm 'old-dir/c.txt'
    rm 'sub/b.txt'
--- index after (git ls-files):
--- worktree after (find, excluding .git):
    .

================================================================
CASE: git rm -r "$PWD"/.
cwd:  $repo
cmd:  git rm -r "$PWD"/.
--- exit: 0
--- stdout+stderr:
    rm 'a.txt'
    rm 'old-dir/c.txt'
    rm 'sub/b.txt'
--- index after (git ls-files):
--- worktree after (find, excluding .git):
    .

================================================================
CASE: git rm -r --cached "$PWD"
cwd:  $repo
cmd:  git rm -r --cached "$PWD"
--- exit: 0
--- stdout+stderr:
    rm 'a.txt'
    rm 'old-dir/c.txt'
    rm 'sub/b.txt'
--- index after (git ls-files):
--- worktree after (find, excluding .git):
    .
    ./a.txt
    ./old-dir
    ./old-dir/c.txt
    ./sub
    ./sub/b.txt

================================================================
CASE: git rm -r --cached .
cwd:  $repo
cmd:  git rm -r --cached .
--- exit: 0
--- stdout+stderr:
    rm 'a.txt'
    rm 'old-dir/c.txt'
    rm 'sub/b.txt'
--- index after (git ls-files):
--- worktree after (find, excluding .git):
    .
    ./a.txt
    ./old-dir
    ./old-dir/c.txt
    ./sub
    ./sub/b.txt

================================================================
CASE: git rm -r "$PWD" from subdir
cwd:  $repo/sub
cmd:  git rm -r "$PWD"
--- exit: 0
--- stdout+stderr:
    rm 'sub/b.txt'
--- index after (git ls-files):
    a.txt
    old-dir/c.txt
--- worktree after (find, excluding .git):
    .
    ./a.txt
    ./old-dir
    ./old-dir/c.txt
    ./sub

================================================================
CASE: git rm -r . from subdir
cwd:  $repo/sub
cmd:  git rm -r .
--- exit: 0
--- stdout+stderr:
    rm 'sub/b.txt'
--- index after (git ls-files):
    a.txt
    old-dir/c.txt
--- worktree after (find, excluding .git):
    .
    ./a.txt
    ./old-dir
    ./old-dir/c.txt
    ./sub

================================================================
CASE: git rm -r "${PWD}"
cwd:  $repo
cmd:  git rm -r "${PWD}"
--- exit: 0
--- stdout+stderr:
    rm 'a.txt'
    rm 'old-dir/c.txt'
    rm 'sub/b.txt'
--- index after (git ls-files):
--- worktree after (find, excluding .git):
    .

================================================================
CASE: git rm -r "$PWD"/sub/..
cwd:  $repo
cmd:  git rm -r "$PWD"/sub/..
--- exit: 0
--- stdout+stderr:
    rm 'a.txt'
    rm 'old-dir/c.txt'
    rm 'sub/b.txt'
--- index after (git ls-files):
--- worktree after (find, excluding .git):
    .

================================================================
CASE: git rm -r $PWD unquoted
cwd:  $repo
cmd:  git rm -r $PWD
--- exit: 0
--- stdout+stderr:
    rm 'a.txt'
    rm 'old-dir/c.txt'
    rm 'sub/b.txt'
--- index after (git ls-files):
--- worktree after (find, excluding .git):
    .
```

The `$(pwd)` cases ran in a second script, because the first one's own repository setup broke on that label:

```
================================================================
CASE cwd=$repo  cmd: git rm -r $(pwd)
--- exit: 0
    rm 'a.txt'
    rm 'old-dir/c.txt'
    rm 'sub/b.txt'
--- index after (git ls-files):
--- worktree after (find . excluding .git):
    .

================================================================
CASE cwd=$repo  cmd: git rm -r "$(pwd)"
--- exit: 0
    rm 'a.txt'
    rm 'old-dir/c.txt'
    rm 'sub/b.txt'
--- index after (git ls-files):
--- worktree after (find . excluding .git):
    .

================================================================
CASE cwd=$repo  cmd: git rm -r --cached $(pwd)
--- exit: 0
    rm 'a.txt'
    rm 'old-dir/c.txt'
    rm 'sub/b.txt'
--- index after (git ls-files):
--- worktree after (find . excluding .git):
    .
    ./a.txt
    ./old-dir
    ./old-dir/c.txt
    ./sub
    ./sub/b.txt
```

**The harm equals `git rm -r .` exactly.** From the repository root, `"$PWD"`, `"${PWD}"`, bare `$PWD`, `"$PWD"/.`, `"$PWD"/sub/..`, `$(pwd)` and `"$(pwd)"` each emptied the index and left nothing on disk but the directory itself. `--cached` emptied the index and left all three files on disk, for `"$PWD"` and for `.` alike. Run from `sub/`, both `"$PWD"` and `.` took that one directory's file and nothing else. So the ticket's condition for blocking is met, and step 3 (close with no change) does not apply.

## The change

Four parameter expansions on `WALK_PLAIN` spell `$PWD`, `${PWD}`, `$(pwd)` and a backticked `pwd` as `.` before Guard 3 splits the command into segments and walks it. The existing operand tests then decide them, so `"$PWD"` and `"$PWD"/.` are refused for the reason `.` and `./.` are refused, and no new branch enters the walk.

Placement is forced from both sides. The rewrite has to run before the quote strip, because that strip removes backticks and would leave `` `pwd` `` reading as the plain name `pwd`; and before `CMD_SEGMENTS=${WALK_PLAIN//[;|&()]/...}`, because that split cuts on `(` and `)` and would leave `$(pwd)` as the operand `$`. It runs after `scrub_message_body`, so a `$PWD` inside a `-m` body stays prose.

The refusal quotes the operand the walk saw, which is now `.` rather than what the agent typed, so a refusal that follows a rewrite carries one added sentence:

```
PreToolUse(Bash): this `git rm` is refused because `.` names no file or directory
of its own. `$PWD` and `pwd` expand to the working directory, so this guard reads
the operand you spelled with one of them as `.`. Name the paths to delete
(`git rm src/foo.ts src/bar.ts`, or `git rm -r src/old-dir` for one directory).
`git ls-files` lists the tracked paths.
```

## The `git add "$FILE"` allowance is intact

Guard 3's policy is that an operand whose value only the shell holds passes as a named path. `$PWD` and `pwd` are the exception this change carves out, and the exception is exactly two names. Measured against the patched hook: `git add "$FILE"`, `git add $(git diff --name-only)`, `git add "$PWD/src/foo.ts"`, `git rm -r "$PWD"/src/old-dir`, `git -C "$PWD" add src/foo.ts`, `REPO=$PWD git add src/foo.ts`, `git add "$OLDPWD"`, `git commit -m "run from $PWD"` and `rg 'git rm -r $(pwd)' .claude` all pass. `git add "$PWDX"` passes too: the rewrite makes it `.X`, which still names a path of its own.

## What is still allowed, and why

The four patterns are literal, so a spelling one character off is not rewritten. Against the patched hook, `git rm -r "${PWD:-.}"`, `git rm -r $(pwd -P)` and `git rm -r $(pwd )` all pass, and `git rm -n -r` given each of the three listed all three tracked files of the scratch repository. Two of them are pinned as `allow` rows in the test file, so widening the rewrite later fails those rows rather than moving the edge in silence.

Widening was considered and rejected. `${WALK_PLAIN//\$\{PWD*\}/.}` looks like the general form, but `*` is greedy in a bash substitution: against `git rm -r "${PWD}" && echo "${HOME}"` it matched from the first `${PWD` to the last `}` and deleted the rest of the command text. The extglob form `${PWD*([!\}])\}` avoids that, leaving the `${HOME}` alone, but it needs `shopt -s extglob`, which changes glob parsing for the whole 721-line file, and its `$(pwd...)` twin rewrites `$(pwdx 1)` to `.` as well. Four literals were the cheaper correct form.

## Review findings

Four cleanup agents and a `code-reviewer` ran on the diff. Applied:

- The refusal named `.` for a command that carried `$PWD`, and the two nearest retries (`${PWD:-.}`, `$(pwd -P)`) are live whole-tree deletes, so a confusing verdict pointed at an unguarded spelling. The added sentence above closes it, pinned by a fourth case in the group that asserts refusal wording whole.
- A `BACKQUOTE='`'` variable existed only to spell one backtick; the line below it already writes `` \` `` inline in the same construct, so it is written that way now.
- The comment respelled the scratch-repository fixture that line 303 already spells; it says "the scratch repository", as the file's other comments do.
- The comment justified leaving `${PWD:-.}` and `$(pwd -P)` alone by putting them in the header's "value only the shell holds" class, which is false for both: the guard could read them as well as it reads `$PWD`. It now states the mechanism that is true (the patterns are literal) with the measurement behind it.
- Three block rows (`--cached -r "$PWD"`, `git add $(pwd)`, `git commit -m x "$PWD"`) produced byte-identical hook output to rows the file already has, because the rewrite runs before the segment split and before any subcommand branch. Deleted. `git commit -m "run from $PWD"` was deleted for the same reason: `scrub_message_body` removes the body before the rewrite runs, so no change to these five lines can fail it.
- A group titled "an operand built from the working directory..." held a `git add "$FILE"` row that is not built from the working directory. Retitled, and `git add $(git diff --name-only)` joined it, so both commands the guard's own policy sentence names are held by a test.

Refuted with measurements rather than argument: that removing `$(pwd)`'s parentheses ahead of the segment split loses a refusal (14 shapes run against both this hook and `origin/main`'s; the two that flipped to allow, `echo hello $(pwd) git rm -r .` and `foo $(pwd) git add -A`, run no git); that `$PWD` as a substring of another name or inside a quoted pattern causes a false refusal (20 shapes, none); and that the rewrite sits wrongly among the scrub, the heredoc drop and the two strips.

## Tests

`.claude/hooks/pre-bash-guard.test.ts` goes from 236 to 247 cases: five block rows (the four spellings and `"$PWD"/.`), three allow rows for operands that name their own path, two allow rows recording the uncovered spellings, and one case asserting the whole refusal sentence.

Each of the four rewrites was deleted in turn and the suite re-run: removing the `${PWD}` line failed 1 case, `$(pwd)` 1, the backtick 1, and `$PWD` 2. The note was broken three ways: deleting its assignment, deleting `${PWD_NOTE}` from the `deny` line (1 case), and making it fire unconditionally by emptying `WALK_BEFORE_PWD` (3 cases).

## A false premise in #166's body

#166 wrote that a review had shown `git rm -r $PWD/sub/..` still passing, given as one reason to drop the narrower carve-out. Against `origin/main`'s guard as merged, `git rm -r "$PWD"/sub/..` is **blocked** — the same PR's `..` rule catches it. The premise the decision cited was already stale at merge time. The other two spellings it named, `git rm -r "$PWD"/.` and `git rm -r $(pwd)`, did pass, as the ticket said.

## Gates

`bun run check`, `bun run test` (817), `bun run knip` (exit 0) and `mise exec -- bun run check:shell` all pass. `similarity-ts` ran in the pre-push hook. Nothing was skipped for a missing binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
