### PR TITLE
fix: Claude / Cursor 共有の YAML frontmatter を修正し CI で検証

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: code-reviewer
-description: Pre-commit reviewer. Reads the uncommitted diff and runs the whole review in one context as four ordered stages: find every candidate across all lenses, dedup, refute each candidate against the real code, return the survivors with a concrete fix and acceptance check. Invoke after implementation, before committing.
+description: "Pre-commit reviewer. Reads the uncommitted diff and runs the whole review in one context as four ordered stages: find every candidate across all lenses, dedup, refute each candidate against the real code, return the survivors with a concrete fix and acceptance check. Invoke after implementation, before committing."
 tools: Read, Bash
 permissionMode: auto
 ---


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 変更内容

- `code-reviewer` と、同じ問題を持つ `prose.md`・skills 3 本の `description` をクォート
- `scripts/check-claude-frontmatter.entry.ts` を追加し、`.claude/rules/`・`.claude/agents/`・`.claude/skills/**/SKILL.md` の frontmatter が YAML としてパースできることを CI で検証
- README に、Cursor が `.claude/skills/` と `.claude/agents/` をそのまま読む旨を追記

## 原因

`description` 内の `word: ...` がクォートなし YAML ではマッピング区切りとして解釈され、Claude Code と Cursor の両方で frontmatter が壊れていた。

## 確認

- `bun scripts/check-claude-frontmatter.entry.ts`
- `bun run check`
- `bun run test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d1972ed-2990-4a5d-bbd3-3d6b5c68eb82?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d1972ed-2990-4a5d-bbd3-3d6b5c68eb82&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

