### PR TITLE
chore: format 確認、git fetch、actionlint が auto mode で classifier を通らず許可される

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,7 +15,10 @@
       "Bash(bun .claude/hooks/check-md-links.ts *)",
       "Bash(similarity-ts *)",
       "Bash(memory_pressure)",
-      "Bash(gh pr merge --squash *)"
+      "Bash(gh pr merge --squash *)",
+      "Bash(bun run format)",
+      "Bash(git fetch *)",
+      "Bash(actionlint *)"
     ],
     "deny": [
       "Bash(rm -rf /)",


### PR DESCRIPTION
transcript 50 本の集計で read-only かつ組み込み許可に入っておらず 3 回以上使われた 3 コマンドを permissions.allow に追加し、複合コマンドの一部として打たれたときに連続拒否の数に入らないようにする。
