### PR TITLE
refactor: PreToolUse の判定が process を起動せずに済む

### DIFF
--- a/.claude/hooks/pre-bash-guard-decision.sh
+++ b/.claude/hooks/pre-bash-guard-decision.sh
@@ -273,7 +273,7 @@ refuse_protected_env_file() { # reads GUARD_SCRUBBED; sets GUARD_REFUSAL
 refuse_broad_find() { # $1 = the Bash tool's command text; sets GUARD_REFUSAL
   local -a LINES
   local NORM NORM_FIND FIND_ASK SEG WORDS_REST WORD SAW_FIND ROOT_COUNT
-  local IN_PREDICATES HEREDOC_DROPPED
+  local IN_PREDICATES BROAD_ROOT HEREDOC_DROPPED
   # A heredoc body is data, not a command — a commit message describing
   # `find . | xargs cat` must not trip this. Guard 1 scrubs `-m` bodies for the
   # same reason; this is the heredoc case, found when the first version of this
@@ -316,12 +316,28 @@ refuse_broad_find() { # $1 = the Bash tool's command text; sets GUARD_REFUSAL
         *)
           [ "$IN_PREDICATES" -eq 1 ] && continue
           ROOT_COUNT=$((ROOT_COUNT + 1))
-          case "$WORD" in
-            . | ./ | .. | ../ | /* | '~'* | '$'* | *'..'*)
-              FIND_ASK="a search root reaches the whole repository (or outside it), so it can read files the deny list protects"
-              break
-              ;;
+          BROAD_ROOT=0
+          # What the shell hands `find` for a root carrying a glob starts at the
+          # literal text ahead of the glob's first character, and a root
+          # carrying no glob is that text itself, so one test covers both. An
+          # empty start is `find *`, which searches every entry of the working
+          # directory whose name does not begin with a dot. A `.` start is
+          # `find .*`, which expanded to `.` and `..` under /bin/bash 3.2.57 in
+          # an empty directory on 2026-09-09 and stayed literal under bash
+          # 5.3.9, whose `globskipdots` is on. `src/` and `./src/` start inside
+          # a directory the command names, so `find ./src/*.tsx` runs
+          # unattended.
+          case "${WORD%%[*?[]*}" in
+            '' | . | ./ | .. | ../ | /* | '~'* | '$'*) BROAD_ROOT=1 ;;
           esac
+          # A `..` past that start still climbs out of what the root names.
+          case "$WORD" in
+            *'..'*) BROAD_ROOT=1 ;;
+          esac
+          if [ "$BROAD_ROOT" -eq 1 ]; then
+            FIND_ASK="a search root reaches the whole repository (or outside it), so it can read files the deny list protects"
+            break
+          fi
           ;;
       esac
     done

--- a/.claude/hooks/pre-bash-guard-decision.sh
+++ b/.claude/hooks/pre-bash-guard-decision.sh
@@ -80,6 +80,18 @@ HEREDOC_OPERATOR_RE='<<-?[[:blank:]]*[^[:blank:]]'
 drop_heredoc_body() { # $1 = text; sets HEREDOC_DROPPED
   local -a LINES
   local KEPT="" BODY="" DELIM="" LINE TRIMMED OPENED=0 CLOSED=0
+  # No `<<` is no operator line, so the walk below would keep every line. It is
+  # skipped because the split copies the text it has left at each line, which
+  # costs more the longer the command is: splitting and walking one took
+  # 0.017 ms at 3 lines, 0.43 ms at 50 and 4.2 ms at 200, over 1500 rounds each
+  # (macOS, bash 5.3.9, 2026-09-09), and three of the guards' passes call this.
+  case "$1" in
+    *'<<'*) ;;
+    *)
+      HEREDOC_DROPPED=$1
+      return 0
+      ;;
+  esac
   split_lines "$1"
   for LINE in "${LINES[@]}"; do
     if [ "$OPENED" -eq 0 ]; then

--- a/.claude/hooks/pre-bash-guard-decision.sh
+++ b/.claude/hooks/pre-bash-guard-decision.sh
@@ -3,97 +3,157 @@
 # `guard_refusal` prints the sentence that refuses it, and prints nothing for a
 # command the three guards below allow. Reading the hook payload off stdin and
 # printing the refusal in each harness's dialect stay in pre-bash-guard.sh,
-# which sources this file. Nothing here forks jq, so
-# pre-bash-guard-decision.test.ts answers its case table in one bash process.
-# One set of 40 commands took 8.0 s that way against 15.6 s as 40 hook forks
-# (macOS under parallel load, 2026-09-09), and the 8.0 s is the sed, awk and
-# grep the guards below still fork per command.
+# which sources this file.
+#
+# Nothing here starts a process. Every text pass below runs as parameter
+# expansion, `[[ =~ ]]` or `case` in the shell that sources this file. One
+# PreToolUse call end to end through pre-bash-guard.sh, on a payload carrying
+# `git commit -m 'feat: add the thing'`, took 174 ms, 175 ms and 158 ms over
+# three rounds of 20 calls, where an entry that reads the same payload and
+# sources this file without calling a guard took 141 ms, 202 ms and 148 ms over
+# three rounds of its own: the same range, so the three guards now cost less
+# than the noise between rounds (macOS under parallel load, 2026-09-09). The 294
+# cases of pre-bash-guard-decision.test.ts answer in 0.41 s of that file's load.
 #
 # pre-bash-guard.sh sets these options too, and they are here as well so the
 # test driver runs the guards under the same ones.
 set -euo pipefail
 
-# Drop a heredoc body, keeping the operator line, the terminator's own line and
-# everything after it: text a command receives on stdin is data rather than a
-# filename or a nested command, while a command chained after the terminator is
-# a command. Dropping only when the body ran to the end of the input instead
-# read the body as commands whenever anything followed, so
+# The newline that joins and separates the lines of a command's text.
+NEWLINE=$'\n'
+
+# Each function below hands its answer back by assigning the variable its own
+# signature comment names, and its caller declares that name `local`. Printing
+# the answer for a `$(...)` read-back forks a subshell instead, and these run
+# per command, per segment and per token on a hook that every Bash tool call
+# waits for.
+
+# Cut the text at each newline. A text ending in a newline yields a last line
+# that is empty, and a text holding none yields itself as the only line.
+split_lines() { # $1 = text; sets LINES
+  local REST=$1
+  LINES=()
+  while [[ $REST == *"$NEWLINE"* ]]; do
+    LINES+=("${REST%%"$NEWLINE"*}")
+    REST=${REST#*"$NEWLINE"}
+  done
+  LINES+=("$REST")
+}
+
+# Take the next word off WORDS_REST, the way the shell splits a line into words
+# but without the pathname expansion `for TOK in $TEXT` also performs: a
+# `git add '*'` reaching a walk below has already lost its quotes, and expanding
+# it against the working directory would hand the walk that directory's entries
+# instead of the glob the agent wrote. A walk sets WORDS_REST to the text and
+# breaks out of the loop on the token it refuses.
+next_word() { # reads and shortens WORDS_REST; sets WORD
+  WORDS_REST=${WORDS_REST#"${WORDS_REST%%[![:blank:]]*}"}
+  if [ -z "$WORDS_REST" ]; then
+    WORD=""
+    return 1
+  fi
+  WORD=${WORDS_REST%%[[:blank:]]*}
+  WORDS_REST=${WORDS_REST#"$WORD"}
+}
+
+# A line that opens a heredoc: `<<` or `<<-`, blanks, then the delimiter.
+HEREDOC_OPERATOR_RE='<<-?[[:blank:]]*[^[:blank:]]'
+
+# Drop a heredoc body and the terminator line that closes it, keeping the
+# operator line and everything after the terminator: text a command receives on
+# stdin is data rather than a filename or a nested command, while a command
+# chained after the terminator is a command. Dropping only when the body ran to
+# the end of the input instead read the body as commands whenever anything
+# followed, so
 # `git commit -F - <<'MSG'` / `git add -A was refused` / `MSG` / `git push`
 # was refused for a command nobody wrote. With no terminator the body cannot be
 # told from the rest, so every line is kept. A redirect belongs to the operator
 # line, which is kept either way. Guards 1, 2 and 3 all read the result.
-drop_heredoc_body() {
-  awk '
-    BEGIN { q = sprintf("%c", 39); op = 0; term = 0 }
-    { lines[NR] = $0 }
-    op == 0 && /<<-?[ \t]*[^ \t]/ {
-      op = NR
-      d = $0
-      sub(/^.*<<-?[ \t]*/, "", d)
-      gsub(/["]/, "", d)
-      gsub(q, "", d)
-      sub(/[ \t].*$/, "", d)
-      next
-    }
-    op > 0 && term == 0 && d != "" {
-      trimmed = $0
-      sub(/^[ \t]+/, "", trimmed)
-      sub(/[ \t]+$/, "", trimmed)
-      if (trimmed == d) { term = NR }
-    }
-    END {
-      for (i = 1; i <= NR; i++) {
-        if (term > 0 && i > op && i <= term) { continue }
-        print lines[i]
-      }
-    }
-  '
+#
+# Only the first operator line on the text counts, and the delimiter is read
+# from the last `<<` on it, because that terminator closes the last of the
+# bodies the line opens and everything the line opened lies above it. Fed
+# `cat <<A <<B` / `bodyA` / `A` / `git add -A` / `B` / `echo done`, the walk
+# below scans to `B` and drops both bodies; reading the delimiter from `A`
+# would have stopped at `A` and handed the `git add -A` inside B's body to
+# Guard 3 as a command.
+drop_heredoc_body() { # $1 = text; sets HEREDOC_DROPPED
+  local -a LINES
+  local KEPT="" BODY="" DELIM="" LINE TRIMMED OPENED=0 CLOSED=0
+  split_lines "$1"
+  for LINE in "${LINES[@]}"; do
+    if [ "$OPENED" -eq 0 ]; then
+      if [[ $LINE =~ $HEREDOC_OPERATOR_RE ]]; then
+        OPENED=1
+        DELIM=${LINE##*<<}
+        DELIM=${DELIM#-}
+        DELIM=${DELIM#"${DELIM%%[![:blank:]]*}"}
+        DELIM=${DELIM//\"/}
+        DELIM=${DELIM//\'/}
+        DELIM=${DELIM%%[[:blank:]]*}
+      fi
+      KEPT=$KEPT$NEWLINE$LINE
+      continue
+    fi
+    if [ "$CLOSED" -eq 0 ] && [ -n "$DELIM" ]; then
+      TRIMMED=${LINE#"${LINE%%[![:blank:]]*}"}
+      TRIMMED=${TRIMMED%"${TRIMMED##*[![:blank:]]}"}
+      if [ "$TRIMMED" = "$DELIM" ]; then
+        CLOSED=1
+        BODY=""
+        continue
+      fi
+      BODY=$BODY$NEWLINE$LINE
+      continue
+    fi
+    KEPT=$KEPT$NEWLINE$LINE
+  done
+  if [ "$CLOSED" -eq 0 ]; then
+    KEPT=$KEPT$BODY
+  fi
+  HEREDOC_DROPPED=${KEPT#"$NEWLINE"}
 }
 
-# Delete the quoted body of an inline-text flag. The whole command is one awk
-# record, so a body spanning lines is still one match. sed cannot do this
-# portably here: its `N` loop quits WITHOUT printing when there is no next line
-# on BSD sed, which emptied every single-line command. The patterns callers
-# pass also avoid `\|` and `{1,2}` — BRE alternation is a GNU extension and awk
-# intervals are not universal — so `--?m(essage)?` carries both git spellings
-# instead. Guard 1 reads the result to tell prose from file access, Guard 3 to
-# tell a commit message from a pathspec.
+# Delete the quoted body of an inline-text flag. The whole command is matched at
+# once, so a body spanning lines is still one match. The patterns callers pass
+# avoid `\|` and `{1,2}` — BRE alternation is a GNU extension — so
+# `--?m(essage)?` carries both git spellings instead. Guard 1 reads the result
+# to tell prose from file access, Guard 3 to tell a commit message from a
+# pathspec.
 #
 # The loop below carries the parity of quote characters already emitted, and
-# deletes a body only where that parity is even, because one `gsub` over the
-# whole record cannot see quote state and matched a `-m` sitting INSIDE a
-# quoted argument. Its `[^q]*` then ran from that argument's closing quote to
-# the real message's opening quote, so `echo 'use -m' && git commit -a -m 'x'`
-# had `-m' && git commit -a -m '` deleted and reached Guard 3 as `echo 'usex'`.
+# deletes a body only where that parity is even, because a single pass over the
+# whole text cannot see quote state and matched a `-m` sitting INSIDE a quoted
+# argument. Its `[^q]*` then ran from that argument's closing quote to the real
+# message's opening quote, so `echo 'use -m' && git commit -a -m 'x'` had
+# `-m' && git commit -a -m '` deleted and reached Guard 3 as `echo 'usex'`.
 # `echo 'x -m' && git add -A && git commit -m 'y'` walked around the `git add`
 # refusal the same way. On odd parity the matched span is emitted unchanged up
 # to the quote that closes that argument, and scanning resumes after it.
-scrub_message_body() { # $1 = the quote character delimiting the body, $2 = flag pattern
-  awk -v q="$1" -v flags="$2" '
-    BEGIN { RS = "\034" }
-    {
-      pattern = flags "[= ]?" q "[^" q "]*" q
-      kept = ""
-      rest = $0
-      while (match(rest, pattern)) {
-        before = substr(rest, 1, RSTART - 1)
-        counted = before
-        if (gsub(q, q, counted) % 2 == 0) {
-          kept = kept before
-          rest = substr(rest, RSTART + RLENGTH)
-        } else {
-          from_flag = substr(rest, RSTART)
-          closes_at = index(from_flag, q)
-          kept = kept before substr(from_flag, 1, closes_at)
-          rest = substr(from_flag, closes_at + 1)
-        }
-      }
-      printf "%s", kept rest
-    }
-  '
+#
+# The regex is leftmost-longest, so the text before the match holds no earlier
+# copy of the match, and `%%` finds the match where the regex found it.
+scrub_message_body() { # $1 = quote character, $2 = flag pattern, $3 = text; sets MESSAGE_SCRUBBED
+  local QUOTE=$1 BODY_RE="$2[= ]?$1[^$1]*$1" REST=$3
+  local KEPT="" MATCH BEFORE UNQUOTED FROM_FLAG UP_TO_CLOSE
+  while [[ $REST =~ $BODY_RE ]]; do
+    MATCH=${BASH_REMATCH[0]}
+    BEFORE=${REST%%"$MATCH"*}
+    UNQUOTED=${BEFORE//"$QUOTE"/}
+    if (( (${#BEFORE} - ${#UNQUOTED}) % 2 == 0 )); then
+      KEPT=$KEPT$BEFORE
+      REST=${REST#*"$MATCH"}
+    else
+      FROM_FLAG=${REST#"$BEFORE"}
+      UP_TO_CLOSE=${FROM_FLAG%%"$QUOTE"*}
+      KEPT=$KEPT$BEFORE$UP_TO_CLOSE$QUOTE
+      REST=${FROM_FLAG#*"$QUOTE"}
+    fi
+  done
+  MESSAGE_SCRUBBED=$KEPT$REST
 }
 
-# git's two spellings of the inline-message flag, as one awk ERE.
+# git's two spellings of the inline-message flag, as one ERE.
 GIT_MESSAGE_FLAG='--?m(essage)?'
 
 # --- Guard 1: .env protection (applies to parent and sidechains alike) ---
@@ -107,18 +167,31 @@ GIT_MESSAGE_FLAG='--?m(essage)?'
 #
 # GUARD_SCRUBBED carries the result to `refuse_protected_env_file` and
 # `refuse_unnamed_changes`, which both read it.
-scrub_command_text() { # $1 = the Bash tool's command text
-  local SCRUBBED FIRST_WORD TEXT_FLAG_PATTERN
-  SCRUBBED=$(printf '%s' "$1" | sed 's/\.env[.A-Za-z]*\.example//g')
-  # NR==1 with an exit: awk would otherwise print the first field of every line,
-  # and a multi-line command (a heredoc body) then matched no first word at all.
-  FIRST_WORD=$(printf '%s' "$SCRUBBED" | awk 'NR == 1 { print $1; exit }')
+
+# Every spelling of the committed example file, which is documentation rather
+# than a secret.
+ENV_EXAMPLE_RE='\.env[.A-Za-z]*\.example'
+
+scrub_command_text() { # $1 = the Bash tool's command text; sets GUARD_SCRUBBED
+  local SCRUBBED="" REST=$1 MATCH FIRST_WORD TEXT_FLAG_PATTERN
+  local HEREDOC_DROPPED MESSAGE_SCRUBBED
+  while [[ $REST =~ $ENV_EXAMPLE_RE ]]; do
+    MATCH=${BASH_REMATCH[0]}
+    SCRUBBED=$SCRUBBED${REST%%"$MATCH"*}
+    REST=${REST#*"$MATCH"}
+  done
+  SCRUBBED=$SCRUBBED$REST
+  # The first word of the FIRST line: a multi-line command (a heredoc body)
+  # names its command on the line the operator sits on.
+  FIRST_WORD=${SCRUBBED%%"$NEWLINE"*}
+  FIRST_WORD=${FIRST_WORD#"${FIRST_WORD%%[![:blank:]]*}"}
+  FIRST_WORD=${FIRST_WORD%%[[:blank:]]*}
   # gh takes inline text through --body, --title and --subject, and reads a file
-  # through -F/--body-file and -T/--template (gh 2.86.0). gsub runs over the
+  # through -F/--body-file and -T/--template (gh 2.86.0). The scrub runs over the
   # whole command rather than over the leading gh alone, so the short -b/-t stay
   # out: with `-b` in the pattern the scrub took the operand of a chained
-  # `cat -b '.env'`, which the grep below then never saw. The pattern follows the
-  # command's first word, so a gh body behind a leading command is left alone.
+  # `cat -b '.env'`, which the search below then never saw. The pattern follows
+  # the command's first word, so a gh body behind a leading command is left alone.
   case "$FIRST_WORD" in
     git) TEXT_FLAG_PATTERN=$GIT_MESSAGE_FLAG ;;
     gh) TEXT_FLAG_PATTERN='--(body|title|subject)' ;;
@@ -126,40 +199,50 @@ scrub_command_text() { # $1 = the Bash tool's command text
   esac
   if [ -n "$TEXT_FLAG_PATTERN" ]; then
     # Single-quoted bodies are always inert (no expansion inside single quotes).
-    SCRUBBED=$(printf '%s' "$SCRUBBED" | scrub_message_body "'" "$TEXT_FLAG_PATTERN")
+    scrub_message_body "'" "$TEXT_FLAG_PATTERN" "$SCRUBBED"
+    SCRUBBED=$MESSAGE_SCRUBBED
     # Double-quoted bodies expand $(...) / ${...} / backticks, so scrub them
     # only when the command contains no substitution opener at all. A bare `$`
     # (e.g. "$5/mo") is inert and still scrubs; any backtick is conservatively
     # treated as a potential pair (= execution) and blocks scrubbing.
     # shellcheck disable=SC2016 # the openers are matched as literal text here
     case "$SCRUBBED" in
-      *'$('*|*'${'*|*'`'*) ;;
-      *) SCRUBBED=$(printf '%s' "$SCRUBBED" | scrub_message_body '"' "$TEXT_FLAG_PATTERN") ;;
+      *'$('* | *'${'* | *'`'*) ;;
+      *)
+        scrub_message_body '"' "$TEXT_FLAG_PATTERN" "$SCRUBBED"
+        SCRUBBED=$MESSAGE_SCRUBBED
+        ;;
     esac
     # A `-F -` / `--body-file -` body arrives as a heredoc instead, by a route the
     # flag scrub above does not cover.
-    SCRUBBED=$(printf '%s' "$SCRUBBED" | drop_heredoc_body)
+    drop_heredoc_body "$SCRUBBED"
+    SCRUBBED=$HEREDOC_DROPPED
   fi
   GUARD_SCRUBBED=$SCRUBBED
 }
 
-refuse_protected_env_file() { # reads GUARD_SCRUBBED
+# The set before `.env` decides which tokens count as the filename. `@` joined
+# it because `gh api -F key=@FILE` reads the file named after the `@` (gh
+# 2.86.0), and `curl -d @FILE` and `curl -F name=@FILE` read it too. The set
+# after it closes the token. A newline is a member of `[[:space:]]` on both
+# sides, so a line of a multi-line command is bounded the way `^` and `$` bound
+# the whole text.
+ENV_FILE_RE='(^|[[:space:]"'\''`=@{}:,;&|<>(/-])\.env(\.(local|development|production))?([[:space:]"'\''`{}:,;&|<>)*]|$)'
+
+refuse_protected_env_file() { # reads GUARD_SCRUBBED; sets GUARD_REFUSAL
   local UNESCAPED UNQUOTED
   # `.env` is one of several spellings the shell turns into the same filename: it
   # drops a backslash and a quote pair from a word, so `.e\nv`, `.en"v"` and
-  # `.e''nv` all reach the file (each printed `.env` on 2026-09-08). The grep gets
-  # the command text and both undecorated forms as three lines, and matching any
-  # one of them refuses the command, so no spelling this normalizes can cost a
-  # block that the raw text already earned. Replacing the text with the
-  # undecorated form instead would have cost one: `"` and `'` are members of the
-  # character classes below, and dropping them turns `cat -b'.env'` into
-  # `cat -b.env`, whose `b` those classes do not list.
+  # `.e''nv` all reach the file (each printed `.env` on 2026-09-08). The command
+  # text and both undecorated forms are searched, and matching any one of them
+  # refuses the command, so no spelling this normalizes can cost a block that the
+  # raw text already earned. Replacing the text with the undecorated form instead
+  # would have cost one: `"` and `'` are members of the character classes above,
+  # and dropping them turns `cat -b'.env'` into `cat -b.env`, whose `b` those
+  # classes do not list.
   UNESCAPED=${GUARD_SCRUBBED//\\/}
   UNQUOTED=${UNESCAPED//[\"\']/}
-  # The set before `.env` decides which tokens count as the filename. `@` joined
-  # it because `gh api -F key=@FILE` reads the file named after the `@` (gh
-  # 2.86.0), and `curl -d @FILE` and `curl -F name=@FILE` read it too.
-  if printf '%s\n%s\n%s' "$GUARD_SCRUBBED" "$UNESCAPED" "$UNQUOTED" | grep -qE '(^|[[:space:]"'\''`=@{}:,;&|<>(/-])\.env(\.(local|development|production))?([[:space:]"'\''`{}:,;&|<>)*]|$)'; then
+  if [[ $GUARD_SCRUBBED =~ $ENV_FILE_RE || $UNESCAPED =~ $ENV_FILE_RE || $UNQUOTED =~ $ENV_FILE_RE ]]; then
     GUARD_REFUSAL="PreToolUse(Bash): this command references a protected env file (.env / .env.local / .env.development / .env.production). Reading or writing these is denied regardless of tool. Use .env.local.example for documented placeholders. To write the filename as prose, put it in a quoted body of \`git\` -m/--message or of \`gh\` --body/--title/--subject: a single-quoted body is read as prose, a double-quoted one only when the command contains no \$(, \${ or backtick."
   fi
 }
@@ -187,24 +270,27 @@ refuse_protected_env_file() { # reads GUARD_SCRUBBED
 # `find` takes MORE THAN ONE starting path, so `find src / -type f` hid a broad
 # root behind a narrow one. Quotes are stripped and every leading operand is
 # checked.
-refuse_broad_find() { # $1 = the Bash tool's command text
-  local NORM NORM_FIND FIND_SEGMENTS FIND_ASK SEG TOK SAW_FIND ROOT_COUNT
-  local IN_PREDICATES
-  # Whitespace-normalized command for Guard 2, its only reader: the segment
-  # filter below matches the literal " find ", so irregular spacing (`find  .`,
-  # tabs, newlines) must not slip past it.
-  NORM=$(printf '%s' "$1" | drop_heredoc_body | tr -s '[:space:]' ' ')
-  FIND_ASK=""
+refuse_broad_find() { # $1 = the Bash tool's command text; sets GUARD_REFUSAL
+  local -a LINES
+  local NORM NORM_FIND FIND_ASK SEG WORDS_REST WORD SAW_FIND ROOT_COUNT
+  local IN_PREDICATES HEREDOC_DROPPED
   # A heredoc body is data, not a command — a commit message describing
   # `find . | xargs cat` must not trip this. Guard 1 scrubs `-m` bodies for the
   # same reason; this is the heredoc case, found when the first version of this
-  # guard refused the commit that introduced it. NORM's `drop_heredoc_body` drops
-  # the body by reading the terminator. Truncating from the first `<<` instead
-  # left `cat <<EOF` / `x` / `EOF` / `find / -type f` allowed, because everything
-  # after the terminator went with the body.
-  NORM_FIND=$(printf '%s' "$NORM" | tr -d "'\"\`")
-  FIND_SEGMENTS=${NORM_FIND//[;|&]/$'\n'}
-  while IFS= read -r SEG; do
+  # guard refused the commit that introduced it. Truncating from the first `<<`
+  # instead left `cat <<EOF` / `x` / `EOF` / `find / -type f` allowed, because
+  # everything after the terminator went with the body.
+  drop_heredoc_body "$1"
+  # Whitespace-normalized command for Guard 2, its only reader: the segment
+  # filter below matches the literal " find ", so a tab or a newline ahead of
+  # `find` must not slip past it. A run of blanks survives the replacement and
+  # neither reader minds: the filter needs one blank on each side of the word,
+  # and `next_word` skips a run of them.
+  NORM=${HEREDOC_DROPPED//[[:space:]]/ }
+  FIND_ASK=""
+  NORM_FIND=${NORM//[\'\"\`]/}
+  split_lines "${NORM_FIND//[;|&]/$NEWLINE}"
+  for SEG in "${LINES[@]}"; do
     [ -n "$FIND_ASK" ] && break
     case " $SEG " in
       *' find '*) ;;
@@ -213,14 +299,15 @@ refuse_broad_find() { # $1 = the Bash tool's command text
     SAW_FIND=0
     ROOT_COUNT=0
     IN_PREDICATES=0
-    for TOK in $SEG; do
+    WORDS_REST=$SEG
+    while next_word; do
       if [ "$SAW_FIND" -eq 0 ]; then
-        [ "$TOK" = find ] && SAW_FIND=1
+        [ "$WORD" = find ] && SAW_FIND=1
         continue
       fi
-      case "$TOK" in
+      case "$WORD" in
         # An action that runs a command or deletes, wherever it appears.
-        -exec|-execdir|-ok|-okdir|-delete|-fprint|-fprintf|-fls)
+        -exec | -execdir | -ok | -okdir | -delete | -fprint | -fprintf | -fls)
           FIND_ASK="it carries an action that runs a command or deletes files"
           break
           ;;
@@ -229,7 +316,7 @@ refuse_broad_find() { # $1 = the Bash tool's command text
         *)
           [ "$IN_PREDICATES" -eq 1 ] && continue
           ROOT_COUNT=$((ROOT_COUNT + 1))
-          case "$TOK" in
+          case "$WORD" in
             . | ./ | .. | ../ | /* | '~'* | '$'* | *'..'*)
               FIND_ASK="a search root reaches the whole repository (or outside it), so it can read files the deny list protects"
               break
@@ -242,8 +329,7 @@ refuse_broad_find() { # $1 = the Bash tool's command text
     if [ -z "$FIND_ASK" ] && [ "$SAW_FIND" -eq 1 ] && [ "$ROOT_COUNT" -eq 0 ]; then
       FIND_ASK="it names no search root, so it searches the working directory"
     fi
-    # `printf` terminates the last segment, which `read` would otherwise drop.
-  done < <(printf '%s\n' "$FIND_SEGMENTS")
+  done
   if [ -n "$FIND_ASK" ]; then
     # Blocks rather than prompts. A hook's `permissionDecision: "ask"` is a valid
     # value, but the documented precedence only settles that a *blocking* hook
@@ -305,16 +391,12 @@ refuse_broad_find() { # $1 = the Bash tool's command text
 #
 # The shell drops a quote pair and a backslash from a word, so `g""it`, `\-A`
 # and `\*` all reach git undecorated; Guard 1 normalizes the same two
-# decorations at UNQUOTED for the same reason. Both run as parameter
-# expansions, so neither forks a `tr`, and both run before the early-outs below,
+# decorations at UNQUOTED for the same reason.
 
 # Set REFUSED to the reason one operand takes more than it names, and leave it
 # alone when the operand names a path of its own. `git add`, `git rm` and
 # `git commit` all read their operands as a pathspec, so all three call this.
-# It assigns rather than printing its answer, because a `$(...)` read-back
-# forks a subshell per operand token on a hook that runs before every Bash
-# call.
-refuse_unnamed_operand() { # $1 = one operand token
+refuse_unnamed_operand() { # $1 = one operand token; sets REFUSED
   case "$1" in
     :*)
       REFUSED="an operand begins with \`:\`, so it is pathspec magic rather than a path: \`:\` is the working directory, and \`:/\` and \`:(top)\` are the repository root"
@@ -361,18 +443,19 @@ refuse_unnamed_operand() { # $1 = one operand token
   esac
 }
 
-refuse_unnamed_changes() { # reads GUARD_SCRUBBED
-  local CMD_PLAIN WALK_PLAIN WALK_BEFORE_PWD PWD_NOTE CMD_SEGMENTS SEG TOK
+refuse_unnamed_changes() { # reads GUARD_SCRUBBED; sets GUARD_REFUSAL
+  local -a LINES
+  local CMD_PLAIN WALK_PLAIN WALK_BEFORE_PWD PWD_NOTE CMD_SEGMENTS SEG
+  local WORDS_REST WORD
   local STATE SKIP_VALUE SUB HAS_SELECTION REFUSED CLUSTER BEFORE_VALUE
-  local NEXT_STEP
+  local NEXT_STEP HEREDOC_DROPPED MESSAGE_SCRUBBED
   CMD_PLAIN=${GUARD_SCRUBBED//[\"\'\`]/}
   CMD_PLAIN=${CMD_PLAIN//\\/}
   # Only a segment a literal `git` opens can be refused, so a command whose text
-  # holds no `git` leaves before the awk fork below. This hook runs on every Bash
-  # call, and on `ls -la` over two rounds of 60 interleaved runs it took 173 ms
-  # and 184 ms with this case against 181 ms and 203 ms without it (a machine
-  # under parallel load, 2026-09-08). Nothing this function does after the
-  # early-out below can refuse a command with no `git` in its text.
+  # holds no `git` leaves before the scrubs and the walk below. Nothing this
+  # function does after the early-out below can refuse a command with no `git`
+  # in its text. On `ls -la`, 5000 calls took 0.327 ms each with this case and
+  # 0.378 ms each with both early-outs removed (macOS, 2026-09-09).
   case "$CMD_PLAIN" in
     *git*) ;;
     *) return 0 ;;
@@ -380,12 +463,10 @@ refuse_unnamed_changes() { # reads GUARD_SCRUBBED
   # A refusal needs a segment whose token is `add`, `stage`, `commit` or `rm`,
   # and the heredoc drop below only removes whole lines, so a command whose text
   # holds none of those four names cannot reach one. `git status`, `git log` and
-  # `git push` all leave here instead of forking the awk, where
-  # `git diff --staged` walks on because its flag carries `stage`. On a
-  # `git status --short` payload, 60 runs of this hook took 20.4 s, 20.2 s and
-  # 21.5 s in three rounds with the three-name form of this case, against 23.5 s,
-  # 24.3 s and 22.6 s for 60 runs without it (a machine under parallel load,
-  # 2026-09-09).
+  # `git push` all leave here instead of walking, where `git diff --staged`
+  # walks on because its flag carries `stage`. On `git status --short`, 5000
+  # calls took 0.376 ms each with this case and 0.433 ms each with both
+  # early-outs removed (macOS, 2026-09-09).
   #
   # `rm` is two letters and needs its own token boundaries, where the other three
   # do not. Over 3300 Bash commands taken from this project's session
@@ -410,24 +491,25 @@ refuse_unnamed_changes() { # reads GUARD_SCRUBBED
   # no such condition, because a quoted body is one argument: a flag or pathspec
   # written outside it survives the scrub, so `-m "msg" .` and `-m "msg" -a` are
   # still refused. An ANSI-C-quoted body is not scrubbed, so `-m $'fix .'` is
-  # refused. The `*-m*` test keeps the two awk forks off a command with no
-  # message flag at all, `--message` included, because that spelling holds `-m`.
+  # refused. The `*-m*` test keeps the two scrubs off a command with no message
+  # flag at all, `--message` included, because that spelling holds `-m`.
   WALK_PLAIN=$GUARD_SCRUBBED
   case "$GUARD_SCRUBBED" in
     *-m*)
-      WALK_PLAIN=$(printf '%s' "$GUARD_SCRUBBED" |
-        scrub_message_body "'" "$GIT_MESSAGE_FLAG" |
-        scrub_message_body '"' "$GIT_MESSAGE_FLAG")
+      scrub_message_body "'" "$GIT_MESSAGE_FLAG" "$GUARD_SCRUBBED"
+      scrub_message_body '"' "$GIT_MESSAGE_FLAG" "$MESSAGE_SCRUBBED"
+      WALK_PLAIN=$MESSAGE_SCRUBBED
       ;;
   esac
   # The heredoc drop reads the raw text, ahead of the strips below, because the
   # backslash strip turns `echo a \<\< MARK` into a heredoc opener the shell
   # never saw: bash ran the next line of `echo a \<\< MARK` / `echo LINE2_RAN` /
-  # `MARK` and printed `a << MARK` and `LINE2_RAN`, where the awk read `MARK` as
+  # `MARK` and printed `a << MARK` and `LINE2_RAN`, where the drop read `MARK` as
   # a delimiter and dropped both lines after it. Written as `echo "a << MARK"`
-  # the two `<` are adjacent in the raw text as well, and the awk has no quote
+  # the two `<` are adjacent in the raw text as well, and the drop has no quote
   # state to tell that pair from an opener, so that spelling still drops them.
-  WALK_PLAIN=$(printf '%s' "$WALK_PLAIN" | drop_heredoc_body)
+  drop_heredoc_body "$WALK_PLAIN"
+  WALK_PLAIN=$HEREDOC_DROPPED
   # `$'x'` and `$"x"` hand git the same argument `'x'` does, and the quote strip
   # below leaves their `$` behind: `git rm -r $'.'` and `git rm -r .$''` each
   # listed all three tracked files of the scratch repository, where the walk saw
@@ -470,25 +552,24 @@ refuse_unnamed_changes() { # reads GUARD_SCRUBBED
   # and the segment split reads a newline as a separator, so the walk got `git`
   # and `rm -r .` as two segments and neither is a refusable shape. Joining the
   # pair into a space puts the subcommand back beside its `git`.
-  WALK_PLAIN=${WALK_PLAIN//\\$'\n'/ }
+  WALK_PLAIN=${WALK_PLAIN//\\$NEWLINE/ }
   WALK_PLAIN=${WALK_PLAIN//\\/}
-  CMD_SEGMENTS=${WALK_PLAIN//[;|\&()]/$'\n'}
-  # A bare `*` operand has to survive word splitting as itself rather than
-  # expanding to the working directory's entries.
-  set -f
-  while IFS= read -r SEG; do
+  CMD_SEGMENTS=${WALK_PLAIN//[;|\&()]/$NEWLINE}
+  split_lines "$CMD_SEGMENTS"
+  for SEG in "${LINES[@]}"; do
     STATE=prefix
     SKIP_VALUE=0
     SUB=""
     HAS_SELECTION=0
-    for TOK in $SEG; do
+    WORDS_REST=$SEG
+    while next_word; do
       if [ "$SKIP_VALUE" -eq 1 ]; then
         SKIP_VALUE=0
         continue
       fi
       case "$STATE" in
         prefix)
-          case "$TOK" in
+          case "$WORD" in
             git) STATE=subcommand ;;
             # An assignment, a redirect, a command that runs another command, or
             # such a command's own flag or count (`timeout 5`) stands between the
@@ -498,7 +579,7 @@ refuse_unnamed_changes() { # reads GUARD_SCRUBBED
           esac
           ;;
         subcommand)
-          case "$TOK" in
+          case "$WORD" in
             # git's own options that take the following token as their value
             # (`git --help`, git 2.50.1). Skipping the value keeps a value that
             # happens to read like a subcommand from ending the walk.
@@ -507,22 +588,22 @@ refuse_unnamed_changes() { # reads GUARD_SCRUBBED
               ;;
             -*) ;;
             add | stage)
-              SUB=$TOK
+              SUB=$WORD
               STATE=operands
               ;;
             commit)
-              SUB=$TOK
+              SUB=$WORD
               STATE=commit
               ;;
             rm)
-              SUB=$TOK
+              SUB=$WORD
               STATE=remove
               ;;
             *) break ;;
           esac
           ;;
         operands)
-          case "$TOK" in
+          case "$WORD" in
             # `git add`'s long options that take the following token as their
             # value. Without this, `git add --pathspec-from-file paths.txt`
             # counted `paths.txt` as a named path and staged both files that file
@@ -535,7 +616,7 @@ refuse_unnamed_changes() { # reads GUARD_SCRUBBED
               SKIP_VALUE=1
               ;;
             --all | --no-ignore-removal)
-              REFUSED="\`${TOK}\` stages every change in the worktree instead of the paths you name"
+              REFUSED="\`${WORD}\` stages every change in the worktree instead of the paths you name"
               break
               ;;
             --update)
@@ -547,7 +628,7 @@ refuse_unnamed_changes() { # reads GUARD_SCRUBBED
             -*)
               # git clusters its short options (`git add -Av` staged the whole
               # scratch repository), so the letters are read one by one.
-              case "${TOK#-}" in
+              case "${WORD#-}" in
                 *A*)
                   REFUSED="the short option -A stages every change in the worktree instead of the paths you name"
                   break
@@ -560,7 +641,7 @@ refuse_unnamed_changes() { # reads GUARD_SCRUBBED
               esac
               ;;
             *)
-              refuse_unnamed_operand "$TOK"
+              refuse_unnamed_operand "$WORD"
               if [ -n "$REFUSED" ]; then
                 break
               fi
@@ -569,7 +650,7 @@ refuse_unnamed_changes() { # reads GUARD_SCRUBBED
           esac
           ;;
         remove)
-          case "$TOK" in
+          case "$WORD" in
             # With a file holding `.`, both
             # `git rm -n -r --pathspec-from-file=ps.txt` and the prefix spelling
             # `git rm -n -r --pathspec-from-f ps.txt` listed all three tracked
@@ -586,7 +667,7 @@ refuse_unnamed_changes() { # reads GUARD_SCRUBBED
               ;;
             -*) ;;
             *)
-              refuse_unnamed_operand "$TOK"
+              refuse_unnamed_operand "$WORD"
               if [ -n "$REFUSED" ]; then
                 break
               fi
@@ -595,7 +676,7 @@ refuse_unnamed_changes() { # reads GUARD_SCRUBBED
           esac
           ;;
         commit)
-          case "$TOK" in
+          case "$WORD" in
             # commit's long options that take the following token as their value.
             # Each was run as `git commit --dry-run <option> ZZZ` against a
             # staged change in a scratch repository (git 2.50.1, 2026-09-09) and
@@ -633,7 +714,7 @@ refuse_unnamed_changes() { # reads GUARD_SCRUBBED
               # `--untracked-files`) and `-u -a -m x` and `-S -a -m x` each
               # committed both modified files, because `-u` and `-S` take an
               # attached value or none (git 2.50.1, 2026-09-09).
-              CLUSTER=${TOK#-}
+              CLUSTER=${WORD#-}
               BEFORE_VALUE=${CLUSTER%%[mFcCtuS]*}
               case "$BEFORE_VALUE" in
                 *a*)
@@ -646,7 +727,7 @@ refuse_unnamed_changes() { # reads GUARD_SCRUBBED
               esac
               ;;
             *)
-              refuse_unnamed_operand "$TOK"
+              refuse_unnamed_operand "$WORD"
               if [ -n "$REFUSED" ]; then
                 break
               fi
@@ -677,9 +758,7 @@ refuse_unnamed_changes() { # reads GUARD_SCRUBBED
     if [ -n "$REFUSED" ]; then
       break
     fi
-    # `printf` terminates the last segment, which `read` would otherwise drop.
-  done < <(printf '%s\n' "$CMD_SEGMENTS")
-  set +f
+  done
   if [ -n "$REFUSED" ]; then
     case "$SUB" in
       commit)
@@ -699,11 +778,7 @@ refuse_unnamed_changes() { # reads GUARD_SCRUBBED
 # The three guards in the order the hook applies them, each leaving
 # GUARD_REFUSAL alone where it allows the command. That name stays inside this
 # file: the answer leaves as this function's own output, which one command
-# substitution reads. Its cost is 0.59 ms against 0.04 ms for reading a global,
-# over 400 rounds each on macOS under parallel load (2026-09-09), where the
-# guards below cost 200 ms for one command. `refuse_unnamed_operand` assigns
-# rather than printing for the same comparison run per operand token instead of
-# once per command.
+# substitution reads.
 guard_refusal() { # $1 = the Bash tool's command text
   local GUARD_REFUSAL="" GUARD_SCRUBBED=""
   scrub_command_text "$1"

--- a/.claude/hooks/pre-bash-guard-decision.test.ts
+++ b/.claude/hooks/pre-bash-guard-decision.test.ts
@@ -428,6 +428,21 @@ group("find: scoped discovery runs unattended", [
     expected: "allow",
     why: "piped into a reader, scoped",
   },
+  {
+    command: "find src/*.ts -type f",
+    expected: "allow",
+    why: "a named directory ahead of the glob bounds what it matches",
+  },
+  {
+    command: "find ./src/*.tsx -type f",
+    expected: "allow",
+    why: "the same bound written with a leading ./",
+  },
+  {
+    command: "find src* -type f",
+    expected: "allow",
+    why: "a glob that starts inside a name the command shows",
+  },
 ]);
 
 group("find: broad reach is refused", [
@@ -451,6 +466,26 @@ group("find: broad reach is refused", [
     command: "find -name '*.ts'",
     expected: "block",
     why: "no root operand at all",
+  },
+  {
+    command: "find .* -type f",
+    expected: "block",
+    why: "a dot glob the shell expands to `.` and `..` where it does not skip them",
+  },
+  {
+    command: "find .[a-z]* -type f",
+    expected: "block",
+    why: "a bracket class in the same position reaches the same two names",
+  },
+  {
+    command: "find * -type f",
+    expected: "block",
+    why: "a glob starting from nothing takes every entry of the working directory",
+  },
+  {
+    command: "find ./* -type f",
+    expected: "block",
+    why: "the same reach written from ./",
   },
   {
     command: "find\t.\t-type f",
@@ -510,6 +545,11 @@ group("find: quoting must not hide the shape", [
     why: "quoted action flag",
   },
   { command: "find src '-delete'", expected: "block", why: "quoted -delete" },
+  {
+    command: "find '.*' -type f",
+    expected: "block",
+    why: "quoted dot glob root",
+  },
 ]);
 
 group("find: a broad root hidden behind a narrow one is still caught", [

--- a/.claude/hooks/pre-bash-guard-decision.test.ts
+++ b/.claude/hooks/pre-bash-guard-decision.test.ts
@@ -485,6 +485,16 @@ group("find: broad reach is refused", [
     expected: "block",
     why: "no root operand at all",
   },
+  {
+    command: "find\t.\t-type f",
+    expected: "block",
+    why: "tabs around the root",
+  },
+  {
+    command: "git status\nfind / -type f",
+    expected: "block",
+    why: "a find on the second line of a multi-line command",
+  },
 ]);
 
 group("find: actions that run or delete are refused, even when scoped", [
@@ -590,6 +600,21 @@ group("find: text inside a heredoc is data, not a command", [
     command: "cat <<'EOF'\nfind . -delete\nEOF\necho done",
     expected: "allow",
     why: "the body stays data when a command follows the terminator",
+  },
+  {
+    command: "cat <<EOF\nfind / -delete",
+    expected: "block",
+    why: "a body with no terminator cannot be told from the rest, so every line is read as a command",
+  },
+  {
+    command: "cat <<-EOF\nfind / -delete\n\tEOF",
+    expected: "allow",
+    why: "the <<- spelling closes at its tab-indented terminator",
+  },
+  {
+    command: "cat <<''\nfind / -delete\n\necho x",
+    expected: "block",
+    why: "an empty delimiter closes on no line, so the blank line does not end the body",
   },
 ]);
 
@@ -1125,6 +1150,11 @@ group("git add: the shapes that defeated earlier guards here", [
     command: "cat <<'EOF'\ngit add -A\nEOF",
     expected: "allow",
     why: "a heredoc body outside a git command is prose too",
+  },
+  {
+    command: "cat <<A <<B\nbodyA\nA\ngit add -A\nB\necho done",
+    expected: "allow",
+    why: "an operator line opening two heredocs ends at the second terminator, so both bodies stay data",
   },
   {
     command: `${COMMIT} -F - <<'MSG'\nbody\nMSG\ngit add -A`,

--- a/.claude/hooks/pre-bash-guard-decision.test.ts
+++ b/.claude/hooks/pre-bash-guard-decision.test.ts
@@ -9,10 +9,10 @@
  * payload the hook reads and the JSON it prints. Nothing in the repository is
  * modified and no command from a case is ever executed.
  *
- * The whole table is answered before the first test runs, by SHARD_COUNT bash
- * processes that each source the decision file once and answer the commands
- * they read NUL-delimited on stdin. A case is then a synchronous comparison
- * and carries none of the driver's wall time.
+ * The whole table is answered before the first test runs, by one bash process
+ * that sources the decision file once and answers the commands it reads
+ * NUL-delimited on stdin. A case is then a synchronous comparison and carries
+ * none of the driver's wall time.
  *
  * A case in the first table asserts the whole refusal sentence, so a branch
  * that answers with another branch's reason fails there. A case in a group
@@ -21,7 +21,6 @@
  */
 
 import { spawn } from "node:child_process";
-import os from "node:os";
 import path from "node:path";
 import { text } from "node:stream/consumers";
 import { describe, expect, it } from "vite-plus/test";
@@ -62,37 +61,35 @@ done
 `;
 
 /**
- * How many driver processes share the table.
+ * How long the driver may take before it is killed.
  *
- * What a command costs is the `sed`, `awk` and `grep` the guards fork for it,
- * not the driver's own start, so one process answers the 280 commands in the
- * sum of them: 53.6 s of this file's load, against 14.4 s to 16.5 s for every
- * count from 2 to 24 (2026-09-09, macOS 16 cores under parallel load). The
- * count is the machine's cores because the flat range covers it.
+ * Nothing else bounds it: the batch is awaited while this file loads, and a
+ * vitest timeout covers a test rather than a module's evaluation, so a guard
+ * that hangs on one command would hold the whole file. A killed driver loses
+ * the answers it had not printed, which the batch test reads as a count.
  */
-const SHARD_COUNT = os.availableParallelism();
+const DRIVER_TIMEOUT_MS = 120_000;
 
-/** What one driver process answered for the slice of the table it was given. */
-interface DriverRun {
-  refusals: readonly string[];
+/** What the driver answered for the table it was given. */
+interface Batch {
+  answered: number;
+  answers: ReadonlyMap<string, string | undefined>;
   stderr: string;
 }
 
 /**
- * How long a shard may take before it is killed.
+ * Answer the whole table in one bash process.
  *
- * Nothing else bounds it: the batch is awaited while this file loads, and a
- * vitest timeout covers a test rather than a module's evaluation, so a guard
- * that hangs on one command would hold the whole file. A killed shard loses
- * the answers it had not printed, which the batch test reads as a count.
- * The shards run at once, so each one runs for most of the 14 s the load takes.
+ * `guard_refusal` answers a command out of the command alone, so a case finds
+ * its answer under the command it sent rather than at a position it has to
+ * keep track of, and two cases sending the same command read the same answer.
+ * `answered` counts what came back before the duplicates collapse, which is
+ * what the batch test at the bottom of this file compares against the table.
  */
-const SHARD_TIMEOUT_MS = 120_000;
-
-const runShard = async (commands: readonly string[]): Promise<DriverRun> => {
+const runDriver = async (commands: readonly string[]): Promise<Batch> => {
   const driver = spawn("bash", ["-c", DRIVER, "bash", DECISION], {
     killSignal: "SIGKILL",
-    timeout: SHARD_TIMEOUT_MS,
+    timeout: DRIVER_TIMEOUT_MS,
   });
   driver.stdin.end(commands.map((command) => `${command}\0`).join(""));
   const [stdout, stderr] = await Promise.all([
@@ -101,43 +98,13 @@ const runShard = async (commands: readonly string[]): Promise<DriverRun> => {
   ]);
   // The driver terminates every answer with a NUL, so the split leaves one
   // trailing empty piece that belongs to no command.
-  return { refusals: stdout.split("\0").slice(0, -1), stderr };
-};
-
-/**
- * What the shards answered between them.
- *
- * `guard_refusal` answers a command out of the command alone, so a case finds
- * its answer under the command it sent rather than at a position it has to
- * keep track of, and two cases sending the same command read the same answer.
- * `answered` counts what came back before the duplicates collapse, which is
- * what the batch test at the bottom of this file compares against the table.
- */
-interface Batch {
-  answered: number;
-  answers: ReadonlyMap<string, string | undefined>;
-  stderr: string;
-}
-
-const runDriver = async (commands: readonly string[]): Promise<Batch> => {
-  // A shard takes every SHARD_COUNT-th command rather than a run of them, so
-  // what it costs does not follow where one kind of shape sits in the table:
-  // 31 of the 68 commands whose first two words are `git` and the commit
-  // subcommand are consecutive, and a run of 18 would have fallen inside them.
-  const slices = Array.from({ length: SHARD_COUNT }, (_, shard) =>
-    commands.filter((_command, index) => index % SHARD_COUNT === shard)
-  );
-  const shards = await Promise.all(
-    slices.map(async (slice) => ({ run: await runShard(slice), slice }))
-  );
+  const refusals = stdout.split("\0").slice(0, -1);
   return {
-    answered: shards.reduce((total, { run }) => total + run.refusals.length, 0),
+    answered: refusals.length,
     answers: new Map(
-      shards.flatMap(({ run, slice }) =>
-        slice.map((command, offset) => [command, run.refusals[offset]] as const)
-      )
+      commands.map((command, index) => [command, refusals[index]] as const)
     ),
-    stderr: shards.map(({ run }) => run.stderr).join(""),
+    stderr,
   };
 };
 


### PR DESCRIPTION
Phase 3 of the plan in #175, and the phase that plan valued most: what it removes is charged to every Bash tool call rather than to a test suite. `.claude/hooks/pre-bash-guard-decision.sh` forked `sed`, `awk`, `grep` and `tr` per command. Every one of those text passes is now bash parameter expansion, `[[ =~ ]]` or `case`, so the three guards start no process.

## Timings

`bunx vp test --run .claude/hooks/pre-bash-guard-decision`, which is the runner #179 used because a filtered `bun run test` exits 1 on the global coverage gate before printing a duration:

| | before | after |
| --- | --- | --- |
| whole run | 17.73 s, 17.92 s (281 tests) | 3.04 s, 2.72 s (294 tests) |
| the batch, which is the `import` line | 15.73 s, 15.98 s | 0.41 s |

One PreToolUse call end to end through `.claude/hooks/pre-bash-guard.sh`, on a payload carrying `git commit -m 'feat: add the thing'`, timed as 20 calls divided by 20 and repeated three times:

| | before | after |
| --- | --- | --- |
| the hook | 460.6 ms, 338.0 ms, 435.7 ms | 174 ms, 175 ms, 158 ms |

An entry that reads the same payload, runs the same two `jq` calls and sources the decision file **without calling a guard** took 141 ms, 202 ms and 148 ms over three rounds of its own. That is the same range as the whole hook after the change, so what is left is the `bash` start, the payload read and the two `jq` calls in `pre-bash-guard.sh`, which this ticket does not own. Inside the decision itself the drop is 134.7 ms to 1.0 ms per command, measured as the wall time of one process answering 2528 commands.

`bun run test` over the whole suite: 909 tests, 29 files, 18.50 s.

## That the answers did not move

The 243-case table #179 moved onto the decision driver decides most of it, and all of it passes. Beyond that I ran #175's reviewer method: 2528 commands (128 hand-written shapes plus 2400 built at random from an alphabet of the tokens the guards read) through both `origin/main`'s file and this one, comparing the whole refusal sentence. **2 disagreements, both `find *` and `find *.ts`, both the deliberate tightening below.** The `code-reviewer` agent then built its own 6746-command corpus against the six points I named as least certain and found 14 disagreements, every one of them in the block direction and every one from that same rule; it reports no allow-direction regression, no hang, no truncated answer and no stderr.

The file also answers all 2528 identically under `/bin/bash` 3.2.57 and under bash 5.3.9, which is what keeps `#!/usr/bin/env bash` honest on a machine with no homebrew bash.

## The one deliberate behaviour change: a `find` root carrying a glob

`find * -type f` and `find .* -type f` were allowed. The shell expands both before `find` runs: `*` to every entry of the working directory whose name does not begin with a dot, and `.*` to `.` and `..` on a shell without `globskipdots` (`/bin/bash` 3.2.57 here expands it that way; bash 5.3.9 leaves it literal, both run in an empty directory on 2026-09-09). So each reaches what `find .` reaches, which is the shape Guard 2 exists to stop.

The old walk half-covered this by accident: `for TOK in $SEG` performs pathname expansion as well as word splitting, so the guard's answer depended on the hook's working directory and on the shell's version. `next_word` does not expand, and the rule is now stated instead of inherited: a root is judged by the literal text ahead of its first glob character, and a root with no glob is that text itself. An empty start, `.`, `./`, `..`, `../`, `/…`, `~…` and `$…` are refused; `src/`, `./src/` and `src` are not, so `find src/*.ts`, `find ./src/*.tsx` and `find src*` stay unattended.

## What moved, function by function

- **`drop_heredoc_body`** was an awk program; it is `split_lines` plus a line walk. The delimiter still comes from the last `<<` on the operator line, and the comment now says why in terms of the terminator rather than of body order, which I had backwards: fed `cat <<A <<B` / `bodyA` / `A` / `git add -A` / `B` / `echo done`, the walk scans to `B` and allows, where reading the delimiter from `A` stops at `A` and refuses for the `git add -A` inside B's body. I ran both spellings to check that.
- **`scrub_message_body`** was an awk program with a quote-parity loop; it is a `[[ =~ ]]` loop over the same ERE. Finding where the match started uses `${REST%%"$MATCH"*}`, which is sound because POSIX ERE matching is leftmost: an earlier copy of the matched text would itself have matched earlier, so the first occurrence of the match is at the match.
- **`scrub_command_text`**'s `sed 's/\.env[.A-Za-z]*\.example//g'` is a `[[ =~ ]]` delete loop, and its `awk 'NR == 1 { print $1 }'` is two parameter expansions.
- **`refuse_protected_env_file`**'s `grep -qE` over a three-line input is three `[[ =~ ]]` tests against the same ERE. grep anchored `^` and `$` per line and bash anchors them to the whole string, which agrees here because a newline is a member of `[[:space:]]` on both sides of the pattern.
- **`refuse_broad_find`**'s `tr -s '[:space:]' ' '` and `tr -d "'\"\`"` are parameter expansions. The squeeze half of the `tr -s` is gone rather than reproduced: every reader of that text tolerates a run of blanks, and removing it changed no answer over 6128 commands.
- **Both token walks** use `next_word`, which slices `WORDS_REST`. **Both segment loops** iterate the array `split_lines` fills, where `done < <(printf ...)` forked a subshell.

## `set +f`, which #179 recorded

`refuse_unnamed_changes` bracketed its walk with `set -f` / `set +f` and so handed globbing back on to whatever its caller had. That pair existed only because `for TOK in $SEG` globs. `next_word` never expands `$WORDS_REST` in a list context, so the pair is gone rather than repaired, and no `case $-` branch was added that no test could reach.

## Findings recorded rather than fixed

**`split_lines` and `next_word` are quadratic in the text they walk.** Both copy what they have left at each step. The `code-reviewer` measured the crossover: a `git add` with 200 paths (3697 chars) costs 0.134 s old against 0.036 s new, with 800 paths (15097 chars) 0.159 s against 0.233 s, with 2000 paths (38897 chars) 0.215 s against 1.310 s. It also measured this project's own traffic, 3381 Bash tool calls across the transcripts under `~/.claude/projects`: p50 299, p90 1200, p99 4456 chars, max 15323, with 4 calls over 10000. So the crossover sits above the 99th percentile, and today this costs about 70 ms spread over the 4 largest calls of 3381 while saving about 134 ms on each of the other 3377. The linear alternatives both cost the common case: `mapfile -d` needs bash 4.4 and `/bin/bash` here is 3.2.57, and a `read` loop fed by a herestring measured 0.045 ms against 0.017 ms for the slicing at 1 to 3 lines, which is where the traffic is. I chose the slicing and added an early-out so a command holding no `<<` skips the split entirely.

**`read -ra WORDS <<< "$SEG"` instead of `next_word`.** It splits without globbing and measured 0.048 ms against 0.088 ms per segment, so it is both simpler and faster. It is not used because on `/bin/bash` 3.2.57 a blank segment leaves `WORDS` empty and `for WORD in "${WORDS[@]}"` then dies under `set -u` with `WORDS[@]: unbound variable`, which I reproduced; `git status && git add -A` splits into exactly such a segment.

**The trim idiom `${X#"${X%%[![:blank:]]*}"}` appears four times.** Two reviewers asked for `next_word` at the `DELIM` and `FIRST_WORD` sites. `DELIM` is not the same operation: it removes quotes between the trim and the word take, so `<< 'A B'` must yield `A` rather than `'A`. `FIRST_WORD` is the same operation, but `next_word` signals the end of a walk with a non-zero status, so a one-shot call needs a `|| :` to survive `set -e`; two expansions read better than that.

**The out-parameter convention.** Four helpers assign the variable their signature comment names and the caller declares it `local`. The structural alternative is `local -n`, which needs bash 4.3. The reviewer checked all three declaration sites and found no call site nesting a `split_lines` inside a loop over `LINES`.

## Verification

`bun run check`, `bun run check:shell` and `bun run test` (909 tests, 29 files) pass on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
