### PR TITLE
fix: clean-worktrees が origin/main を見てマージ済みブランチを消す

### DIFF
--- a/scripts/orchestrate-decisions.test.ts
+++ b/scripts/orchestrate-decisions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
   agentWorktrees,
+  ancestryAfterFetch,
   ancestryKeepReason,
   branchNames,
   formatBranch,
@@ -18,6 +19,7 @@ import {
   worktreeVerdict,
 } from "./orchestrate-decisions";
 import type {
+  Ancestry,
   PullRequest,
   RateLimitsFile,
   Worktree,
@@ -948,6 +950,43 @@ describe(localVerdict, () => {
   });
 });
 
+const ancestorAnswer = (): Ancestry => ({ kind: "ancestor" });
+
+describe(ancestryAfterFetch, () => {
+  it("should answer with the comparison when the fetch refreshed the ref", () => {
+    const result = ancestryAfterFetch({ kind: "fetched" }, ancestorAnswer);
+
+    expect(result).toStrictEqual({ kind: "ancestor" });
+  });
+
+  it("should answer with the fetch failure rather than the comparison when the fetch failed", () => {
+    const result = ancestryAfterFetch(
+      { kind: "failed", reason: "fatal: unable to access origin" },
+      ancestorAnswer
+    );
+
+    expect(result).toStrictEqual({
+      kind: "unfetched",
+      reason: "fatal: unable to access origin",
+    });
+  });
+
+  it("should leave the comparison unrun when the fetch failed", () => {
+    const calls: string[] = [];
+    const counted = (): Ancestry => {
+      calls.push("compared");
+      return { kind: "ancestor" };
+    };
+
+    ancestryAfterFetch(
+      { kind: "failed", reason: "fatal: unable to access origin" },
+      counted
+    );
+
+    expect(calls).toStrictEqual([]);
+  });
+});
+
 describe(ancestryKeepReason, () => {
   it("should return undefined when the holder holds the branch commits", () => {
     const reason = ancestryKeepReason({ kind: "ancestor" }, "main");
@@ -972,6 +1011,17 @@ describe(ancestryKeepReason, () => {
     );
   });
 
+  it("should name the fetch when the ref could not be refreshed", () => {
+    const reason = ancestryKeepReason(
+      { kind: "unfetched", reason: "fatal: unable to access origin" },
+      "origin/main"
+    );
+
+    expect(reason).toBe(
+      "git could not fetch origin/main: fatal: unable to access origin"
+    );
+  });
+
   it("should name the failure when the ancestry check could not run", () => {
     const reason = ancestryKeepReason(
       { kind: "failed", reason: "fatal: not a git repository" },
@@ -985,7 +1035,7 @@ describe(ancestryKeepReason, () => {
 });
 
 describe(worktreeVerdict, () => {
-  it("should remove the worktree when its branch has no pull request and main holds its commits", () => {
+  it("should remove the worktree when its branch has no pull request and origin/main holds its commits", () => {
     const verdict = worktreeVerdict({
       kind: "no-pull-request",
       mainAncestry: { kind: "ancestor" },
@@ -994,7 +1044,7 @@ describe(worktreeVerdict, () => {
     expect(verdict).toStrictEqual({ kind: "remove" });
   });
 
-  it("should keep the worktree when its branch has no pull request and holds a commit main does not", () => {
+  it("should keep the worktree when its branch has no pull request and holds a commit origin/main does not", () => {
     const verdict = worktreeVerdict({
       kind: "no-pull-request",
       mainAncestry: { kind: "not-ancestor" },
@@ -1002,7 +1052,7 @@ describe(worktreeVerdict, () => {
 
     expect(verdict).toStrictEqual({
       kind: "keep",
-      reason: "no pull request, commits main does not hold",
+      reason: "no pull request, commits origin/main does not hold",
     });
   });
 
@@ -1015,7 +1065,7 @@ describe(worktreeVerdict, () => {
     expect(verdict).toStrictEqual({
       kind: "keep",
       reason:
-        "no pull request, git could not compare with main: fatal: bad revision",
+        "no pull request, git could not compare with origin/main: fatal: bad revision",
     });
   });
 
@@ -1033,7 +1083,7 @@ describe(worktreeVerdict, () => {
     });
   });
 
-  it("should keep the worktree naming both holders when neither the pull request nor main holds its branch commits", () => {
+  it("should keep the worktree naming both holders when neither the pull request nor origin/main holds its branch commits", () => {
     const verdict = worktreeVerdict({
       kind: "pull-request",
       mainAncestry: { kind: "not-ancestor" },
@@ -1044,11 +1094,11 @@ describe(worktreeVerdict, () => {
     expect(verdict).toStrictEqual({
       kind: "keep",
       reason:
-        "commits the pull request does not hold, and commits main does not hold",
+        "commits the pull request does not hold, and commits origin/main does not hold",
     });
   });
 
-  it("should keep the worktree when the pull request's commit is not in this repository and main holds no branch commit", () => {
+  it("should keep the worktree when the pull request's commit is not in this repository and origin/main holds no branch commit", () => {
     const verdict = worktreeVerdict({
       kind: "pull-request",
       mainAncestry: { kind: "not-ancestor" },
@@ -1059,7 +1109,7 @@ describe(worktreeVerdict, () => {
     expect(verdict).toStrictEqual({
       kind: "keep",
       reason:
-        "the pull request is at commit 4b486bc, which this repository does not have, and commits main does not hold",
+        "the pull request is at commit 4b486bc, which this repository does not have, and commits origin/main does not hold",
     });
   });
 
@@ -1077,7 +1127,7 @@ describe(worktreeVerdict, () => {
     expect(verdict).toStrictEqual({
       kind: "keep",
       reason:
-        "git could not compare with the pull request: fatal: Not a valid commit name 4b486bc, and git could not compare with main: fatal: bad revision",
+        "git could not compare with the pull request: fatal: Not a valid commit name 4b486bc, and git could not compare with origin/main: fatal: bad revision",
     });
   });
 
@@ -1103,7 +1153,7 @@ describe(worktreeVerdict, () => {
     expect(verdict).toStrictEqual({ kind: "remove" });
   });
 
-  it("should remove the worktree when main holds its branch commits and the pull request does not", () => {
+  it("should remove the worktree when origin/main holds its branch commits and the pull request does not", () => {
     const verdict = worktreeVerdict({
       kind: "pull-request",
       mainAncestry: { kind: "ancestor" },
@@ -1114,7 +1164,7 @@ describe(worktreeVerdict, () => {
     expect(verdict).toStrictEqual({ kind: "remove" });
   });
 
-  it("should remove the worktree when main holds its branch commits and the pull request's commit is not in this repository", () => {
+  it("should remove the worktree when origin/main holds its branch commits and the pull request's commit is not in this repository", () => {
     const verdict = worktreeVerdict({
       kind: "pull-request",
       mainAncestry: { kind: "ancestor" },

--- a/scripts/orchestrate-decisions.ts
+++ b/scripts/orchestrate-decisions.ts
@@ -467,21 +467,57 @@ export const localVerdict = (isDirty: boolean): WorktreeVerdict | undefined =>
  * Where git put one commit relative to another's history. `absent` is the
  * second commit missing from the repository, which is what the commit GitHub
  * reports for a pull request is once the remote branch is deleted and nothing
- * fetched it, and `failed` is a check that did not answer either way.
+ * fetched it, `failed` is a check that did not answer either way, and
+ * `unfetched` is a ref whose refresh failed before any check ran on it.
  */
 export type Ancestry =
   | { readonly commit: string; readonly kind: "absent" }
   | { readonly kind: "ancestor" }
   | { readonly kind: "failed"; readonly reason: string }
-  | { readonly kind: "not-ancestor" };
+  | { readonly kind: "not-ancestor" }
+  | { readonly kind: "unfetched"; readonly reason: string };
+
+/** The remote `clean-worktrees` refreshes MAIN_REF from. */
+export const MAIN_REMOTE = "origin";
+
+/** The branch of MAIN_REMOTE that a finished branch's commits land on. */
+export const MAIN_BRANCH = "main";
+
+/**
+ * The ref whose history `clean-worktrees` looks for a branch's commits in. The
+ * local `main` holds what the checkout this command runs in last pulled, so a
+ * branch whose commits the remote already holds reads as unheld there until
+ * someone pulls that checkout.
+ */
+export const MAIN_REF = `${MAIN_REMOTE}/${MAIN_BRANCH}`;
+
+/** Whether the fetch refreshing MAIN_REF ran, and what git said when it did not. */
+export type MainFetch =
+  | { readonly kind: "failed"; readonly reason: string }
+  | { readonly kind: "fetched" };
+
+/**
+ * The branch's place in MAIN_REF's history, or the failed fetch in place of an
+ * answer. MAIN_REF keeps what the last fetch that reached the remote wrote
+ * there, so comparing against it after this command's own fetch failed would
+ * report the ancestry of some earlier moment as this one's.
+ */
+export const ancestryAfterFetch = (
+  mainFetch: MainFetch,
+  compare: () => Ancestry
+): Ancestry =>
+  mainFetch.kind === "fetched"
+    ? compare()
+    : { kind: "unfetched", reason: mainFetch.reason };
 
 /**
  * Why the commits of a branch keep what holds them, or undefined when `holder`
- * already holds every one of them. A commit this repository does not have and a
- * check that did not run are each their own answer, because reading either as
- * "not an ancestor" would keep the branch with a reason naming the wrong cause.
- * A squash merge leaves the branch's commits outside main's ancestry, so the
- * reason states what git answered rather than calling the branch unmerged.
+ * already holds every one of them. A commit this repository does not have, a
+ * check that did not run, and a ref this call could not refresh each get their
+ * own answer, because reading any of them as "not an ancestor" would keep the
+ * branch with a reason naming the wrong cause. A squash merge leaves the
+ * branch's commits outside the holder's ancestry, so the reason states what git
+ * answered rather than calling the branch unmerged.
  */
 export const ancestryKeepReason = (
   ancestry: Ancestry,
@@ -496,14 +532,17 @@ export const ancestryKeepReason = (
   if (ancestry.kind === "absent") {
     return `${holder} is at commit ${ancestry.commit}, which this repository does not have`;
   }
+  if (ancestry.kind === "unfetched") {
+    return `git could not fetch ${holder}: ${ancestry.reason}`;
+  }
   return `git could not compare with ${holder}: ${ancestry.reason}`;
 };
 
 /**
  * What GitHub and git report about the worktree of a branch the run named. Each
- * shape names every commit whose history the branch was looked for in: main
- * alone when GitHub reports no pull request for the branch, and main together
- * with the commit GitHub holds for it when there is one.
+ * shape names every commit whose history the branch was looked for in: MAIN_REF
+ * alone when GitHub reports no pull request for the branch, and MAIN_REF
+ * together with the commit GitHub holds for it when there is one.
  */
 export type WorktreeFacts =
   | { readonly kind: "no-pull-request"; readonly mainAncestry: Ancestry }
@@ -518,19 +557,19 @@ export type WorktreeFacts =
  * Whether the worktree of a branch this run named can go. Removing it deletes
  * the branch, so what decides is whether anything else holds the branch's
  * commits. Two commits are asked, and either one holding them clears the
- * worktree: the commit GitHub holds for the pull request, and main. Which of
- * them answers depends on the branch. A squash merge leaves the commits a
- * branch carried outside main's ancestry, so the pull request's commit is what
- * holds those, and main holds a branch that ended at a commit main already had.
- * Main is the one of the two this repository can still resolve once
- * `gh pr update-branch` has left the pull request at a merge nothing fetched.
- * Ancestry rather than equality, because the branch also differs from GitHub's
- * commit when it sits behind one a worker never pulled, and nothing of the
- * branch's own is lost then.
+ * worktree: the commit GitHub holds for the pull request, and MAIN_REF. Which
+ * of them answers depends on the branch. A squash merge leaves the commits a
+ * branch carried outside MAIN_REF's ancestry, so the pull request's commit is
+ * what holds those, and MAIN_REF holds a branch that ended at a commit MAIN_REF
+ * already had. MAIN_REF is the one of the two this repository can still resolve
+ * once `gh pr update-branch` has left the pull request at a merge nothing
+ * fetched. Ancestry rather than equality, because the branch also differs from
+ * GitHub's commit when it sits behind one a worker never pulled, and nothing of
+ * the branch's own is lost then.
  */
 export const worktreeVerdict = (facts: WorktreeFacts): WorktreeVerdict => {
   if (facts.kind === "no-pull-request") {
-    const mainReason = ancestryKeepReason(facts.mainAncestry, "main");
+    const mainReason = ancestryKeepReason(facts.mainAncestry, MAIN_REF);
     return mainReason === undefined
       ? { kind: "remove" }
       : { kind: "keep", reason: `no pull request, ${mainReason}` };
@@ -543,7 +582,7 @@ export const worktreeVerdict = (facts: WorktreeFacts): WorktreeVerdict => {
     pullRequestAncestry,
     "the pull request"
   );
-  const mainReason = ancestryKeepReason(mainAncestry, "main");
+  const mainReason = ancestryKeepReason(mainAncestry, MAIN_REF);
   return pullRequestReason === undefined || mainReason === undefined
     ? { kind: "remove" }
     : { kind: "keep", reason: `${pullRequestReason}, and ${mainReason}` };

--- a/scripts/orchestrate.ts
+++ b/scripts/orchestrate.ts
@@ -29,7 +29,8 @@
  *
  * `clean-worktrees` prints one line per agent worktree saying whether it was
  * removed or why it was kept. It removes only the worktrees of the branches
- * given.
+ * given, and it fetches MAIN_REF first, because whether a branch's commits are
+ * held anywhere else is asked of that ref.
  */
 
 import { execFileSync } from "node:child_process";
@@ -39,8 +40,12 @@ import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import {
   agentWorktrees,
+  ancestryAfterFetch,
   ancestryKeepReason,
   branchNames,
+  MAIN_BRANCH,
+  MAIN_REF,
+  MAIN_REMOTE,
   formatBranch,
   formatEvent,
   formatRemainingBudget,
@@ -58,6 +63,7 @@ import {
 } from "./orchestrate-decisions";
 import type {
   Ancestry,
+  MainFetch,
   PullRequest,
   RateLimitsFile,
   Worktree,
@@ -289,14 +295,37 @@ const ancestry = (commit: string, descendant: string): Ancestry => {
 };
 
 /**
+ * Brings MAIN_REF up to what the remote holds. The refspec names the ref it
+ * writes, and running the fetch once per `clean-worktrees` leaves every verdict
+ * of that call reading the one it wrote.
+ */
+const fetchMain = (): MainFetch => {
+  try {
+    run("git", [
+      "fetch",
+      "--quiet",
+      MAIN_REMOTE,
+      `+refs/heads/${MAIN_BRANCH}:refs/remotes/${MAIN_REF}`,
+    ]);
+    return { kind: "fetched" };
+  } catch (error) {
+    return { kind: "failed", reason: commandMessage(error) };
+  }
+};
+
+/** Where the branch sits in MAIN_REF's history, as this call's fetch left it. */
+const mainRefAncestry = (branch: string, mainFetch: MainFetch): Ancestry =>
+  ancestryAfterFetch(mainFetch, () => ancestry(branch, MAIN_REF));
+
+/**
  * What `worktreeVerdict` judges. Every ancestry runs on the branch, which is
  * the commit the worktree has checked out and the ref `removeWorktree` deletes.
- * Comparing main runs on every worktree that reaches this call, including one
- * whose pull request settles the verdict on its own.
+ * Comparing MAIN_REF runs on every worktree that reaches this call, including
+ * one whose pull request settles the verdict on its own.
  */
-const worktreeFacts = (branch: string): WorktreeFacts => {
+const worktreeFacts = (branch: string, mainFetch: MainFetch): WorktreeFacts => {
   const pullRequest = prOf(branch);
-  const mainAncestry = ancestry(branch, "main");
+  const mainAncestry = mainRefAncestry(branch, mainFetch);
   return pullRequest === undefined
     ? { kind: "no-pull-request", mainAncestry }
     : {
@@ -314,7 +343,8 @@ const worktreeFacts = (branch: string): WorktreeFacts => {
  */
 const verdictFor = (
   worktree: Worktree,
-  branches: readonly string[]
+  branches: readonly string[],
+  mainFetch: MainFetch
 ): WorktreeVerdict => {
   const probe = worktreeProbe(worktree, branches);
   if (probe.kind === "verdict") {
@@ -325,7 +355,7 @@ const verdictFor = (
     if (local !== undefined) {
       return local;
     }
-    const verdict = worktreeVerdict(worktreeFacts(probe.branch));
+    const verdict = worktreeVerdict(worktreeFacts(probe.branch, mainFetch));
     return verdict.kind === "remove"
       ? removeWorktree(worktree, probe.branch)
       : verdict;
@@ -335,19 +365,26 @@ const verdictFor = (
 };
 
 /**
- * Deletes the branch once main holds its commits, and returns why it did not.
- * Main is named, where `git branch -d` would check the branch against its
- * upstream, or against HEAD when it has none.
+ * Deletes the branch once MAIN_REF holds its commits, and returns why it did
+ * not. MAIN_REF is named, where `git branch -d` would check the branch against
+ * its upstream, or against HEAD when it has none.
  */
-const deleteMergedBranch = (branch: string): string | undefined =>
-  ancestryKeepReason(ancestry(branch, "main"), "main") ?? deleteBranch(branch);
+const deleteMergedBranch = (
+  branch: string,
+  mainFetch: MainFetch
+): string | undefined =>
+  ancestryKeepReason(mainRefAncestry(branch, mainFetch), MAIN_REF) ??
+  deleteBranch(branch);
 
 const cleanWorktrees = (branches: readonly string[]): void => {
+  const mainFetch = fetchMain();
   const worktrees = agentWorktrees(
     run("git", ["worktree", "list", "--porcelain"])
   );
   worktrees.forEach((worktree) => {
-    console.log(formatVerdict(worktree, verdictFor(worktree, branches)));
+    console.log(
+      formatVerdict(worktree, verdictFor(worktree, branches, mainFetch))
+    );
   });
   const remaining = agentWorktrees(
     run("git", ["worktree", "list", "--porcelain"])
@@ -360,7 +397,7 @@ const cleanWorktrees = (branches: readonly string[]): void => {
     .split("\n")
     .filter((line) => line !== "");
   strandedAgentBranches(names, remaining).forEach((branch) => {
-    console.log(formatBranch(branch, deleteMergedBranch(branch)));
+    console.log(formatBranch(branch, deleteMergedBranch(branch, mainFetch)));
   });
 };
 


### PR DESCRIPTION
## The defect

`bun scripts/orchestrate.ts clean-worktrees <branch>...` decided whether a run's worktree and its leftover `worktree-agent-*` branch could go by asking whether the local `main` of the checkout it ran in held the branch's commits.

Before, in `scripts/orchestrate.ts`, `ancestry(branch, "main")` ran two commands:

```
git rev-parse --verify --quiet main^{commit}
git merge-base --is-ancestor <branch> main
```

Its two callers were `worktreeFacts` (the worktree verdict) and `deleteMergedBranch` (the stranded-branch pass). On 2026-09-09 the main checkout sat eight commits behind `origin/main`, so four branches whose commits `origin/main` already held printed as `kept branch worktree-agent-... (commits main does not hold)`, and a second run after `git pull` removed them.

After, the same two commands run against `origin/main`, and `clean-worktrees` refreshes that ref once per invocation:

```
git fetch --quiet origin +refs/heads/main:refs/remotes/origin/main
git rev-parse --verify --quiet origin/main^{commit}
git merge-base --is-ancestor <branch> origin/main
```

The refspec names the destination ref, so the tracking ref this call judges against is the one this call wrote. Running the fetch in this worktree moved `refs/remotes/origin/main` from 317a2f4 to b930e74 while the main checkout's local `main` stayed at cdd6ff2, which is the gap that produced the wrong lines.

## The failed fetch

`Ancestry` gains an `unfetched` variant. When the fetch fails, `ancestryAfterFetch` returns it without running either git command, and `ancestryKeepReason` prints `git could not fetch origin/main: <what git printed>`. The line keeps the `kept <path> (<reason>)` and `kept branch <branch> (<reason>)` shapes the `dispatch-run` skill's "Watching the run" section relies on; that section names no ref, so it needed no change. `execFileSync` captures git's stderr, checked against a failing fetch: `error.stderr` came back as `"fatal: couldn't find remote ref refs/heads/no-such-branch-zz\n"`, which is what reaches the reason.

The holder in every keep reason is now `origin/main` rather than `main`, because that is the ref the comparison asked.

## Tests

`scripts/orchestrate-decisions.test.ts` covers the new branch three ways: the fetched path answers with the comparison, the failed path answers `unfetched` with git's message, and a counting thunk shows the comparison does not run after a failed fetch. Making `ancestryAfterFetch` evaluate the thunk before the branch fails that third test, and returning the comparison on the failed path fails the second. The `worktreeVerdict` expectations were renamed to `origin/main`. `bun run check`, `bun run test` (893 tests, 100% branch coverage) and the pre-push hooks pass.

## Decisions taken without asking

- The efficiency review asked for a lazy memoized fetch, so an invocation whose worktrees all short-circuit pays no network round trip. Skipped: the stranded-branch pass runs on every invocation and needs the ancestry, and a memo would add mutable state to a module that has none for one fetch of one ref.
- The fetch takes a single-branch refspec rather than a plain `git fetch origin`, so it writes one tracking ref instead of every branch of a repository that carries one per dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
