### PR TITLE
chore: worker が worktree 内の AGENTS.md を二重に読まず、gh の読み取りが classifier を通らない

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,7 +18,9 @@
       "Bash(gh pr merge --squash *)",
       "Bash(bun run format)",
       "Bash(git fetch *)",
-      "Bash(actionlint *)"
+      "Bash(actionlint *)",
+      "Bash(gh pr view *)",
+      "Bash(gh pr checks *)"
     ],
     "deny": [
       "Bash(rm -rf /)",
@@ -88,5 +90,6 @@
     "typescript-lsp@claude-plugins-official": true,
     "context7@claude-plugins-official": true
   },
-  "plansDirectory": "./.claude/plans"
+  "plansDirectory": "./.claude/plans",
+  "claudeMdExcludes": ["**/.claude/worktrees/**"]
 }


### PR DESCRIPTION
worktree 配下の CLAUDE.md と rules を claudeMdExcludes で除外し、main checkout から既に渡っている同じ文書の nested_memory 再送（1 回約 1.2 万 token、worker あたり 1〜3 回）を止める。gh pr view と gh pr checks を allow に加え、2026-09-09 の run で 3 回あった classifier 拒否と再試行をなくす。
