### PR TITLE
refactor: Stop gate の判定が hook の入出力から分かれる

### DIFF
--- a/.claude/hooks/stop-gate-decision.sh
+++ b/.claude/hooks/stop-gate-decision.sh
@@ -45,10 +45,7 @@ holds_code_relevant_file() { # $1 = newline-delimited paths
   return 1
 }
 
-# The markdown link check's own verdict, which travels into the block body and
-# into both success messages, so a Stop that blocks on another step still says
-# what this one did. A missing runtime downgrades the step; it never silently
-# passes (AGENTS.md, "Degraded Environments").
+# The three verdicts the markdown link check can print.
 # Every sentence below reaches printf as an argument rather than as its format
 # string, so a `%` someone later writes into one of them prints as itself.
 link_note_clean() { printf '%s' 'md links: clean'; }

--- a/.claude/hooks/stop-gate-decision.sh
+++ b/.claude/hooks/stop-gate-decision.sh
@@ -1,0 +1,98 @@
+# shellcheck shell=bash
+# What the Stop gate says, and the three judgments behind it: which payload
+# field downgraded a block, whether the changed files reach the quality gate,
+# and how the failures the steps collected become one summary and one body.
+# Running the steps, reading the payload off stdin, entering the tree and
+# encoding the JSON stay in stop-gate.sh, which sources this file, so
+# stop-gate-decision.test.ts reaches every sentence below in one bash process
+# without building a scratch git repository.
+#
+# stop-gate.sh sets these options too, and they are here as well so the test
+# driver judges under the same ones. `-e` is absent from both: a step that
+# fails is collected and reported rather than ending the gate.
+set -uo pipefail
+
+# `stop_hook_active` is Claude Code's "this Stop was already blocked once"
+# flag. Cursor's stop payload carries `loop_count` (auto-followups already
+# triggered) instead, and it runs Claude-registered stop hooks with NO loop
+# limit (loop_limit defaults to null for third-party hooks), so without this
+# mapping a pre-existing failure would re-block forever there.
+# `warning_message` quotes the name this prints, so a Cursor turn reads
+# `loop_count` rather than a Claude field its payload never carried.
+downgrade_cause() { # $1 = the Stop payload; prints "" when neither field is set
+  printf '%s' "$1" | jq -j \
+    'if .stop_hook_active == true then "stop_hook_active" elif (.loop_count // 0) > 0 then "loop_count" else "" end' \
+    2>/dev/null || true
+}
+
+# The quality gate runs only when one of the changed paths carries one of these
+# suffixes, so a docs-only turn skips typecheck, lint, format and the test
+# suite. The paths arrive newline-delimited and whole, because a split on
+# whitespace would truncate a filename containing a space and skip the gate for
+# it. `case` reads each line where a `grep -q` would close the pipe on the
+# first match: under `set -o pipefail` the SIGPIPE that kills the `printf`
+# feeding it takes the pipeline to 141, which reads here as no match (measured
+# on a 20001-line list, macOS, 2026-09-09).
+holds_code_relevant_file() { # $1 = newline-delimited paths
+  local path
+  while IFS= read -r path; do
+    case "$path" in
+      *.ts | *.mts | *.cts | *.tsx | *.js | *.jsx | *.mjs | *.cjs | *.json | *.css)
+        return 0
+        ;;
+    esac
+  done <<<"$1"
+  return 1
+}
+
+# The markdown link check's own verdict, which travels into the block body and
+# into both success messages, so a Stop that blocks on another step still says
+# what this one did. A missing runtime downgrades the step; it never silently
+# passes (AGENTS.md, "Degraded Environments").
+link_note_clean() { printf 'md links: clean'; }
+link_note_failed() { printf 'md links: FAILED'; }
+link_note_skipped() { printf 'md links: SKIPPED (bun not installed)'; }
+
+# A failure is collected instead of emitted, so the steps after it still run and
+# one block names all of them.
+GATE_FAILED_STEPS=""
+GATE_FAILURE_OUTPUT=""
+
+record_failure() { # $1 = step name, $2 = the step's output
+  GATE_FAILED_STEPS="${GATE_FAILED_STEPS:+$GATE_FAILED_STEPS, }$1"
+  GATE_FAILURE_OUTPUT="${GATE_FAILURE_OUTPUT}===== $1 =====
+$2
+
+"
+}
+
+failure_summary() {
+  printf '%s failed. Fix before ending the turn.' "$GATE_FAILED_STEPS"
+}
+
+failure_body() { # $1 = the link note
+  printf '%s%s' "$GATE_FAILURE_OUTPUT" "$1"
+}
+
+block_message() { # $1 = summary
+  printf '⛔ Stop block: %s' "$1"
+}
+
+block_reason() { # $1 = summary, $2 = reason body
+  printf '%s\n\n%s' "$1" "$2"
+}
+
+# Emitted in place of a block when downgrade_cause named a field, so an
+# unfixable failure does not loop.
+warning_message() { # $1 = downgrade cause, $2 = summary, $3 = reason body
+  printf '⚠️ Stop gate STILL failing (not re-blocking — %s): %s — if this failure is pre-existing or unfixable, report it to the user explicitly; do not treat it as passed.\n%s' \
+    "$1" "$2" "$3"
+}
+
+quality_gate_pass_message() { # $1 = the link note
+  printf '✅ Stop gate: typecheck / lint / format and the test suite pass (%s)' "$1"
+}
+
+quality_gate_skipped_message() { # $1 = the link note
+  printf '✅ Stop gate: no code-relevant changes (quality gate skipped, %s)' "$1"
+}

--- a/.claude/hooks/stop-gate-decision.sh
+++ b/.claude/hooks/stop-gate-decision.sh
@@ -49,9 +49,11 @@ holds_code_relevant_file() { # $1 = newline-delimited paths
 # into both success messages, so a Stop that blocks on another step still says
 # what this one did. A missing runtime downgrades the step; it never silently
 # passes (AGENTS.md, "Degraded Environments").
-link_note_clean() { printf 'md links: clean'; }
-link_note_failed() { printf 'md links: FAILED'; }
-link_note_skipped() { printf 'md links: SKIPPED (bun not installed)'; }
+# Every sentence below reaches printf as an argument rather than as its format
+# string, so a `%` someone later writes into one of them prints as itself.
+link_note_clean() { printf '%s' 'md links: clean'; }
+link_note_failed() { printf '%s' 'md links: FAILED'; }
+link_note_skipped() { printf '%s' 'md links: SKIPPED (bun not installed)'; }
 
 # A failure is collected instead of emitted, so the steps after it still run and
 # one block names all of them.
@@ -67,7 +69,7 @@ $2
 }
 
 failure_summary() {
-  printf '%s failed. Fix before ending the turn.' "$GATE_FAILED_STEPS"
+  printf '%s' "$GATE_FAILED_STEPS failed. Fix before ending the turn."
 }
 
 failure_body() { # $1 = the link note
@@ -75,7 +77,7 @@ failure_body() { # $1 = the link note
 }
 
 block_message() { # $1 = summary
-  printf '⛔ Stop block: %s' "$1"
+  printf '%s' "⛔ Stop block: $1"
 }
 
 block_reason() { # $1 = summary, $2 = reason body
@@ -85,14 +87,15 @@ block_reason() { # $1 = summary, $2 = reason body
 # Emitted in place of a block when downgrade_cause named a field, so an
 # unfixable failure does not loop.
 warning_message() { # $1 = downgrade cause, $2 = summary, $3 = reason body
-  printf '⚠️ Stop gate STILL failing (not re-blocking — %s): %s — if this failure is pre-existing or unfixable, report it to the user explicitly; do not treat it as passed.\n%s' \
-    "$1" "$2" "$3"
+  printf '%s\n%s' \
+    "⚠️ Stop gate STILL failing (not re-blocking — $1): $2 — if this failure is pre-existing or unfixable, report it to the user explicitly; do not treat it as passed." \
+    "$3"
 }
 
 quality_gate_pass_message() { # $1 = the link note
-  printf '✅ Stop gate: typecheck / lint / format and the test suite pass (%s)' "$1"
+  printf '%s' "✅ Stop gate: typecheck / lint / format and the test suite pass ($1)"
 }
 
 quality_gate_skipped_message() { # $1 = the link note
-  printf '✅ Stop gate: no code-relevant changes (quality gate skipped, %s)' "$1"
+  printf '%s' "✅ Stop gate: no code-relevant changes (quality gate skipped, $1)"
 }

--- a/.claude/hooks/stop-gate-decision.test.ts
+++ b/.claude/hooks/stop-gate-decision.test.ts
@@ -35,12 +35,16 @@ const call = (fn: string, ...args: readonly string[]): string =>
  * substitution strips them, so the answer would otherwise read as the same
  * text with the newline gone. `answers_yes` reports an exit status as a word,
  * because holds_code_relevant_file prints nothing.
+ *
+ * The `</dev/null` closes the snippet off from this stream. Without it a
+ * decision function that read stdin would eat the snippets not yet read, and
+ * every case after it would be compared against another case's answer.
  */
 const DRIVER = `
 . "$1"
 answers_yes() { if "$@"; then printf 'yes'; else printf 'no'; fi; }
 while IFS= read -r -d '' SNIPPET; do
-  ANSWER=$(eval "$SNIPPET"; printf '.')
+  ANSWER=$(eval "$SNIPPET" </dev/null; printf '.')
   printf '%s\\0' "\${ANSWER%.}"
 done
 `;

--- a/.claude/hooks/stop-gate-decision.test.ts
+++ b/.claude/hooks/stop-gate-decision.test.ts
@@ -89,6 +89,31 @@ interface Case {
   answer: string;
 }
 
+/**
+ * Every suffix `holds_code_relevant_file` accepts, one case each. A single
+ * case listing all ten would pass on the first match alone, so dropping one
+ * pattern from the decision file would leave the suite green and a turn that
+ * changed a file with that suffix would skip the quality gate.
+ */
+const CODE_EXTENSIONS = [
+  "ts",
+  "mts",
+  "cts",
+  "tsx",
+  "js",
+  "jsx",
+  "mjs",
+  "cjs",
+  "json",
+  "css",
+] as const;
+
+const EXTENSION_CASES: readonly Case[] = CODE_EXTENSIONS.map((extension) => ({
+  answer: "yes",
+  name: `should reach the quality gate when a changed path ends in .${extension}`,
+  snippet: `answers_yes ${call("holds_code_relevant_file", `docs/note.md\nsrc/a.${extension}`)}`,
+}));
+
 const CASES: readonly Case[] = [
   {
     answer: "stop_hook_active",
@@ -134,11 +159,7 @@ const CASES: readonly Case[] = [
     name: "should name no cause when the payload is not JSON",
     snippet: call("downgrade_cause", "{not json"),
   },
-  {
-    answer: "yes",
-    name: "should reach the quality gate when one changed path carries a code extension",
-    snippet: `answers_yes ${call("holds_code_relevant_file", "docs/note.md\nsrc/a.ts")}`,
-  },
+  ...EXTENSION_CASES,
   {
     answer: "no",
     name: "should skip the quality gate when every changed path is a document",

--- a/.claude/hooks/stop-gate-decision.test.ts
+++ b/.claude/hooks/stop-gate-decision.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Exercise the judgments and the wording in
+ * .claude/hooks/stop-gate-decision.sh: which payload field downgrades a block,
+ * whether the changed files reach the quality gate, how collected failures
+ * become one summary and one body, and the sentence each outcome prints.
+ *
+ * Every case here reaches the same code .claude/hooks/stop-gate.sh runs,
+ * through one bash process for the whole file: the driver below sources the
+ * decision file once and evaluates the snippets it reads NUL-delimited on
+ * stdin, each inside a command substitution so one case's collected failures
+ * do not reach the next. stop-gate.test.ts builds a scratch git repository with
+ * stub steps per case instead, because what it judges is which steps the gate
+ * ran and which tree it judged them in.
+ */
+
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { text } from "node:stream/consumers";
+import { describe, expect, it } from "vite-plus/test";
+
+const DECISION = path.resolve(import.meta.dirname, "stop-gate-decision.sh");
+
+/** One shell word carrying `value` verbatim, whatever it holds. */
+const quoted = (value: string): string => `'${value.replaceAll("'", `'\\''`)}'`;
+
+/** A call to one decision function, its arguments passed verbatim. */
+const call = (fn: string, ...args: readonly string[]): string =>
+  [fn, ...args.map(quoted)].join(" ");
+
+/**
+ * `read -d ''` splits on NUL, which keeps a snippet spanning lines in one
+ * piece, and the answers come back NUL-delimited in the same order.
+ *
+ * The trailing `.` is what keeps a newline the wording ends on: a command
+ * substitution strips them, so the answer would otherwise read as the same
+ * text with the newline gone. `answers_yes` reports an exit status as a word,
+ * because holds_code_relevant_file prints nothing.
+ */
+const DRIVER = `
+. "$1"
+answers_yes() { if "$@"; then printf 'yes'; else printf 'no'; fi; }
+while IFS= read -r -d '' SNIPPET; do
+  ANSWER=$(eval "$SNIPPET"; printf '.')
+  printf '%s\\0' "\${ANSWER%.}"
+done
+`;
+
+/**
+ * What the driver answered for one batch of snippets.
+ *
+ * A driver that died partway through would leave the answers short of the
+ * snippets, and each case after that point would compare against another
+ * case's answer. The count and the stderr travel with them, and the first test
+ * compares both.
+ */
+interface DriverRun {
+  answers: readonly string[];
+  stderr: string;
+}
+
+const runDriver = async (snippets: readonly string[]): Promise<DriverRun> => {
+  const driver = spawn("bash", ["-c", DRIVER, "bash", DECISION]);
+  driver.stdin.end(snippets.map((snippet) => `${snippet}\0`).join(""));
+  const [stdout, stderr] = await Promise.all([
+    text(driver.stdout),
+    text(driver.stderr),
+  ]);
+  // The driver terminates every answer with a NUL, so the split leaves one
+  // trailing empty piece that belongs to no snippet.
+  return { answers: stdout.split("\0").slice(0, -1), stderr };
+};
+
+const LINK_CLEAN = "md links: clean";
+const LINK_FAILED = "md links: FAILED";
+const LINK_SKIPPED = "md links: SKIPPED (bun not installed)";
+
+const SUMMARY = "bun run check failed. Fix before ending the turn.";
+const RECORD_CHECK = call("record_failure", "bun run check", "check said no");
+
+/** The first path matches, so a reader that stopped at the match would leave the rest unread. */
+const LONG_LIST = [
+  "src/a.ts",
+  ...Array.from({ length: 20_000 }, () => "docs/note.md"),
+].join("\n");
+
+interface Case {
+  name: string;
+  snippet: string;
+  answer: string;
+}
+
+const CASES: readonly Case[] = [
+  {
+    answer: "stop_hook_active",
+    name: "should name stop_hook_active when Claude Code reports this Stop was already blocked",
+    snippet: call(
+      "downgrade_cause",
+      JSON.stringify({ stop_hook_active: true })
+    ),
+  },
+  {
+    answer: "loop_count",
+    name: "should name loop_count when Cursor reports an auto-followup already ran",
+    snippet: call("downgrade_cause", JSON.stringify({ loop_count: 1 })),
+  },
+  {
+    answer: "stop_hook_active",
+    name: "should name stop_hook_active when the payload carries both fields",
+    snippet: call(
+      "downgrade_cause",
+      JSON.stringify({ loop_count: 1, stop_hook_active: true })
+    ),
+  },
+  {
+    answer: "",
+    name: "should name no cause when the payload carries neither field",
+    snippet: call("downgrade_cause", JSON.stringify({ cwd: "/tmp" })),
+  },
+  {
+    answer: "",
+    name: "should name no cause when Claude Code reports this Stop was not blocked before",
+    snippet: call(
+      "downgrade_cause",
+      JSON.stringify({ stop_hook_active: false })
+    ),
+  },
+  {
+    answer: "",
+    name: "should name no cause when Cursor reports no auto-followup yet",
+    snippet: call("downgrade_cause", JSON.stringify({ loop_count: 0 })),
+  },
+  {
+    answer: "",
+    name: "should name no cause when the payload is not JSON",
+    snippet: call("downgrade_cause", "{not json"),
+  },
+  {
+    answer: "yes",
+    name: "should reach the quality gate when one changed path carries a code extension",
+    snippet: `answers_yes ${call("holds_code_relevant_file", "docs/note.md\nsrc/a.ts")}`,
+  },
+  {
+    answer: "no",
+    name: "should skip the quality gate when every changed path is a document",
+    snippet: `answers_yes ${call("holds_code_relevant_file", "docs/note.md\nREADME.md")}`,
+  },
+  {
+    answer: "no",
+    name: "should skip the quality gate when nothing changed",
+    snippet: `answers_yes ${call("holds_code_relevant_file", "")}`,
+  },
+  {
+    answer: "yes",
+    name: "should reach the quality gate when the code file's name holds a space",
+    snippet: `answers_yes ${call("holds_code_relevant_file", "src/my notes.ts")}`,
+  },
+  {
+    answer: "no",
+    name: "should skip the quality gate when a code extension sits inside the name rather than at its end",
+    snippet: `answers_yes ${call("holds_code_relevant_file", "src/a.ts.bak")}`,
+  },
+  {
+    answer: "yes",
+    name: "should reach the quality gate when the matching path is followed by 20000 more",
+    snippet: `answers_yes ${call("holds_code_relevant_file", LONG_LIST)}`,
+  },
+  {
+    answer: SUMMARY,
+    name: "should name the one step that failed in the summary",
+    snippet: `${RECORD_CHECK}; failure_summary`,
+  },
+  {
+    answer: "bun run check, bun run test failed. Fix before ending the turn.",
+    name: "should name both steps in one summary when the step after a failing one fails too",
+    snippet: `${RECORD_CHECK}; ${call("record_failure", "bun run test", "test said no")}; failure_summary`,
+  },
+  {
+    answer: `===== markdown link check =====
+links said no
+
+${LINK_FAILED}`,
+    name: "should carry the failing step's output and the link note into the body",
+    snippet: `${call("record_failure", "markdown link check", "links said no")}; failure_body "$(link_note_failed)"`,
+  },
+  {
+    answer: `⛔ Stop block: ${SUMMARY}`,
+    name: "should mark the summary as a block when the gate blocks",
+    snippet: call("block_message", SUMMARY),
+  },
+  {
+    answer: `${SUMMARY}\n\nthe body`,
+    name: "should separate the summary from the body by a blank line in the block reason",
+    snippet: call("block_reason", SUMMARY, "the body"),
+  },
+  {
+    answer: `⚠️ Stop gate STILL failing (not re-blocking — stop_hook_active): ${SUMMARY} — if this failure is pre-existing or unfixable, report it to the user explicitly; do not treat it as passed.\nthe body`,
+    name: "should name the field that downgraded the block in the warning",
+    snippet: call("warning_message", "stop_hook_active", SUMMARY, "the body"),
+  },
+  {
+    answer: `✅ Stop gate: typecheck / lint / format and the test suite pass (${LINK_CLEAN})`,
+    name: "should report the quality gate and a clean link check as passing",
+    snippet: 'quality_gate_pass_message "$(link_note_clean)"',
+  },
+  {
+    answer: `✅ Stop gate: no code-relevant changes (quality gate skipped, ${LINK_SKIPPED})`,
+    name: "should report the skipped quality gate and the link check bun could not run",
+    snippet: 'quality_gate_skipped_message "$(link_note_skipped)"',
+  },
+];
+
+// The whole table is answered while this file is loaded, so each case below is
+// a synchronous comparison and none of them carries the driver's wall time.
+const RUN = await runDriver(CASES.map((one) => one.snippet));
+
+describe("stop-gate-decision.sh", () => {
+  it("should answer every snippet with nothing on stderr when the driver ran to the end", () => {
+    expect({ answered: RUN.answers.length, stderr: RUN.stderr }).toStrictEqual({
+      answered: CASES.length,
+      stderr: "",
+    });
+  });
+
+  it.each(CASES.map((one, index) => ({ ...one, index })))(
+    "$name",
+    ({ answer, index, name }) => {
+      expect({ answer: RUN.answers[index], name }).toStrictEqual({
+        answer,
+        name,
+      });
+    }
+  );
+});

--- a/.claude/hooks/stop-gate.sh
+++ b/.claude/hooks/stop-gate.sh
@@ -13,6 +13,11 @@
 # downgrades to a warning instead of blocking again when the payload says this
 # Stop already triggered a followup, so a pre-existing failure the agent cannot
 # fix does not loop forever. The warning names which field said so.
+#
+# This file reads the payload, enters the tree, runs the steps and encodes the
+# JSON. What the gate says, which payload field downgrades a block and whether
+# the changed files reach the quality gate all live in stop-gate-decision.sh,
+# which this file sources.
 
 set -uo pipefail
 
@@ -26,53 +31,55 @@ CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null || true)
 if [ -n "$CWD" ] && [ -d "$CWD/.claude/hooks" ]; then
   ROOT="$CWD"
 fi
-# `stop_hook_active` is Claude Code's "this Stop was already blocked once"
-# flag. Cursor's stop payload carries `loop_count` (auto-followups already
-# triggered) instead — and it runs Claude-registered stop hooks with NO loop
-# limit (loop_limit defaults to null for third-party hooks), so without this
-# mapping a pre-existing failure would re-block forever there.
-# The warning below quotes this value, so a Cursor turn reads `loop_count`
-# rather than a Claude field its payload never carried.
-DOWNGRADE_CAUSE=$(printf '%s' "$INPUT" | jq -r \
-  'if .stop_hook_active == true then "stop_hook_active" elif (.loop_count // 0) > 0 then "loop_count" else "" end' \
-  2>/dev/null || echo "")
 
-# Emit a block, downgraded to a warning when DOWNGRADE_CAUSE is set, to prevent
-# an unfixable failure from looping.
-# The body reaches jq through a pipe rather than argv: `--arg body "$2"` made
-# execve fail with E2BIG once a step's diagnostics crossed ARG_MAX (1048576 on
-# macOS), and the exit below then ended the turn having printed nothing.
-# `printf` is a shell builtin, so the body never passes through an argv again.
-emit_block() { # $1 = summary, $2 = reason body
-  if [ -n "$DOWNGRADE_CAUSE" ]; then
-    printf '%s' "$2" | jq -n --arg sum "$1" --arg cause "$DOWNGRADE_CAUSE" --rawfile body /dev/stdin '{
-      systemMessage: ("⚠️ Stop gate STILL failing (not re-blocking — " + $cause + "): " + $sum + " — if this failure is pre-existing or unfixable, report it to the user explicitly; do not treat it as passed.\n" + $body)
-    }'
-  else
-    printf '%s' "$2" | jq -n --arg sum "$1" --rawfile body /dev/stdin '{
-      systemMessage: ("⛔ Stop block: " + $sum),
-      decision: "block",
-      reason: ($sum + "\n\n" + $body)
-    }'
-  fi
-  exit 0
-}
-
-FAILED_STEPS=""
-FAILURE_OUTPUT=""
-
-# Both blocks that fire before any step runs end with this, so a step added
+# Every block that fires before any step runs ends with this, so a step added
 # below reaches them without being written into each body again.
 NOTHING_RAN="Nothing below it was judged: no typecheck, no lint, no format, no test suite, no markdown link check."
 
-# A failure is collected instead of emitted, so the steps after it still run and
-# one block names all of them.
-record_failure() { # $1 = step name, $2 = the step's output
-  FAILED_STEPS="${FAILED_STEPS:+$FAILED_STEPS, }$1"
-  FAILURE_OUTPUT="${FAILURE_OUTPUT}===== $1 =====
-$2
+# A `source` that fails leaves every function of the decision file undefined,
+# and the gate would then end the turn having judged nothing. Blocking instead
+# puts that failure where the turn cannot pass it by. This is the one block the
+# downgrade below cannot reach, because the mapping that reads it is in the
+# file that would not load; restoring the file is what ends the block.
+# `$0` carries the directory whenever the caller names this file by path, which
+# .claude/settings.json and stop-gate.test.ts both do; a bare
+# `bash stop-gate.sh` leaves the name in place, finds no file under it and
+# takes the block.
+HOOK_DIR=${0%/*}
+# shellcheck source=.claude/hooks/stop-gate-decision.sh
+if ! source "$HOOK_DIR/stop-gate-decision.sh" 2>/dev/null; then
+  jq -n --arg dir "$HOOK_DIR" --arg nothing "$NOTHING_RAN" '{
+    systemMessage: ("⛔ Stop block: the Stop gate could not load " + $dir + "/stop-gate-decision.sh, so no check ran."),
+    decision: "block",
+    reason: ("The Stop gate could not load " + $dir + "/stop-gate-decision.sh, so no check ran. Put that file back beside stop-gate.sh, or run the hook by a path that names its directory. " + $nothing)
+  }'
+  exit 0
+fi
 
-"
+DOWNGRADE_CAUSE=$(downgrade_cause "$INPUT")
+
+# The message reaches jq through a pipe rather than argv: `--arg body "$2"` made
+# execve fail with E2BIG once a step's diagnostics crossed ARG_MAX (1048576 on
+# macOS), and the exit below then ended the turn having printed nothing.
+# `printf` is a shell builtin, so no message the gate composes passes through an
+# argv again.
+emit_message() { # the message on stdin
+  jq -n --rawfile message /dev/stdin '{systemMessage: $message}'
+}
+
+# Emit a block, downgraded to a warning when DOWNGRADE_CAUSE is set, to prevent
+# an unfixable failure from looping.
+emit_block() { # $1 = summary, $2 = reason body
+  if [ -n "$DOWNGRADE_CAUSE" ]; then
+    warning_message "$DOWNGRADE_CAUSE" "$1" "$2" | emit_message
+  else
+    block_reason "$1" "$2" | jq -n --arg message "$(block_message "$1")" --rawfile reason /dev/stdin '{
+      systemMessage: $message,
+      decision: "block",
+      reason: $reason
+    }'
+  fi
+  exit 0
 }
 
 # `local out` is separate from the assignment because `local out=$(...)` would
@@ -124,9 +131,9 @@ ALL_FILES=$(printf '%s\n%s' "$CHANGED" "$UNTRACKED" | sort -u)
 
 # ==== 1. Quality gate (only when code-relevant files changed) ====
 
-CODE_CHANGED=$(printf '%s\n' "$ALL_FILES" | grep -cE '\.(ts|mts|cts|tsx|js|jsx|mjs|cjs|json|css)$' || true)
-
-if [ "$CODE_CHANGED" -gt 0 ]; then
+CODE_RELEVANT=no
+if holds_code_relevant_file "$ALL_FILES"; then
+  CODE_RELEVANT=yes
   # `bun run check` is `vp check`, which formats, lints and type-checks over one
   # file walk. `bun run test` is `vp test --run --coverage`.
   run_step check
@@ -140,31 +147,27 @@ fi
 # deleted, and the file holding the link is then untouched. Scoping to the diff
 # would have missed the case that motivated the check (docs/adr/ deleted on
 # 2026-07-29, dead links left in files the same commit did not edit).
-# LINK_NOTE carries this step's own verdict into the block body and into both
-# summary branches, so a Stop that blocks on another step still says what this
-# one did. Each branch below sets it, because a note left at "clean" while the
+# Each branch below sets LINK_NOTE, because a note left at "clean" while the
 # check failed would contradict the failure section in the same body.
-LINK_NOTE="md links: clean"
+LINK_NOTE=$(link_note_clean)
 if command -v bun >/dev/null 2>&1; then
   if ! LINKS=$(bun "$ROOT/.claude/hooks/check-md-links.ts" 2>&1); then
     record_failure "markdown link check" "$LINKS"
-    LINK_NOTE="md links: FAILED"
+    LINK_NOTE=$(link_note_failed)
   fi
 else
-  # A missing runtime downgrades the step; it never silently passes
-  # (AGENTS.md, "Degraded Environments").
-  LINK_NOTE="md links: SKIPPED (bun not installed)"
+  LINK_NOTE=$(link_note_skipped)
 fi
 
 # ==== Report every failure the steps above collected ====
 
-if [ -n "$FAILED_STEPS" ]; then
-  emit_block "$FAILED_STEPS failed. Fix before ending the turn." "$FAILURE_OUTPUT$LINK_NOTE"
+if [ -n "$GATE_FAILED_STEPS" ]; then
+  emit_block "$(failure_summary)" "$(failure_body "$LINK_NOTE")"
 fi
 
-if [ "$CODE_CHANGED" -gt 0 ]; then
-  jq -n --arg links "$LINK_NOTE" '{"systemMessage":("✅ Stop gate: typecheck / lint / format and the test suite pass (" + $links + ")")}'
+if [ "$CODE_RELEVANT" = yes ]; then
+  quality_gate_pass_message "$LINK_NOTE" | emit_message
 else
-  jq -n --arg links "$LINK_NOTE" '{"systemMessage":("✅ Stop gate: no code-relevant changes (quality gate skipped, " + $links + ")")}'
+  quality_gate_skipped_message "$LINK_NOTE" | emit_message
 fi
 exit 0

--- a/.claude/hooks/stop-gate.sh
+++ b/.claude/hooks/stop-gate.sh
@@ -156,6 +156,8 @@ if command -v bun >/dev/null 2>&1; then
     LINK_NOTE=$(link_note_failed)
   fi
 else
+  # A missing runtime downgrades the step; it never silently passes
+  # (AGENTS.md, "Degraded Environments").
   LINK_NOTE=$(link_note_skipped)
 fi
 

--- a/.claude/hooks/stop-gate.sh
+++ b/.claude/hooks/stop-gate.sh
@@ -40,7 +40,7 @@ NOTHING_RAN="Nothing below it was judged: no typecheck, no lint, no format, no t
 # and the gate would then end the turn having judged nothing. Blocking instead
 # puts that failure where the turn cannot pass it by. This is the one block the
 # downgrade below cannot reach, because the mapping that reads it is in the
-# file that would not load; restoring the file is what ends the block.
+# file that would not load; loading that file again is what ends the block.
 # `$0` carries the directory whenever the caller names this file by path, which
 # .claude/settings.json and stop-gate.test.ts both do; a bare
 # `bash stop-gate.sh` leaves the name in place, finds no file under it and
@@ -48,10 +48,18 @@ NOTHING_RAN="Nothing below it was judged: no typecheck, no lint, no format, no t
 HOOK_DIR=${0%/*}
 # shellcheck source=.claude/hooks/stop-gate-decision.sh
 if ! source "$HOOK_DIR/stop-gate-decision.sh" 2>/dev/null; then
-  jq -n --arg dir "$HOOK_DIR" --arg nothing "$NOTHING_RAN" '{
+  # A file that is absent and a file that will not parse are the two ways the
+  # `source` above fails, and they need different fixes, so the block carries
+  # what bash says about this one. `bash -n` reads the file without running it,
+  # and prints the path for the first and the line and the token for the
+  # second. Reading the failing `source`'s own stderr instead would need a
+  # temp file, because a command substitution around it would define the
+  # functions in a subshell that then exits.
+  SOURCE_ERROR=$(bash -n "$HOOK_DIR/stop-gate-decision.sh" 2>&1)
+  jq -n --arg dir "$HOOK_DIR" --arg why "$SOURCE_ERROR" --arg nothing "$NOTHING_RAN" '{
     systemMessage: ("⛔ Stop block: the Stop gate could not load " + $dir + "/stop-gate-decision.sh, so no check ran."),
     decision: "block",
-    reason: ("The Stop gate could not load " + $dir + "/stop-gate-decision.sh, so no check ran. Put that file back beside stop-gate.sh, or run the hook by a path that names its directory. " + $nothing)
+    reason: ("The Stop gate could not load " + $dir + "/stop-gate-decision.sh, so no check ran:\n" + $why + "\n" + $nothing)
   }'
   exit 0
 fi

--- a/.claude/hooks/stop-gate.test.ts
+++ b/.claude/hooks/stop-gate.test.ts
@@ -121,6 +121,8 @@ interface StopPayload {
 interface RunOptions {
   /** Overrides the payload's `cwd`, which the gate prefers over CLAUDE_PROJECT_DIR. */
   cwd?: string;
+  /** Overrides the copy of the gate that runs, which decides where it looks for the decision file. */
+  gate?: string;
   loopCount?: number;
   path?: string;
   projectDir?: string;
@@ -133,7 +135,7 @@ const runGate = (root: string, options: RunOptions = {}): GateRun => {
     loop_count: options.loopCount,
     stop_hook_active: options.stopHookActive,
   };
-  const result = spawnSync("bash", [GATE], {
+  const result = spawnSync("bash", [options.gate ?? GATE], {
     cwd: root,
     encoding: "utf-8",
     env: {
@@ -388,6 +390,28 @@ md links: FAILED`,
       decision: "block",
       status: 0,
       systemMessage: `⛔ Stop block: the Stop gate could not read git status in ${broken}, so no check ran.`,
+    });
+  });
+
+  // A copy of the entry alone has no stop-gate-decision.sh beside it, which
+  // leaves every function it calls undefined. With the entry's `source` guard
+  // loosened to `if false`, the gate carried on and emitted an empty
+  // systemMessage, ending the turn with nothing judged. Deciding that needs no
+  // scratch repository.
+  it("should block naming the decision file when the entry cannot load it", () => {
+    const lone = scratchDir("stop-gate-lone-");
+    fs.copyFileSync(GATE, path.join(lone, "stop-gate.sh"));
+
+    const run = runGate(lone, { gate: path.join(lone, "stop-gate.sh") });
+
+    expect({
+      decision: run.decision,
+      status: run.status,
+      systemMessage: run.systemMessage,
+    }).toStrictEqual({
+      decision: "block",
+      status: 0,
+      systemMessage: `⛔ Stop block: the Stop gate could not load ${lone}/stop-gate-decision.sh, so no check ran.`,
     });
   });
 });

--- a/.claude/hooks/stop-gate.test.ts
+++ b/.claude/hooks/stop-gate.test.ts
@@ -19,6 +19,7 @@ import { z } from "zod";
 import { readHookJson } from "./hook-output";
 
 const GATE = path.resolve(import.meta.dirname, "stop-gate.sh");
+const DECISION = path.resolve(import.meta.dirname, "stop-gate-decision.sh");
 
 /** A directory the case owns, removed when the case ends. */
 const scratchDir = (prefix: string): string => {
@@ -412,6 +413,29 @@ md links: FAILED`,
       decision: "block",
       status: 0,
       systemMessage: `⛔ Stop block: the Stop gate could not load ${lone}/stop-gate-decision.sh, so no check ran.`,
+    });
+  });
+
+  // The other way the `source` fails is a decision file that will not parse,
+  // and the block's remedy for a missing file is the wrong one for it, so the
+  // reason carries what bash says about this file rather than a guess.
+  it("should carry bash's reason into the block when the decision file does not parse", () => {
+    const broken = scratchDir("stop-gate-unparsable-");
+    fs.copyFileSync(GATE, path.join(broken, "stop-gate.sh"));
+    fs.copyFileSync(DECISION, path.join(broken, "stop-gate-decision.sh"));
+    fs.appendFileSync(
+      path.join(broken, "stop-gate-decision.sh"),
+      "if [ x ; then\n"
+    );
+
+    const run = runGate(broken, { gate: path.join(broken, "stop-gate.sh") });
+
+    expect({
+      decision: run.decision,
+      reasonNamesTheParseFailure: run.reason.includes("syntax error"),
+    }).toStrictEqual({
+      decision: "block",
+      reasonNamesTheParseFailure: true,
     });
   });
 });

--- a/.claude/hooks/stop-gate.test.ts
+++ b/.claude/hooks/stop-gate.test.ts
@@ -330,7 +330,7 @@ md links: FAILED`,
     const root = scratchRepo(PASSING, ["notes.md"]);
 
     const run = runGate(root, {
-      path: pathWithOnly(["bash", "cat", "git", "grep", "jq", "sort"]),
+      path: pathWithOnly(["bash", "cat", "git", "jq", "sort"]),
     });
 
     expect(run.systemMessage).toBe(

--- a/.claude/hooks/stop-gate.test.ts
+++ b/.claude/hooks/stop-gate.test.ts
@@ -108,14 +108,12 @@ const GateOutput = z.object({
 /** What one Stop gate run reported. */
 type GateRun = z.infer<typeof GateOutput> & {
   status: number | null;
-  stderr: string;
   stdout: string;
 };
 
 /** The Stop payload the harness sends. JSON.stringify drops the absent fields. */
 interface StopPayload {
   cwd: string;
-  hook_event_name: string;
   loop_count: number | undefined;
   stop_hook_active: boolean | undefined;
 }
@@ -132,7 +130,6 @@ interface RunOptions {
 const runGate = (root: string, options: RunOptions = {}): GateRun => {
   const payload: StopPayload = {
     cwd: options.cwd ?? root,
-    hook_event_name: "Stop",
     loop_count: options.loopCount,
     stop_hook_active: options.stopHookActive,
   };
@@ -150,7 +147,6 @@ const runGate = (root: string, options: RunOptions = {}): GateRun => {
   return {
     ...readHookJson(result.stdout, GateOutput),
     status: result.status,
-    stderr: result.stderr,
     stdout: result.stdout,
   };
 };

--- a/.claude/hooks/stop-gate.test.ts
+++ b/.claude/hooks/stop-gate.test.ts
@@ -47,7 +47,7 @@ const PASSING: Steps = {
 /**
  * A committed git repository with the three step stand-ins in place, plus the
  * named files left untracked so `git status --porcelain` reports them and
- * CODE_CHANGED counts them.
+ * `holds_code_relevant_file` sees them.
  */
 const scratchRepo = (steps: Steps, untracked: readonly string[]): string => {
   const root = scratchDir("stop-gate-");


### PR DESCRIPTION
The Stop gate's three judgments and every sentence it prints now live in `.claude/hooks/stop-gate-decision.sh`. `.claude/hooks/stop-gate.sh` is the entry that sources it, and keeps what touches the outside: reading the payload, entering the tree, running the steps, encoding the JSON. The new `.claude/hooks/stop-gate-decision.test.ts` answers 30 snippets in one bash process.

This is phase 4 of the plan in #175, and the last phase that plan names.

## What moved

| name | what it decides |
| --- | --- |
| `downgrade_cause` | whether `stop_hook_active` or `loop_count` downgraded the block, and which name the warning quotes |
| `holds_code_relevant_file` | whether a changed path reaches the quality gate |
| `record_failure`, `failure_summary`, `failure_body` | how the failures the steps collected become one summary and one body |
| `block_message`, `block_reason`, `warning_message` | the block and the warning it downgrades to |
| `quality_gate_pass_message`, `quality_gate_skipped_message` | the two success lines |
| `link_note_clean`, `link_note_failed`, `link_note_skipped` | what the markdown link check reports, the skip a missing `bun` earns included |

Two of those are new shapes rather than moved text.

`CODE_CHANGED=$(printf '%s\n' "$ALL_FILES" | grep -cE ...)` counted matching lines and was then read as `-gt 0` twice, so it is now the predicate `holds_code_relevant_file`. Its body is a per-line `case` rather than a `grep`, because the obvious `grep -q` is wrong here: `-q` closes the pipe on the first match, and under `set -o pipefail` the SIGPIPE that kills the feeding `printf` takes the pipeline to 141, which the `if` reads as no match. On a 20001-line list whose first line matched, that pipeline returned 141 here on 2026-09-09. A case in the new file passes the same 20001 lines, so a rewrite back to `grep -q` fails it.

`jq -r` became `jq -j` in `downgrade_cause`, and the fallback `|| echo ""` became `|| true`. Both dropped a trailing newline that the entry's `DOWNGRADE_CAUSE=$(...)` was stripping anyway, and every other function in the decision file prints without one.

## The hole the split opens, and the block that fills it

A `source` that fails leaves every function above undefined. Loosening the entry's guard to `if false` and running the entry alone in a directory with no decision file beside it produced a gate that carried on and emitted an empty `systemMessage`, ending the turn with nothing judged. The entry now takes the `source` through `if !` and blocks.

Two failures reach that block and they need different fixes, so it carries what bash says about this one: `bash -n` reads the file again without running it, printing the path when the file is absent and the line and the token when it does not parse. Reading the failing `source`'s own stderr would need a temp file, because a command substitution around a `source` defines the functions in a subshell that then exits, and `shellcheck -x` 0.11.0 crashes on that shape (`Non-exhaustive patterns in function checkCmd`, reproduced here on a four-line file).

Two cases in `stop-gate.test.ts` cover the block, and both need no scratch git repository: one copies the entry alone into a temp directory, the other copies both files and appends `if [ x ; then` to the decision file.

That block is the one the downgrade cannot reach, because the mapping that reads `stop_hook_active` is in the file that would not load. A missing decision file therefore blocks every Stop until someone puts it back. The alternative is a second copy of the jq expression in the entry, and the failure it would buy back is a broken checkout rather than a check the agent cannot fix.

In #175 this guard was its own commit. Here it ships with the extraction: writing the intermediate state, an entry whose `source` has no guard, was refused by the auto-mode classifier, and the guard is not separable from the `source` it guards without that state existing in the tree first.

## Which of the 13 cases still need the scratch repository

All 13. Each one judges which steps the gate ran, or which tree it ran them in, and the scratch repository is what makes a step fail or a tree unreadable on demand. No case in that file is only about the wording.

The cost of a case is real processes rather than stubbed ones. `scratchRepo` runs `git init`, `git add` and `git commit` for real, and the gate then runs real `bun run check`, `bun run test` and `bun <link check>`; what is stubbed is the `package.json` script each one executes. The one case that touches `PATH` builds a directory of symlinks so that `bun` is *absent*.

So this phase takes no time off `stop-gate.test.ts`. What it buys is that the next case about a sentence, a downgrade field or an extension is a line in the new file rather than another scratch repository, and that each judgment now has a test naming it and asserting the whole sentence it answers with.

## Measurements

Wall time on this machine moved more between repeated runs than this change moves it, so both readings of each are given, taken back to back on 2026-09-09 (macOS, other work running).

| | before | after |
| --- | --- | --- |
| `stop-gate.test.ts` | 13 cases, 15.03 s / 14.27 s | 15 cases, 12.50 s / 14.15 s |
| `stop-gate-decision.test.ts` | — | 31 tests over 30 snippets, 1.14 s |
| `bun run test` | 856 tests / 28 files, 27.33 s / 42.82 s | 889 tests / 29 files, 32.01 s / 39.86 s |

#175 recorded `stop-gate.test.ts` at 15.7 s; the same file on this branch's base read 15.03 s and 14.27 s.

## `package.json` is untouched

`check:shell` is `git ls-files -z '*.sh' | xargs -0r shellcheck -x`, which holds no list of files, so `.claude/hooks/stop-gate-decision.sh` joined it by being tracked. `bun run check:shell` passes over all 7 tracked `.sh` files, the new one included. The ticket allowed a fifth file for this and it was not needed.

## The review round

`code-reviewer` ran against the whole branch diff and raised seven findings, each landed as its own commit. It also ran the old and the new gate side by side over seven payload and step-outcome combinations, including a 2 MB failure body through both the block and the warning branch, and reported the stdout byte-identical and stderr empty in all seven; and it compared the old regex against `holds_code_relevant_file` over 41 inputs with no mismatch.

- The block for a `source` that failed named only "put the file back", which is the wrong remedy for a decision file that will not parse. It now carries `bash -n`'s output.
- Eight sentences sat in `printf`'s format slot, so a `%` written into one of them later would print as a conversion. Every sentence is now an argument and the formats are `%s` and `%s\n%s`.
- Nine of the ten accepted extensions reached no test; dropping `*.cjs` from the `case` left the suite green. There is a row per extension now, and deleting `*.cjs` fails the `.cjs` row.
- The driver's `eval` inherited the stream of snippets not yet read, so a decision function that ever read stdin would shift every later answer. `</dev/null` closes it off.
- The comment over `link_note_*` described the `command -v bun` branch, which lives in the entry. It moved back there.
- A comment named `CODE_CHANGED`, which this diff deleted.
- The missing-`bun` case's PATH allowlist named `grep`, which the gate no longer runs.

It refuted three of its own candidates, one of them by measurement: the pure-bash line loop costs about 1 s on a 20000-line list with no match, against a real changed-file list that is orders of magnitude shorter and a gate that then spends seconds inside `bun run check`.

## Premises of the ticket and of #175 that turned out false

- **"Dead code in `stop-gate.sh` goes first."** `stop-gate.sh` had none, and `shellcheck -x` on it before the change reported nothing. The dead code was in `stop-gate.test.ts`: the payload carried `hook_event_name: "Stop"`, which the gate never reads, and `runGate` returned a `stderr` no case asserted. Both are gone in the first commit.
- **#175: "each builds a scratch git repository with stub `bun` and `git` on PATH".** No case stubs `bun` or `git`. Both run for real, against a scratch `package.json` whose `check` and `test` scripts are `exit 0` or `exit 1`. The single `PATH` case removes `bun` rather than stubbing it.
- **"the shellcheck list in `check:shell`".** There is no list; see above.

## Verification

`bun run check`, `bun run test` (889 tests, 29 files) and `bun run check:shell` pass on this branch. The 13 pre-existing cases of `stop-gate.test.ts` pass unchanged, which is what says the move preserved the gate's output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
