### PR TITLE
test: hook のテストが process の起動を待ち合わせずに済む

### DIFF
--- a/.claude/hooks/pre-bash-guard.test.ts
+++ b/.claude/hooks/pre-bash-guard.test.ts
@@ -24,7 +24,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it, onTestFinished } from "vite-plus/test";
+import { afterAll, describe, expect, it } from "vite-plus/test";
 import { z } from "zod";
 import { readHookJson } from "./hook-output";
 import { runBash } from "./run-bash";
@@ -163,11 +163,22 @@ describe.concurrent("the payload's command is what the guards read", () => {
 });
 
 describe.concurrent("the decision file the hook sources", () => {
+  /**
+   * The directory this suite's cases write into, removed when the suite ends.
+   * `onTestFinished` registers against whichever case is current when it runs,
+   * which under `describe.concurrent` is not reliably the case that created
+   * the directory.
+   */
+  const scratchRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), "pre-bash-guard-cases-")
+  );
+
+  afterAll(() => {
+    fs.rmSync(scratchRoot, { force: true, recursive: true });
+  });
+
   it("should refuse the command when the decision file is not beside the hook", async () => {
-    const alone = fs.mkdtempSync(path.join(os.tmpdir(), "pre-bash-guard-"));
-    onTestFinished(() => {
-      fs.rmSync(alone, { force: true, recursive: true });
-    });
+    const alone = fs.mkdtempSync(path.join(scratchRoot, "lone-"));
     const copy = path.join(alone, "pre-bash-guard.sh");
     fs.copyFileSync(HOOK, copy);
 

--- a/.claude/hooks/pre-bash-guard.test.ts
+++ b/.claude/hooks/pre-bash-guard.test.ts
@@ -24,7 +24,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, describe, expect, it } from "vite-plus/test";
+import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
 import { z } from "zod";
 import { readHookJson } from "./hook-output";
 import { runBash } from "./run-bash";
@@ -167,11 +167,14 @@ describe.concurrent("the decision file the hook sources", () => {
    * The directory this suite's cases write into, removed when the suite ends.
    * `onTestFinished` registers against whichever case is current when it runs,
    * which under `describe.concurrent` is not reliably the case that created
-   * the directory.
+   * the directory. `beforeAll` assigns it, because vitest runs neither hook
+   * for a suite whose cases a `-t` filter all deselects.
    */
-  const scratchRoot = fs.mkdtempSync(
-    path.join(os.tmpdir(), "pre-bash-guard-cases-")
-  );
+  let scratchRoot = "";
+
+  beforeAll(() => {
+    scratchRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pre-bash-guard-"));
+  });
 
   afterAll(() => {
     fs.rmSync(scratchRoot, { force: true, recursive: true });

--- a/.claude/hooks/pre-bash-guard.test.ts
+++ b/.claude/hooks/pre-bash-guard.test.ts
@@ -21,16 +21,13 @@
  * from a case is ever executed.
  */
 
-import type { ChildProcess } from "node:child_process";
-import { spawn } from "node:child_process";
-import { once } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { text } from "node:stream/consumers";
 import { describe, expect, it, onTestFinished } from "vite-plus/test";
 import { z } from "zod";
 import { readHookJson } from "./hook-output";
+import { runBash } from "./run-bash";
 
 const HOOK = path.resolve(import.meta.dirname, "pre-bash-guard.sh");
 
@@ -66,15 +63,6 @@ const denyOutput = (reason: string): z.infer<typeof HookOutput> => ({
   reason,
 });
 
-/** node emits `close` with the exit code and the signal that ended the child. */
-const CloseArgs = z.tuple([z.number().nullable(), z.string().nullable()]);
-
-const exitStatusOf = async (hook: ChildProcess): Promise<number | null> => {
-  const closed: unknown = await once(hook, "close");
-  const [status] = CloseArgs.parse(closed);
-  return status;
-};
-
 /**
  * What one run of the hook produced.
  *
@@ -101,13 +89,9 @@ interface Payload {
 }
 
 const runHook = async (payload: Payload, hookPath = HOOK): Promise<HookRun> => {
-  const hook = spawn("bash", [hookPath]);
-  hook.stdin.end(JSON.stringify(payload));
-  const [stdout, stderr, status] = await Promise.all([
-    text(hook.stdout),
-    text(hook.stderr),
-    exitStatusOf(hook),
-  ]);
+  const { status, stderr, stdout } = await runBash(hookPath, {
+    input: JSON.stringify(payload),
+  });
   return {
     output: stdout.trim() === "" ? "" : readHookJson(stdout, HookOutput),
     status,

--- a/.claude/hooks/run-bash.ts
+++ b/.claude/hooks/run-bash.ts
@@ -1,0 +1,47 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { text } from "node:stream/consumers";
+import { z } from "zod";
+
+/** node emits `close` with the exit code and the signal that ended the child. */
+const CloseArgs = z.tuple([z.number().nullable(), z.string().nullable()]);
+
+/** Where one bash run happens, what it inherits, and what it reads on stdin. */
+export interface BashRunOptions {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  input?: string;
+}
+
+/** What one bash run produced. */
+export interface BashRun {
+  status: number | null;
+  stderr: string;
+  stdout: string;
+}
+
+/**
+ * One run of a bash script, awaited rather than blocking the thread, so a file
+ * whose cases each fork a hook runs those forks at once instead of one at a
+ * time.
+ *
+ * Both pipes get a reader before the exit is awaited, because `close` fires
+ * only once they drain: a script writing more than a pipe buffer would block
+ * on a reader that arrives after the await that never returns. Neither pipe
+ * has a size cap, which `spawnSync`'s `maxBuffer` would have imposed.
+ */
+export const runBash = async (
+  script: string,
+  options: BashRunOptions = {}
+): Promise<BashRun> => {
+  const child = spawn("bash", [script], {
+    cwd: options.cwd,
+    env: options.env,
+  });
+  const stdout = text(child.stdout);
+  const stderr = text(child.stderr);
+  child.stdin.end(options.input ?? "");
+  const closed: unknown = await once(child, "close");
+  const [status] = CloseArgs.parse(closed);
+  return { status, stderr: await stderr, stdout: await stdout };
+};

--- a/.claude/hooks/run-bash.ts
+++ b/.claude/hooks/run-bash.ts
@@ -10,7 +10,7 @@ const CloseArgs = z.tuple([z.number().nullable(), z.string().nullable()]);
 export interface BashRunOptions {
   cwd?: string;
   env?: NodeJS.ProcessEnv;
-  input?: string;
+  input: string;
 }
 
 /** What one bash run produced. */
@@ -32,7 +32,7 @@ export interface BashRun {
  */
 export const runBash = async (
   script: string,
-  options: BashRunOptions = {}
+  options: BashRunOptions
 ): Promise<BashRun> => {
   const child = spawn("bash", [script], {
     cwd: options.cwd,
@@ -40,7 +40,7 @@ export const runBash = async (
   });
   const stdout = text(child.stdout);
   const stderr = text(child.stderr);
-  child.stdin.end(options.input ?? "");
+  child.stdin.end(options.input);
   const closed: unknown = await once(child, "close");
   const [status] = CloseArgs.parse(closed);
   return { status, stderr: await stderr, stdout: await stdout };

--- a/.claude/hooks/stop-gate.test.ts
+++ b/.claude/hooks/stop-gate.test.ts
@@ -14,7 +14,14 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it, onTestFinished } from "vite-plus/test";
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  onTestFinished,
+} from "vite-plus/test";
 import { z } from "zod";
 import { readHookJson } from "./hook-output";
 
@@ -45,50 +52,72 @@ const PASSING: Steps = {
 };
 
 /**
- * A committed git repository with the three step stand-ins in place, plus the
+ * The paths carrying the step stand-ins, which every case writes with its own
+ * bodies. The template repository lists them in `.git/info/exclude`, so
+ * `git status --porcelain` and `git ls-files --others --exclude-standard`
+ * report neither and one committed tree serves every set of steps.
+ */
+const STAND_INS = {
+  links: ".claude/hooks/check-md-links.ts",
+  packageJson: "package.json",
+} as const;
+
+const templateRoot = fs.mkdtempSync(
+  path.join(os.tmpdir(), "stop-gate-template-")
+);
+
+const git = (root: string, ...args: string[]): void => {
+  // The identity comes from the environment because a CI runner's git has
+  // none, and signing is turned off because a machine whose global config
+  // signs every commit has no key for this scratch repository.
+  const result = spawnSync(
+    "git",
+    ["-c", "commit.gpgsign=false", "-c", "init.defaultBranch=main", ...args],
+    {
+      cwd: root,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        GIT_AUTHOR_EMAIL: "gate@example.com",
+        GIT_AUTHOR_NAME: "gate",
+        GIT_COMMITTER_EMAIL: "gate@example.com",
+        GIT_COMMITTER_NAME: "gate",
+      },
+    }
+  );
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${result.stderr}`);
+  }
+};
+
+const buildTemplateRepo = (): void => {
+  git(templateRoot, "init", "--quiet");
+  fs.writeFileSync(
+    path.join(templateRoot, ".git/info/exclude"),
+    `${Object.values(STAND_INS)
+      .map((standIn) => `/${standIn}`)
+      .join("\n")}\n`
+  );
+  git(templateRoot, "commit", "--allow-empty", "--quiet", "-m", "scaffolding");
+};
+
+/**
+ * A git repository carrying one commit and the three step stand-ins, plus the
  * named files left untracked so `git status --porcelain` reports them and
  * `holds_code_relevant_file` sees them.
  */
 const scratchRepo = (steps: Steps, untracked: readonly string[]): string => {
   const root = scratchDir("stop-gate-");
+  fs.cpSync(templateRoot, root, { recursive: true });
   fs.mkdirSync(path.join(root, ".claude/hooks"), { recursive: true });
   fs.writeFileSync(
-    path.join(root, "package.json"),
+    path.join(root, STAND_INS.packageJson),
     `${JSON.stringify({
       name: "stop-gate-scratch",
       scripts: { check: steps.check, test: steps.test },
     })}\n`
   );
-  fs.writeFileSync(
-    path.join(root, ".claude/hooks/check-md-links.ts"),
-    `${steps.links}\n`
-  );
-  // The identity comes from the environment because a CI runner's git has
-  // none, and signing is turned off because a machine whose global config
-  // signs every commit has no key for this scratch repository.
-  const git = (...args: string[]): void => {
-    const result = spawnSync(
-      "git",
-      ["-c", "commit.gpgsign=false", "-c", "init.defaultBranch=main", ...args],
-      {
-        cwd: root,
-        encoding: "utf-8",
-        env: {
-          ...process.env,
-          GIT_AUTHOR_EMAIL: "gate@example.com",
-          GIT_AUTHOR_NAME: "gate",
-          GIT_COMMITTER_EMAIL: "gate@example.com",
-          GIT_COMMITTER_NAME: "gate",
-        },
-      }
-    );
-    if (result.status !== 0) {
-      throw new Error(`git ${args.join(" ")} failed: ${result.stderr}`);
-    }
-  };
-  git("init", "--quiet");
-  git("add", "package.json", ".claude/hooks/check-md-links.ts");
-  git("commit", "--quiet", "-m", "scaffolding");
+  fs.writeFileSync(path.join(root, STAND_INS.links), `${steps.links}\n`);
   untracked.forEach((name) => {
     fs.writeFileSync(path.join(root, name), "x\n");
   });
@@ -181,6 +210,15 @@ const pathWithOnly = (names: readonly string[]): string => {
 };
 
 describe("stop-gate.sh", () => {
+  // `git init` plus `git commit` take 275 ms together on this machine (macOS,
+  // 2026-09-09) and copying the tree they leave takes 0.8 ms, so the history
+  // every case needs is built once here rather than fourteen times.
+  beforeAll(buildTemplateRepo);
+
+  afterAll(() => {
+    fs.rmSync(templateRoot, { force: true, recursive: true });
+  });
+
   it("should stay silent when the tree holds no change", () => {
     const root = scratchRepo(PASSING, []);
 

--- a/.claude/hooks/stop-gate.test.ts
+++ b/.claude/hooks/stop-gate.test.ts
@@ -27,13 +27,19 @@ const GATE = path.resolve(import.meta.dirname, "stop-gate.sh");
 const DECISION = path.resolve(import.meta.dirname, "stop-gate-decision.sh");
 
 /**
- * Everything the cases write lives under here and goes when the file ends.
- * `onTestFinished` registers against whichever case is current when it runs,
- * and under `describe.concurrent` that is not reliably the case that asked for
- * the directory. Removing each case's tree that way failed three of eight runs
- * of this file; removing one root when the file ends failed none of eight.
+ * Everything the cases write lives under `scratchRoot`, and the suite's
+ * `afterAll` removes it. `onTestFinished` registers against whichever case is
+ * current when it runs, and under `describe.concurrent` that is not reliably
+ * the case that asked for the directory. Removing each case's tree that way
+ * failed three of eight runs of this file; removing one root when the file
+ * ends failed none of eight.
+ *
+ * Both are assigned in `beforeAll` rather than here, because vitest runs
+ * neither hook for a suite whose cases a `-t` filter all deselects, which left
+ * the directories behind while `mkdtempSync` ran at collection time.
  */
-const scratchRoot = fs.mkdtempSync(path.join(os.tmpdir(), "stop-gate-cases-"));
+let scratchRoot = "";
+let templateRoot = "";
 
 /** A directory the case owns. */
 const scratchDir = (prefix: string): string =>
@@ -56,16 +62,14 @@ const PASSING: Steps = {
 /**
  * The paths carrying the step stand-ins, which `scratchRepo` writes with the
  * bodies its caller chose. The template repository lists them in
- * `.git/info/exclude`, so
- * `git status --porcelain` and `git ls-files --others --exclude-standard`
- * report neither and one committed tree serves every set of steps.
+ * `.git/info/exclude`, so `git status --porcelain` and `git ls-files --others
+ * --exclude-standard` report neither and one committed tree serves every set
+ * of steps.
  */
 const STAND_INS = {
   links: ".claude/hooks/check-md-links.ts",
   packageJson: "package.json",
 } as const;
-
-const templateRoot = fs.mkdtempSync(path.join(scratchRoot, "template-"));
 
 const git = (root: string, ...args: string[]): void => {
   // The identity comes from the environment because a CI runner's git has
@@ -91,7 +95,9 @@ const git = (root: string, ...args: string[]): void => {
   }
 };
 
-const buildTemplateRepo = (): void => {
+const createScratchTrees = (): void => {
+  scratchRoot = fs.mkdtempSync(path.join(os.tmpdir(), "stop-gate-cases-"));
+  templateRoot = fs.mkdtempSync(path.join(scratchRoot, "template-"));
   git(templateRoot, "init", "--quiet");
   fs.mkdirSync(path.join(templateRoot, path.dirname(STAND_INS.links)), {
     recursive: true,
@@ -221,7 +227,7 @@ describe.concurrent("stop-gate.sh", { timeout: 30_000 }, () => {
   // `git init` plus `git commit` take 275 ms together on this machine (macOS,
   // 2026-09-09) and copying the tree they leave takes 0.8 ms, so the history
   // is built once here rather than at each of `scratchRepo`'s 13 call sites.
-  beforeAll(buildTemplateRepo);
+  beforeAll(createScratchTrees);
 
   afterAll(() => {
     fs.rmSync(scratchRoot, { force: true, recursive: true });

--- a/.claude/hooks/stop-gate.test.ts
+++ b/.claude/hooks/stop-gate.test.ts
@@ -8,34 +8,36 @@
  * the link failure in the same body. Each case runs the real hook against a
  * scratch git repository whose `check`, `test` and link-check steps this file
  * writes, so no step of this repository's own toolchain runs.
+ *
+ * A gate run over a code change forks bash, three bun processes, three git
+ * processes and jq, so the cases run concurrently and copy their repository
+ * from one committed tree this file builds once.
  */
 
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import {
-  afterAll,
-  beforeAll,
-  describe,
-  expect,
-  it,
-  onTestFinished,
-} from "vite-plus/test";
+import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
 import { z } from "zod";
 import { readHookJson } from "./hook-output";
+import { runBash } from "./run-bash";
 
 const GATE = path.resolve(import.meta.dirname, "stop-gate.sh");
 const DECISION = path.resolve(import.meta.dirname, "stop-gate-decision.sh");
 
-/** A directory the case owns, removed when the case ends. */
-const scratchDir = (prefix: string): string => {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-  onTestFinished(() => {
-    fs.rmSync(dir, { force: true, recursive: true });
-  });
-  return dir;
-};
+/**
+ * Everything the cases write lives under here and goes when the file ends.
+ * `onTestFinished` registers against whichever case is current when it runs,
+ * and under `describe.concurrent` that is not reliably the case that asked for
+ * the directory. Removing each case's tree that way failed three of eight runs
+ * of this file; removing one root when the file ends failed none of eight.
+ */
+const scratchRoot = fs.mkdtempSync(path.join(os.tmpdir(), "stop-gate-cases-"));
+
+/** A directory the case owns. */
+const scratchDir = (prefix: string): string =>
+  fs.mkdtempSync(path.join(scratchRoot, prefix));
 
 /** A step's stand-in: what `bun run <script>` runs, and what bun executes for the link check. */
 interface Steps {
@@ -62,9 +64,7 @@ const STAND_INS = {
   packageJson: "package.json",
 } as const;
 
-const templateRoot = fs.mkdtempSync(
-  path.join(os.tmpdir(), "stop-gate-template-")
-);
+const templateRoot = fs.mkdtempSync(path.join(scratchRoot, "template-"));
 
 const git = (root: string, ...args: string[]): void => {
   // The identity comes from the environment because a CI runner's git has
@@ -159,22 +159,23 @@ interface RunOptions {
   stopHookActive?: boolean;
 }
 
-const runGate = (root: string, options: RunOptions = {}): GateRun => {
+const runGate = async (
+  root: string,
+  options: RunOptions = {}
+): Promise<GateRun> => {
   const payload: StopPayload = {
     cwd: options.cwd ?? root,
     loop_count: options.loopCount,
     stop_hook_active: options.stopHookActive,
   };
-  const result = spawnSync("bash", [options.gate ?? GATE], {
+  const result = await runBash(options.gate ?? GATE, {
     cwd: root,
-    encoding: "utf-8",
     env: {
       ...process.env,
       CLAUDE_PROJECT_DIR: options.projectDir ?? root,
       PATH: options.path ?? process.env.PATH,
     },
     input: JSON.stringify(payload),
-    maxBuffer: 8 * 1024 * 1024,
   });
   return {
     ...readHookJson(result.stdout, GateOutput),
@@ -209,20 +210,24 @@ const pathWithOnly = (names: readonly string[]): string => {
   return dir;
 };
 
-describe("stop-gate.sh", () => {
+// The timeout bounds a gate that hangs rather than budgeting one case. A
+// case's wall clock here is set by how many of its neighbours are forking at
+// the same moment: the slowest reached 2.2 s on an idle machine, and at the
+// 5 s default a loaded one failed two of the fifteen before any assertion ran.
+describe.concurrent("stop-gate.sh", { timeout: 30_000 }, () => {
   // `git init` plus `git commit` take 275 ms together on this machine (macOS,
   // 2026-09-09) and copying the tree they leave takes 0.8 ms, so the history
   // every case needs is built once here rather than fourteen times.
   beforeAll(buildTemplateRepo);
 
   afterAll(() => {
-    fs.rmSync(templateRoot, { force: true, recursive: true });
+    fs.rmSync(scratchRoot, { force: true, recursive: true });
   });
 
-  it("should stay silent when the tree holds no change", () => {
+  it("should stay silent when the tree holds no change", async () => {
     const root = scratchRepo(PASSING, []);
 
-    const run = runGate(root);
+    const run = await runGate(root);
 
     expect({ status: run.status, stdout: run.stdout }).toStrictEqual({
       status: 0,
@@ -230,30 +235,30 @@ describe("stop-gate.sh", () => {
     });
   });
 
-  it("should skip the quality gate when only a docs file changed", () => {
+  it("should skip the quality gate when only a docs file changed", async () => {
     const root = scratchRepo(PASSING, ["notes.md"]);
 
-    const run = runGate(root);
+    const run = await runGate(root);
 
     expect(run.systemMessage).toBe(
       "✅ Stop gate: no code-relevant changes (quality gate skipped, md links: clean)"
     );
   });
 
-  it("should report the quality gate and the link check as passing when a code file changed and every step succeeds", () => {
+  it("should report the quality gate and the link check as passing when a code file changed and every step succeeds", async () => {
     const root = scratchRepo(PASSING, ["a.ts"]);
 
-    const run = runGate(root);
+    const run = await runGate(root);
 
     expect(run.systemMessage).toBe(
       "✅ Stop gate: typecheck / lint / format and the test suite pass (md links: clean)"
     );
   });
 
-  it("should block and name the step when the quality gate fails", () => {
+  it("should block and name the step when the quality gate fails", async () => {
     const root = scratchRepo({ ...PASSING, check: "exit 1" }, ["a.ts"]);
 
-    const run = runGate(root);
+    const run = await runGate(root);
 
     expect({
       decision: run.decision,
@@ -267,19 +272,19 @@ describe("stop-gate.sh", () => {
     });
   });
 
-  it("should name both steps in one block when the step after a failing one fails too", () => {
+  it("should name both steps in one block when the step after a failing one fails too", async () => {
     const root = scratchRepo({ ...PASSING, check: "exit 1", test: "exit 1" }, [
       "a.ts",
     ]);
 
-    const run = runGate(root);
+    const run = await runGate(root);
 
     expect(run.systemMessage).toBe(
       "⛔ Stop block: bun run check, bun run test failed. Fix before ending the turn."
     );
   });
 
-  it("should report the link check as failed rather than clean when it fails", () => {
+  it("should report the link check as failed rather than clean when it fails", async () => {
     const root = scratchRepo(
       {
         ...PASSING,
@@ -288,7 +293,7 @@ describe("stop-gate.sh", () => {
       ["a.ts"]
     );
 
-    const run = runGate(root);
+    const run = await runGate(root);
 
     expect({ decision: run.decision, reason: run.reason }).toStrictEqual({
       decision: "block",
@@ -304,7 +309,7 @@ md links: FAILED`,
   // `jq --arg body "$2"` failed with E2BIG here (ARG_MAX is 1048576 on macOS,
   // and Linux caps one argument at 131072), and the gate's own `exit` then
   // ended the turn having printed nothing at all.
-  it("should carry the whole failure body into the block when that body is larger than ARG_MAX", () => {
+  it("should carry the whole failure body into the block when that body is larger than ARG_MAX", async () => {
     const fillerBytes = 1_500_000;
     const root = scratchRepo(
       {
@@ -321,7 +326,7 @@ md links: FAILED`,
       "markdown link check failed. Fix before ending the turn.\n\n===== markdown link check =====\n";
     const tail = "\ntail-marker\n\nmd links: FAILED";
 
-    const run = runGate(root);
+    const run = await runGate(root);
 
     expect({
       decision: run.decision,
@@ -334,10 +339,10 @@ md links: FAILED`,
     });
   });
 
-  it("should warn instead of blocking when Claude Code reports this Stop was already blocked", () => {
+  it("should warn instead of blocking when Claude Code reports this Stop was already blocked", async () => {
     const root = scratchRepo({ ...PASSING, check: "exit 1" }, ["a.ts"]);
 
-    const run = runGate(root, { stopHookActive: true });
+    const run = await runGate(root, { stopHookActive: true });
 
     expect({
       decision: run.decision,
@@ -349,10 +354,10 @@ md links: FAILED`,
     });
   });
 
-  it("should warn instead of blocking when Cursor reports an auto-followup already ran", () => {
+  it("should warn instead of blocking when Cursor reports an auto-followup already ran", async () => {
     const root = scratchRepo({ ...PASSING, check: "exit 1" }, ["a.ts"]);
 
-    const run = runGate(root, { loopCount: 1 });
+    const run = await runGate(root, { loopCount: 1 });
 
     expect({
       decision: run.decision,
@@ -364,10 +369,10 @@ md links: FAILED`,
     });
   });
 
-  it("should report the link check as skipped rather than clean when bun is not installed", () => {
+  it("should report the link check as skipped rather than clean when bun is not installed", async () => {
     const root = scratchRepo(PASSING, ["notes.md"]);
 
-    const run = runGate(root, {
+    const run = await runGate(root, {
       path: pathWithOnly(["bash", "cat", "git", "jq", "sort"]),
     });
 
@@ -380,11 +385,11 @@ md links: FAILED`,
   // started in and the payload's cwd is the one the turn edited, so the gate
   // prefers cwd. The session tree here is clean, which is what the gate would
   // report if it read CLAUDE_PROJECT_DIR instead.
-  it("should judge the tree the payload names when the session started in another one", () => {
+  it("should judge the tree the payload names when the session started in another one", async () => {
     const session = scratchRepo(PASSING, []);
     const work = scratchRepo(PASSING, ["a.ts"]);
 
-    const run = runGate(work, { cwd: work, projectDir: session });
+    const run = await runGate(work, { cwd: work, projectDir: session });
 
     expect(run.systemMessage).toBe(
       "✅ Stop gate: typecheck / lint / format and the test suite pass (md links: clean)"
@@ -393,11 +398,11 @@ md links: FAILED`,
 
   // The scratch repository's `check` fails, so a gate that carried on in the
   // wrong tree would block naming `bun run check` rather than the root.
-  it("should block naming the unreachable root when it cannot enter the tree to judge", () => {
+  it("should block naming the unreachable root when it cannot enter the tree to judge", async () => {
     const root = scratchRepo({ ...PASSING, check: "exit 1" }, ["a.ts"]);
     const missing = path.join(root, "gone");
 
-    const run = runGate(root, { cwd: missing, projectDir: missing });
+    const run = await runGate(root, { cwd: missing, projectDir: missing });
 
     expect({
       decision: run.decision,
@@ -414,12 +419,12 @@ md links: FAILED`,
   // exits non-zero with empty stdout without walking up to any repository above
   // the scratch directory. The gate's step stand-ins are absent, so a gate that
   // read that emptiness as a clean tree would exit 0 having judged nothing.
-  it("should block naming the root when it cannot read git status in the tree", () => {
+  it("should block naming the root when it cannot read git status in the tree", async () => {
     const broken = scratchDir("stop-gate-nogit-");
     fs.mkdirSync(path.join(broken, ".claude/hooks"), { recursive: true });
     fs.writeFileSync(path.join(broken, ".git"), "not a gitfile\n");
 
-    const run = runGate(broken, { cwd: broken, projectDir: broken });
+    const run = await runGate(broken, { cwd: broken, projectDir: broken });
 
     expect({
       decision: run.decision,
@@ -437,11 +442,11 @@ md links: FAILED`,
   // loosened to `if false`, the gate carried on and emitted an empty
   // systemMessage, ending the turn with nothing judged. Deciding that needs no
   // scratch repository.
-  it("should block naming the decision file when the entry cannot load it", () => {
+  it("should block naming the decision file when the entry cannot load it", async () => {
     const lone = scratchDir("stop-gate-lone-");
     fs.copyFileSync(GATE, path.join(lone, "stop-gate.sh"));
 
-    const run = runGate(lone, { gate: path.join(lone, "stop-gate.sh") });
+    const run = await runGate(lone, { gate: path.join(lone, "stop-gate.sh") });
 
     expect({
       decision: run.decision,
@@ -457,7 +462,7 @@ md links: FAILED`,
   // The other way the `source` fails is a decision file that will not parse,
   // and the block's remedy for a missing file is the wrong one for it, so the
   // reason carries what bash says about this file rather than a guess.
-  it("should carry bash's reason into the block when the decision file does not parse", () => {
+  it("should carry bash's reason into the block when the decision file does not parse", async () => {
     const broken = scratchDir("stop-gate-unparsable-");
     fs.copyFileSync(GATE, path.join(broken, "stop-gate.sh"));
     fs.copyFileSync(DECISION, path.join(broken, "stop-gate-decision.sh"));
@@ -466,7 +471,9 @@ md links: FAILED`,
       "if [ x ; then\n"
     );
 
-    const run = runGate(broken, { gate: path.join(broken, "stop-gate.sh") });
+    const run = await runGate(broken, {
+      gate: path.join(broken, "stop-gate.sh"),
+    });
 
     expect({
       decision: run.decision,

--- a/.claude/hooks/stop-gate.test.ts
+++ b/.claude/hooks/stop-gate.test.ts
@@ -92,6 +92,9 @@ const git = (root: string, ...args: string[]): void => {
 
 const buildTemplateRepo = (): void => {
   git(templateRoot, "init", "--quiet");
+  fs.mkdirSync(path.join(templateRoot, path.dirname(STAND_INS.links)), {
+    recursive: true,
+  });
   fs.writeFileSync(
     path.join(templateRoot, ".git/info/exclude"),
     `${Object.values(STAND_INS)
@@ -109,7 +112,6 @@ const buildTemplateRepo = (): void => {
 const scratchRepo = (steps: Steps, untracked: readonly string[]): string => {
   const root = scratchDir("stop-gate-");
   fs.cpSync(templateRoot, root, { recursive: true });
-  fs.mkdirSync(path.join(root, ".claude/hooks"), { recursive: true });
   fs.writeFileSync(
     path.join(root, STAND_INS.packageJson),
     `${JSON.stringify({

--- a/.claude/hooks/stop-gate.test.ts
+++ b/.claude/hooks/stop-gate.test.ts
@@ -9,9 +9,9 @@
  * scratch git repository whose `check`, `test` and link-check steps this file
  * writes, so no step of this repository's own toolchain runs.
  *
- * A gate run over a code change forks bash, three bun processes, three git
- * processes and jq, so the cases run concurrently and copy their repository
- * from one committed tree this file builds once.
+ * A gate run over a code change execs 14 processes, three of them bun, so the
+ * cases run concurrently and copy their repository from one committed tree
+ * this file builds once.
  */
 
 import { spawnSync } from "node:child_process";
@@ -54,8 +54,9 @@ const PASSING: Steps = {
 };
 
 /**
- * The paths carrying the step stand-ins, which every case writes with its own
- * bodies. The template repository lists them in `.git/info/exclude`, so
+ * The paths carrying the step stand-ins, which `scratchRepo` writes with the
+ * bodies its caller chose. The template repository lists them in
+ * `.git/info/exclude`, so
  * `git status --porcelain` and `git ls-files --others --exclude-standard`
  * report neither and one committed tree serves every set of steps.
  */
@@ -219,7 +220,7 @@ const pathWithOnly = (names: readonly string[]): string => {
 describe.concurrent("stop-gate.sh", { timeout: 30_000 }, () => {
   // `git init` plus `git commit` take 275 ms together on this machine (macOS,
   // 2026-09-09) and copying the tree they leave takes 0.8 ms, so the history
-  // every case needs is built once here rather than fourteen times.
+  // is built once here rather than at each of `scratchRepo`'s 13 call sites.
   beforeAll(buildTemplateRepo);
 
   afterAll(() => {


### PR DESCRIPTION
`bun run test` の wall を 15.06 s から 6.33 s にする（warm な vite cache で 5 回の中央値、macOS、2026-09-09）。

## 何に時間がかかっていたか

テストの本数ではない。909 ケースのうち `src/` の 16 ファイル 174 ケースは合計 0.30 s で終わる。wall のほぼ全部を 1 ファイル、`.claude/hooks/stop-gate.test.ts` の 15 ケースが占めていた。

その 15 ケースがやっていたこと。

1. 各ケースが scratch の git repository を `git init` + `git add` + `git commit` で作る。3 つで 392 ms、`scratchRepo` の呼び出しは 13 か所なので 39 プロセス。
2. `spawnSync` で gate を起動する。thread が止まるので 15 回が 1 つずつ順番に走る。

1 回の gate 起動が exec するプロセスを PATH に置いた shim で数えた。code の変更があるツリーで 14（bash 3、bun 3、git 3、jq 3、sort 1、cat 1）、docs だけのツリーで 10。この機械での 1 プロセスあたりの起動コストは `true` が 12 ms、`jq` が 24 ms、`git` が 58 ms、`bun` が 80 ms。gate 1 回が 683 ms、scratch repository が 392 ms で、ケースあたり 620〜1075 ms になっていた。

つまりコストはプロセス生成であって、vitest の pool でも `fileParallelism` でもない。ファイル同士は既に並列で、JSON reporter の start/end を見ると stop-gate 以外は全部 2.5 s までに終わっていた。`--maxConcurrency=15` も試したが 5 のときと変わらない（4.83 s 対 4.42 s）ので、pool や parallelism の設定は変えていない。

## 直したこと

**git の履歴を 1 本にする。** commit を 1 つ持つ template repository を `beforeAll` で作り、各ケースは `fs.cpSync` で複製する。`git init` + `git commit` が 275 ms、複製が 0.8 ms。step の stand-in（`package.json` と `.claude/hooks/check-md-links.ts`）は commit せず template の `.git/info/exclude` に載せた。commit 済みで未変更だったときと同じく `git status --porcelain` にも `git ls-files --others --exclude-standard` にも出ないので、1 本の tree が 5 通りの step の組み合わせ全部に使える。scaffolding の git プロセスは 39 から 2 になった。

**gate の起動を待ち合わせない。** bash の終了を await する `runBash` を `.claude/hooks/run-bash.ts` に置き、stop-gate.test.ts の suite を `describe.concurrent` にした。pre-bash-guard.test.ts が自前で持っていた同じ処理もこれを呼ぶ。gate の起動回数（15）は変わらず、重なるようになっただけ。

**timeout を 30 s にした。** concurrent にすると 1 ケースの wall はその瞬間に何本の隣が fork しているかで決まる。idle な機械で最も遅いケースが 2.2 s、負荷のかかった機械では既定の 5 s で 15 本中 2 本が assertion に届かず落ちた。hang の上限としての 30 s であって 1 ケースの予算ではない。

**`onTestFinished` をやめた。** これは呼ばれた時点の case に紐づき、`describe.concurrent` の下では tree を要求した case とは限らない。ケースごとに片付ける書き方は 8 回中 3 回落ちた。ファイル 1 つの root にまとめて 8 回中 0 回。

assertion は 1 つも書き換えていない。909 ケース全部が通る。

## 計測

| file | tests | before | after |
| --- | --- | --- | --- |
| `.claude/hooks/stop-gate.test.ts` | 15 | 11528 ms | 3590 ms |
| `scripts/setup.test.ts` | 3 | 1065 ms | 971 ms |
| `.claude/hooks/pre-bash-guard.test.ts` | 7 | 859 ms | 660 ms |
| `.claude/hooks/check-md-links.test.ts` | 75 | 217 ms | 224 ms |
| `scripts/cursor-rule-mirrors.test.ts` | 14 | 163 ms | 164 ms |
| `vitest.config.test.ts` | 4 | 147 ms | 144 ms |
| 全ファイルの span | 909 | 12727 ms | 5215 ms |

上位 3 ファイルの遅いケース 3 つずつ。

`.claude/hooks/stop-gate.test.ts`

| test | before | after |
| --- | --- | --- |
| should carry the whole failure body into the block when that body is larger than ARG_MAX | 1772 ms | 1976 ms |
| should name both steps in one block when the step after a failing one fails too | 1521 ms | 1834 ms |
| should report the link check as failed rather than clean when it fails | 928 ms | 1842 ms |

ケース単体の数字は concurrent にすると上がる。隣が CPU を使っている間もそのケースの時計は進むので、ここは待ち時間を含む。ファイルの 11528 ms が 3590 ms になったのが実際に減った分。

`scripts/setup.test.ts`

| test | before | after |
| --- | --- | --- |
| should trust mise.toml before the remaining steps when mise is on PATH | 771 ms | 642 ms |
| should report the skipped trust step and still run the rest when mise is absent | 280 ms | 307 ms |
| should name the failing step and stop when a step cannot run | 14 ms | 21 ms |

`.claude/hooks/pre-bash-guard.test.ts`

| test | before | after |
| --- | --- | --- |
| should refuse the same sweep it refuses for Bash when the payload names Cursor's Shell tool | 858 ms | 638 ms |
| should finish silently when the payload carries no command at all | 858 ms | 638 ms |
| should stay silent when no guard refuses the command | 773 ms | 342 ms |

## 手を付けなかったもの

**`scripts/setup.test.ts`（971 ms、3 ケース）** は concurrent にしていない。stop-gate が 3.6 s なのでこのファイルは critical path に乗らず、wall は 1 ms も変わらない。

**stop-gate.test.ts に残る 3.6 s** はほぼ全部プロセス起動。さらに削るには、gate が呼ぶ `bun run check` / `bun run test` / link check を PATH 上の stub に差し替えるしかなく、それはケースが証明している内容を弱める。

**cleanup の共有ヘルパー** は作らなかった。altitude のレビューが、2 ファイルに同じ `scratchRoot` + `afterAll` の形が出るので `runBash` と同じように切り出せと言った。5 行を 2 か所から呼ぶための helper が `afterAll` を自分で登録することになり、hook を describe の中に置かせる lint ルール（`vitest/require-top-level-describe`）から隠れる。重複より悪い取引だと判断した。

**pre-bash-guard.test.ts の cleanup 変更** は、simplification のレビューが「その suite はケースが 1 本なので今は何も直していない」として削除を求めた。残した理由は、その suite が `describe.concurrent` である以上 `onTestFinished` はもう安全ではなく、2 本目のケースが足された時点で同じ flake が戻るから。stop-gate.test.ts で 8 回中 3 回落ちるのを実測した組み合わせと同じ形になる。

**Linux の CI runner では計測していない。** 数字は全部この macOS の worktree のもの。

## prompt の前提のうち合わなかったもの

- 「`bun run test` takes 27.8 s wall」は再現しなかった。今日の `origin/main`（8272a81）で warm な vite cache なら 15.06 s。cold cache の 1 回目は 38 s だったので、27.8 s はその中間の状態を測ったものだと思われる。
- 「the 9 test files under `.claude/hooks/` and `scripts/` take 22.2 s for 531 tests」も再現しなかった。ファイル数は合っているがケース数は 545 で、9 ファイルの wall の合計は 13.85 s。うち 11.53 s が stop-gate.test.ts 1 本で、残り 8 ファイルは合計 2.32 s。
- 「the 16 files under `src/` take 2.85 s for 174 tests」はファイル数もケース数も合っているが、wall の合計は 0.30 s。
- prompt が数えている 9 + 16 = 25 ファイルに対して、実行されるのは 29 ファイル 909 ケース。`tools/` の 3 ファイルと `vitest.config.test.ts` が抜けている。
- 「a single fork pool, `fileParallelism`, `pool` settings」を疑うよう指示があったが、直列化していたのは pool ではなくファイル内のケースだった。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
