### PR TITLE
chore: Claude / Cursor 共有設定の同期を揃える

### DIFF
--- a/.claude/rules/prose.md
+++ b/.claude/rules/prose.md
@@ -1,5 +1,5 @@
 ---
-description: How a sentence is built in comments, instruction documents, commit messages, and replies, in English and Japanese: plain words, what a sentence is allowed to be about, precision, format, and the generated-text patterns to keep out
+description: "How a sentence is built in comments, instruction documents, commit messages, and replies, in English and Japanese: plain words, what a sentence is allowed to be about, precision, format, and the generated-text patterns to keep out"
 alwaysApply: true
 ---
 

--- a/.claude/skills/codex-delegation/SKILL.md
+++ b/.claude/skills/codex-delegation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codex-delegation
-description: Hand a ticket's mechanical implementation to the Codex CLI (`codex exec`) while the Claude worker keeps the ticket: what Codex is given, what never leaves Claude, the sandbox the call runs under, and what the worker does with the diff that comes back. Invoke at `ticket-work` step 5 when the change's acceptance is a command's exit code and its specification is already written.
+description: "Hand a ticket's mechanical implementation to the Codex CLI (`codex exec`) while the Claude worker keeps the ticket: what Codex is given, what never leaves Claude, the sandbox the call runs under, and what the worker does with the diff that comes back. Invoke at `ticket-work` step 5 when the change's acceptance is a command's exit code and its specification is already written."
 ---
 
 # Codex delegation

--- a/.claude/skills/dispatch-run/SKILL.md
+++ b/.claude/skills/dispatch-run/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dispatch-run
-description: The two standing parts of a dispatch run: the brief every worker follows to carry its ticket to a merged pull request, and what the dispatching session does while they work (watch the run's pull requests with `scripts/orchestrate.ts watch-prs`, act on the line the watch exits with, clean the run's worktrees once every pull request is closed). A dispatching session names this skill in each worker prompt and invokes it itself right after dispatching one worker per ticket; a worker invokes it when its prompt names it.
+description: "The two standing parts of a dispatch run: the brief every worker follows to carry its ticket to a merged pull request, and what the dispatching session does while they work (watch the run's pull requests with `scripts/orchestrate.ts watch-prs`, act on the line the watch exits with, clean the run's worktrees once every pull request is closed). A dispatching session names this skill in each worker prompt and invokes it itself right after dispatching one worker per ticket; a worker invokes it when its prompt names it."
 ---
 
 # Dispatch run

--- a/.claude/skills/ticket-work/SKILL.md
+++ b/.claude/skills/ticket-work/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ticket-work
-description: The seven-step sequence for ticket-granularity work: implementing a component, fixing a non-trivial bug, refactoring a module, adding a feature. Invoke at the start of such work.
+description: "The seven-step sequence for ticket-granularity work: implementing a component, fixing a non-trivial bug, refactoring a module, adding a feature. Invoke at the start of such work."
 ---
 
 # Ticket work

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,6 +117,9 @@ jobs:
       - name: Check the Cursor rule mirrors
         run: bun scripts/check-cursor-rule-mirrors.entry.ts
 
+      - name: Check Claude frontmatter parses
+        run: bun scripts/check-claude-frontmatter.entry.ts
+
       # `vp check` runs format, lint and type checks in one pass, which is why
       # this workflow has no separate tsc step.
       - name: Run format, lint and type checks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ Your training data goes stale. Outdated guidance is worse than no guidance.
 
 ## Rules
 
-Rules are auto-loaded from `.claude/rules/`, and each is mirrored into `.cursor/rules/*.mdc` as a file-level symlink so Cursor sessions load the same text (never replace a symlink with a copy). Each rule's own frontmatter states its subject and its scope, and it states the scope twice because Claude Code reads `paths` and Cursor reads `globs`, so both keys change together.
+Rules are auto-loaded from `.claude/rules/`, and each is mirrored into `.cursor/rules/*.mdc` as a file-level symlink so Cursor sessions load the same text (never replace a symlink with a copy). Skills and agents live only under `.claude/skills/` and `.claude/agents/`; Cursor reads those paths directly, so do not add `.cursor/skills/` or `.cursor/agents/`. Each rule's own frontmatter states its subject and its scope, and it states the scope twice because Claude Code reads `paths` and Cursor reads `globs`, so both keys change together.
 
 - **`design.md`** is scoped to `src/**/*.css` and `src/**/*.tsx`, so a session deciding a UI question without opening one of those files loads none of it and has to open the rule itself.
 - **`prose.md`** carries no path scope, so every session holds it whatever it is editing.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ src/
 - **`.claude/rules/`**：規約の分冊。path scope を持つものは対象ファイルを編集するときだけ、持たないものは毎セッション読み込まれます
 - **`.claude/skills/`**：名前のついた作業の手順。チケット粒度の作業は `ticket-work` が持ち、AGENTS.md はそれを指します
 - **`.claude/hooks/`**：規約を機械的に強制する側。SessionStart で依存の欠落を報告し、Bash 実行前にガードを掛け、Stop ではコードが変わった turn だけ `bun run check`（format / lint / 型検査）と `bun run test` を回します。markdown のリンク切れ検査は変更があれば毎回走ります。ツリー全体を判定する検査は Stop に置かず、knip は CI、`similarity-ts` は lefthook の pre-push が回します
+- **Cursor**：`.cursor/rules/` は `.claude/rules/` の symlink。skills と agents は `.claude/` をそのまま読む（`.cursor/skills/` や `.cursor/agents/` は置かない）
 
 コミット前のレビューは `code-reviewer` エージェントが担い、PR ブランチへのコミットと push はエージェントが AGENTS.md の規律に従って自分で行います。`main` へは PR 経由でだけ入ります。
 

--- a/scripts/check-claude-frontmatter.entry.ts
+++ b/scripts/check-claude-frontmatter.entry.ts
@@ -1,0 +1,15 @@
+#!/usr/bin/env bun
+
+/**
+ * ```
+ * bun scripts/check-claude-frontmatter.entry.ts         # this repository
+ * bun scripts/check-claude-frontmatter.entry.ts <root>  # a tree holding .claude/
+ * ```
+ *
+ * Exits non-zero when any rule, agent, or skill frontmatter fails to parse,
+ * which `claude-frontmatter.ts` decides and prints.
+ */
+
+import { main } from "./claude-frontmatter";
+
+process.exit(main(process.argv.slice(2)));

--- a/scripts/claude-frontmatter.test.ts
+++ b/scripts/claude-frontmatter.test.ts
@@ -1,0 +1,197 @@
+// @vitest-environment node
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+import {
+  frontmatterReport,
+  frontmatterText,
+  main,
+  yamlParseErrorDetail,
+} from "./claude-frontmatter";
+
+const WORK = fs.mkdtempSync(path.join(os.tmpdir(), "claude-frontmatter-"));
+
+const write = (root: string, relative: string, content: string): void => {
+  const absolute = path.join(root, relative);
+  fs.mkdirSync(path.dirname(absolute), { recursive: true });
+  fs.writeFileSync(absolute, content);
+};
+
+const validTree = (): string => {
+  const root = fs.mkdtempSync(path.join(WORK, "case-"));
+  write(
+    root,
+    ".claude/rules/alpha.md",
+    `---
+description: "scoped rule: with a colon"
+alwaysApply: true
+---
+
+# Alpha
+`
+  );
+  write(
+    root,
+    ".claude/agents/reviewer.md",
+    `---
+name: reviewer
+description: "reviews code: carefully"
+---
+
+Review.
+`
+  );
+  write(
+    root,
+    ".claude/skills/ticket-work/SKILL.md",
+    `---
+name: ticket-work
+description: "step one: clarify"
+---
+
+# Ticket work
+`
+  );
+  write(root, ".claude/skills/ticket-work/notes.md", "# not a skill\n");
+  return root;
+};
+
+describe("claude-frontmatter", () => {
+  afterAll(() => {
+    fs.rmSync(WORK, { force: true, recursive: true });
+  });
+
+  it("should return the first line when an Error message spans multiple lines", () => {
+    expect(yamlParseErrorDetail(new Error("line one\nline two"))).toBe(
+      "line one"
+    );
+  });
+
+  it("should stringify the value when the thrown value is not an Error", () => {
+    expect(yamlParseErrorDetail("broken")).toBe("broken");
+  });
+
+  it("should parse when the description contains a quoted colon", () => {
+    expect(
+      frontmatterText(`---
+description: "work: clarify"
+---
+`)
+    ).toStrictEqual({ ok: true });
+  });
+
+  it("should report a parse error when the description contains an unquoted colon", () => {
+    expect(
+      frontmatterText(`---
+description: work: clarify
+---
+`)
+    ).toStrictEqual({
+      detail:
+        "Nested mappings are not allowed in compact mappings at line 1, column 14:",
+      ok: false,
+    });
+  });
+
+  it("should report no problem when every target file parses", () => {
+    const root = validTree();
+
+    expect(frontmatterReport(root)).toStrictEqual({
+      files: [
+        ".claude/rules/alpha.md",
+        ".claude/agents/reviewer.md",
+        ".claude/skills/ticket-work/SKILL.md",
+      ],
+      problems: [],
+    });
+  });
+
+  it("should exit zero when main is called on a valid tree", () => {
+    expect(main([validTree()])).toBe(0);
+  });
+
+  it("should report a missing frontmatter block when the file has no opening delimiter", () => {
+    expect(frontmatterText("# Title\n")).toStrictEqual({
+      detail: "missing opening --- frontmatter block",
+      ok: false,
+    });
+  });
+
+  it("should list only markdown skill files when a skill folder also holds notes", () => {
+    const root = validTree();
+    write(root, ".claude/rules/notes.txt", "plain text\n");
+    write(root, ".claude/agents/config.json", "{}\n");
+
+    expect(frontmatterReport(root).files).toStrictEqual([
+      ".claude/rules/alpha.md",
+      ".claude/agents/reviewer.md",
+      ".claude/skills/ticket-work/SKILL.md",
+    ]);
+  });
+
+  it("should report an empty file list when the `.claude` tree is absent", () => {
+    const root = fs.mkdtempSync(path.join(WORK, "empty-"));
+
+    expect(frontmatterReport(root)).toStrictEqual({
+      files: [],
+      problems: [],
+    });
+  });
+
+  it("should skip a subdirectory it cannot read when collecting rule files", () => {
+    const root = validTree();
+    const unreadable = path.join(root, ".claude/rules/private");
+    fs.mkdirSync(unreadable);
+    fs.chmodSync(unreadable, 0);
+    try {
+      expect(frontmatterReport(root).files).toStrictEqual([
+        ".claude/rules/alpha.md",
+        ".claude/agents/reviewer.md",
+        ".claude/skills/ticket-work/SKILL.md",
+      ]);
+    } finally {
+      fs.chmodSync(unreadable, 0o755);
+      fs.rmSync(unreadable, { recursive: true });
+    }
+  });
+
+  it("should exit zero when main is called without a root argument on this repository", () => {
+    expect(main([])).toBe(0);
+  });
+
+  it("should report a broken rule when its frontmatter does not parse", () => {
+    const root = validTree();
+    write(
+      root,
+      ".claude/rules/broken.md",
+      `---
+description: broken: value
+---
+`
+    );
+
+    expect(frontmatterReport(root).problems).toStrictEqual([
+      {
+        detail:
+          "Nested mappings are not allowed in compact mappings at line 1, column 14:",
+        entry: ".claude/rules/broken.md",
+      },
+    ]);
+  });
+
+  it("should exit one when main is called on a tree with broken frontmatter", () => {
+    const root = validTree();
+    write(
+      root,
+      ".claude/rules/broken.md",
+      `---
+description: broken: value
+---
+`
+    );
+
+    expect(main([root])).toBe(1);
+  });
+});

--- a/scripts/claude-frontmatter.ts
+++ b/scripts/claude-frontmatter.ts
@@ -1,0 +1,116 @@
+/**
+ * Report `.claude/rules/*.md`, `.claude/agents/*.md`, and each
+ * `.claude/skills/.../SKILL.md` file whose YAML frontmatter does not parse.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { parse } from "yaml";
+
+const REPO = path.resolve(import.meta.dirname, "..");
+
+const FRONTMATTER = /^---\r?\n(?<body>[\s\S]*?)\r?\n---/u;
+
+const TARGETS = [".claude/rules", ".claude/agents", ".claude/skills"] as const;
+
+export interface FrontmatterProblem {
+  readonly detail: string;
+  readonly entry: string;
+}
+
+const readEntries = (dir: string): fs.Dirent[] => {
+  try {
+    return fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+};
+
+const collectMarkdownFile = (
+  root: string,
+  relative: string,
+  entryPath: string,
+  entryName: string
+): readonly string[] => {
+  if (!entryName.endsWith(".md")) {
+    return [];
+  }
+  if (relative === ".claude/skills" && entryName !== "SKILL.md") {
+    return [];
+  }
+  return [path.relative(root, entryPath)];
+};
+
+/** Every markdown file this check reads under one `.claude` subtree. */
+const markdownFilesUnder = (root: string, relative: string): string[] => {
+  const walk = (dir: string): readonly string[] =>
+    readEntries(dir).flatMap((entry) => {
+      const entryPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        return walk(entryPath);
+      }
+      return collectMarkdownFile(root, relative, entryPath, entry.name);
+    });
+
+  return [...walk(path.join(root, relative))].toSorted();
+};
+
+export const frontmatterFiles = (root: string): readonly string[] =>
+  TARGETS.flatMap((relative) => markdownFilesUnder(root, relative));
+
+export const yamlParseErrorDetail = (error: unknown): string => {
+  if (error instanceof Error) {
+    const [firstLine = error.message] = error.message.split("\n");
+    return firstLine;
+  }
+  return String(error);
+};
+
+export const frontmatterText = (
+  content: string
+): { ok: true } | { detail: string; ok: false } => {
+  const match = FRONTMATTER.exec(content);
+  const body = match?.groups?.body;
+  if (body === undefined) {
+    return { detail: "missing opening --- frontmatter block", ok: false };
+  }
+  try {
+    parse(body);
+    return { ok: true };
+  } catch (error) {
+    return { detail: yamlParseErrorDetail(error), ok: false };
+  }
+};
+
+export interface FrontmatterReport {
+  readonly files: readonly string[];
+  readonly problems: readonly FrontmatterProblem[];
+}
+
+export const frontmatterReport = (root: string): FrontmatterReport => {
+  const files = frontmatterFiles(root);
+  const problems = files.flatMap((entry) => {
+    const absolute = path.join(root, entry);
+    const content = fs.readFileSync(absolute, "utf-8");
+    const parsed = frontmatterText(content);
+    return parsed.ok ? [] : [{ detail: parsed.detail, entry }];
+  });
+  return { files, problems };
+};
+
+export const main = (argv: readonly string[]): number => {
+  const { files, problems } = frontmatterReport(path.resolve(argv[0] ?? REPO));
+  if (problems.length > 0) {
+    console.log(
+      [
+        `Claude frontmatter parse errors: ${problems.length}`,
+        ...problems.map(({ detail, entry }) => `  ${entry}: ${detail}`),
+        "",
+        "Quote description values that contain ': ' or wrap them in a block scalar.",
+      ].join("\n")
+    );
+    return 1;
+  }
+  console.log(`claude frontmatter ok (${files.length} files)`);
+  return 0;
+};

--- a/scripts/cursor-rule-mirrors.test.ts
+++ b/scripts/cursor-rule-mirrors.test.ts
@@ -264,4 +264,17 @@ describe("check-cursor-rule-mirrors", () => {
   it("should exit zero when this repository's own mirrors are in sync", () => {
     expect(main([])).toBe(0);
   });
+
+  it("should report a problem when .cursor/skills duplicates .claude/skills", () => {
+    const root = mirroredTree();
+    fs.mkdirSync(path.join(root, ".cursor/skills"), { recursive: true });
+
+    expect(mirrorReport(root).problems).toStrictEqual([
+      {
+        detail:
+          "exists; Cursor reads the matching tree under .claude/ directly, so remove it",
+        entry: ".cursor/skills",
+      },
+    ]);
+  });
 });

--- a/scripts/cursor-rule-mirrors.ts
+++ b/scripts/cursor-rule-mirrors.ts
@@ -1,6 +1,7 @@
 /**
  * Report `.cursor/rules/*.mdc` entries that have stopped mirroring
- * `.claude/rules/*.md`.
+ * `.claude/rules/*.md`, and `.cursor/skills/` or `.cursor/agents/` trees
+ * that would duplicate what Cursor already reads from `.claude/`.
  *
  * A mirror is right when it is a symlink whose text is exactly
  * `../../.claude/rules/<its own name>.md` and whose target exists, and when
@@ -16,6 +17,8 @@ const REPO = path.resolve(import.meta.dirname, "..");
 
 const RULES = ".claude/rules";
 const MIRRORS = ".cursor/rules";
+
+const FORBIDDEN_CURSOR_DIRS = [".cursor/skills", ".cursor/agents"] as const;
 
 /** The one link text a mirror may carry. */
 const linkTextFor = (name: string): string => `../../${RULES}/${name}.md`;
@@ -111,6 +114,19 @@ export interface MirrorReport {
   readonly rules: readonly string[];
 }
 
+const duplicateCursorTreeProblems = (root: string): MirrorProblem[] =>
+  FORBIDDEN_CURSOR_DIRS.flatMap((entry) =>
+    fs.existsSync(path.join(root, entry))
+      ? [
+          {
+            detail:
+              "exists; Cursor reads the matching tree under .claude/ directly, so remove it",
+            entry,
+          },
+        ]
+      : []
+  );
+
 /** Judges every name either directory holds, so both directions are decided. */
 export const mirrorReport = (root: string): MirrorReport => {
   const ruleEntries = readEntries(path.join(root, RULES));
@@ -142,6 +158,7 @@ export const mirrorReport = (root: string): MirrorReport => {
     });
   return {
     problems: [
+      ...duplicateCursorTreeProblems(root),
       ...emptyRules,
       ...directoryProblems(RULES, ruleEntries),
       ...directoryProblems(MIRRORS, mirrorEntries),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 変更内容

前回 PR で入らなかった同期まわりをまとめて入れる。

1. **YAML frontmatter 修正** — `prose.md` と skills 3 本の `description` をクォート（`code-reviewer` は main 済み）
2. **CI: `check-claude-frontmatter`** — `.claude/rules/`・`agents/`・`skills/**/SKILL.md` の frontmatter がパースできることを検証
3. **CI: `check-cursor-rule-mirrors` 拡張** — `.cursor/skills/` と `.cursor/agents/` が存在したら失敗（Cursor は `.claude/` を直接読むため複製禁止）
4. **AGENTS.md / README** — 正本の置き場と Cursor の読み方を明記

## 同期の形

| 種別 | 正本 | Cursor |
|---|---|---|
| rules | `.claude/rules/` | `.cursor/rules/*.mdc` symlink |
| skills | `.claude/skills/` | 互換パスで直接読む |
| agents | `.claude/agents/` | 互換パスで直接読む |

hooks と permissions はプラットフォーム差のため同期対象外。

## 確認

- `bun scripts/check-claude-frontmatter.entry.ts`
- `bun scripts/check-cursor-rule-mirrors.entry.ts`
- `bun run check`
- `bun run test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d1972ed-2990-4a5d-bbd3-3d6b5c68eb82?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d1972ed-2990-4a5d-bbd3-3d6b5c68eb82&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

