### PR TITLE
chore: auto mode で gh pr merge --squash が classifier を通らず許可される

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,7 +14,8 @@
       "Bash(bun run knip)",
       "Bash(bun .claude/hooks/check-md-links.ts *)",
       "Bash(similarity-ts *)",
-      "Bash(memory_pressure)"
+      "Bash(memory_pressure)",
+      "Bash(gh pr merge --squash *)"
     ],
     "deny": [
       "Bash(rm -rf /)",


### PR DESCRIPTION
permissions.allow に Bash(gh pr merge --squash *) を追加し、PR の author が持つ merge step が Merge Without Review の soft_deny に止まらないようにする。
